### PR TITLE
[FEAT] 타임 테이블 구성 화면 레이아웃,  찬성, 반대, 작전 시간, 타이머 추가 버튼 컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ yarn-error.log*
 .idea
 
 
+
+*storybook.log

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,0 +1,16 @@
+import type { StorybookConfig } from '@storybook/react-vite';
+
+const config: StorybookConfig = {
+  stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
+  addons: [
+    '@storybook/addon-onboarding',
+    '@storybook/addon-essentials',
+    '@chromatic-com/storybook',
+    '@storybook/addon-interactions',
+  ],
+  framework: {
+    name: '@storybook/react-vite',
+    options: {},
+  },
+};
+export default config;

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,0 +1,15 @@
+import type { Preview } from '@storybook/react';
+import '../src/index.css';
+
+const preview: Preview = {
+  parameters: {
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/i,
+      },
+    },
+  },
+};
+
+export default preview;

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="stylesheet" as="style" crossorigin href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.min.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
+import TableSetup from './page/TableSetupPage/TableSetup';
+
 function App() {
   return (
     <>
-      <div className="p-4 font-bold text-red-500">HI</div>
+      <TableSetup />
     </>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-pretendard;
+  }
+}

--- a/src/layout/components/footer/FixedFooterWrapper.tsx
+++ b/src/layout/components/footer/FixedFooterWrapper.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from 'react';
+
+export default function FixedFooterWrapper(props: PropsWithChildren) {
+  const { children } = props;
+
+  return (
+    <footer className="fixed bottom-0 flex w-full flex-col content-center items-center gap-1">
+      {children}
+    </footer>
+  );
+}

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -1,0 +1,30 @@
+import { PropsWithChildren } from 'react';
+
+function StickyTriSectionHeader(props: PropsWithChildren) {
+  const { children } = props;
+
+  return (
+    <header className="sticky top-0 h-20 bg-slate-300 px-2">
+      <div className="relative flex h-full items-center justify-between gap-x-6">
+        {children}
+      </div>
+    </header>
+  );
+}
+
+StickyTriSectionHeader.Left = function Left(props: PropsWithChildren) {
+  const { children } = props;
+  return <div>{children}</div>;
+};
+
+StickyTriSectionHeader.Center = function Center(props: PropsWithChildren) {
+  const { children } = props;
+  return <div>{children}</div>;
+};
+
+StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
+  const { children } = props;
+  return <div>{children}</div>;
+};
+
+export default StickyTriSectionHeader;

--- a/src/layout/components/main/ContentContanier.tsx
+++ b/src/layout/components/main/ContentContanier.tsx
@@ -1,0 +1,7 @@
+import { PropsWithChildren } from 'react';
+
+export default function ContentContanier(props: PropsWithChildren) {
+  const { children } = props;
+
+  return <main className="flex flex-col">{children}</main>;
+}

--- a/src/layout/components/main/ContentContanier.tsx
+++ b/src/layout/components/main/ContentContanier.tsx
@@ -3,5 +3,7 @@ import { PropsWithChildren } from 'react';
 export default function ContentContanier(props: PropsWithChildren) {
   const { children } = props;
 
-  return <main className="flex flex-col">{children}</main>;
+  return (
+    <main className="flex flex-col items-center gap-4 px-8">{children}</main>
+  );
 }

--- a/src/layout/components/main/ContentContanier.tsx
+++ b/src/layout/components/main/ContentContanier.tsx
@@ -4,6 +4,8 @@ export default function ContentContanier(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <main className="flex flex-col items-center gap-4 px-8">{children}</main>
+    <main className="flex flex-col items-center gap-4 px-8 py-4">
+      {children}
+    </main>
   );
 }

--- a/src/layout/defaultLayout/DefaultLayout.tsx
+++ b/src/layout/defaultLayout/DefaultLayout.tsx
@@ -1,0 +1,15 @@
+import { PropsWithChildren } from 'react';
+import StickyTriSectionHeader from '../components/header/StickyTriSectionHeader';
+import FixedFooterWrapper from '../components/footer/FixedFooterWrapper';
+import ContentContanier from '../components/main/ContentContanier';
+
+function DefaultLayout(props: PropsWithChildren) {
+  const { children } = props;
+
+  return <div className="flex h-screen flex-col">{children}</div>;
+}
+
+DefaultLayout.Header = StickyTriSectionHeader;
+DefaultLayout.ContentContanier = ContentContanier;
+DefaultLayout.FixedFooterWrapper = FixedFooterWrapper;
+export default DefaultLayout;

--- a/src/page/TableSetupPage/TableSetup.tsx
+++ b/src/page/TableSetupPage/TableSetup.tsx
@@ -1,4 +1,7 @@
 import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
+import DebatePanel from './components/DebatePanel/DebatePanel';
+import PropsAndConsTitle from './components/ProsAndConsTitle/PropsAndConsTitle';
+import TimerCreationButton from './components/TimerCreationButton/TimerCreationButton';
 
 export default function TableSetup() {
   return (
@@ -8,7 +11,34 @@ export default function TableSetup() {
         <DefaultLayout.Header.Center>의회식</DefaultLayout.Header.Center>
         <DefaultLayout.Header.Right>wpahr</DefaultLayout.Header.Right>
       </DefaultLayout.Header>
-      <DefaultLayout.ContentContanier>테이블</DefaultLayout.ContentContanier>
+      <DefaultLayout.ContentContanier>
+        <PropsAndConsTitle />
+        <DebatePanel
+          info={{
+            stance: 'PROS' as const,
+            debateType: 'OPENING' as const,
+            time: 150,
+            speakerNumber: 3,
+          }}
+        />
+        <DebatePanel
+          info={{
+            stance: 'CONS' as const,
+            debateType: 'OPENING' as const,
+            time: 150,
+            speakerNumber: 3,
+          }}
+        />
+        <DebatePanel
+          info={{
+            stance: 'NEUTRAL' as const,
+            debateType: 'TIME_OUT' as const,
+            time: 150,
+            speakerNumber: 3,
+          }}
+        />
+        <TimerCreationButton leftOnClick={() => {}} rightOnClick={() => {}} />
+      </DefaultLayout.ContentContanier>
       <DefaultLayout.FixedFooterWrapper>
         <button className="h-20 w-screen bg-amber-300">버튼</button>
       </DefaultLayout.FixedFooterWrapper>

--- a/src/page/TableSetupPage/TableSetup.tsx
+++ b/src/page/TableSetupPage/TableSetup.tsx
@@ -1,0 +1,17 @@
+import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
+
+export default function TableSetup() {
+  return (
+    <DefaultLayout>
+      <DefaultLayout.Header>
+        <DefaultLayout.Header.Left>헤더</DefaultLayout.Header.Left>
+        <DefaultLayout.Header.Center>의회식</DefaultLayout.Header.Center>
+        <DefaultLayout.Header.Right>wpahr</DefaultLayout.Header.Right>
+      </DefaultLayout.Header>
+      <DefaultLayout.ContentContanier>테이블</DefaultLayout.ContentContanier>
+      <DefaultLayout.FixedFooterWrapper>
+        <button className="h-20 w-screen bg-amber-300">버튼</button>
+      </DefaultLayout.FixedFooterWrapper>
+    </DefaultLayout>
+  );
+}

--- a/src/page/TableSetupPage/components/DebatePanel/DebatePanel.stories.tsx
+++ b/src/page/TableSetupPage/components/DebatePanel/DebatePanel.stories.tsx
@@ -1,0 +1,55 @@
+import { Meta, StoryObj } from '@storybook/react';
+import DebatePanel from './DebatePanel';
+
+const meta: Meta<typeof DebatePanel> = {
+  title: 'page/TableSetup/Components/DebatePanel',
+  component: DebatePanel,
+  tags: ['autodocs'],
+  args: {
+    info: {
+      stance: 'PROS',
+      debateType: 'OPENING',
+      time: 150,
+      speakerNumber: 1,
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DebatePanel>;
+
+// 찬성 입론
+export const ProsOpening: Story = {
+  args: {
+    info: {
+      stance: 'PROS',
+      debateType: 'OPENING',
+      time: 150,
+      speakerNumber: 1,
+    },
+  },
+};
+
+// 반대 반론
+export const ConsRebuttal: Story = {
+  args: {
+    info: {
+      stance: 'CONS',
+      debateType: 'REBUTTAL',
+      time: 120,
+      speakerNumber: 2,
+    },
+  },
+};
+
+// 중립 작전 시간
+export const NeutralTimeout: Story = {
+  args: {
+    info: {
+      stance: 'NEUTRAL',
+      debateType: 'TIME_OUT',
+      time: 60,
+      speakerNumber: 0,
+    },
+  },
+};

--- a/src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
@@ -1,0 +1,47 @@
+import { DEBATE_TYPE_LABELS, DebateInfo } from '../../../../type/type';
+import { Formatting } from '../../../../util/formatting';
+
+interface DebatePanelProps {
+  info: DebateInfo;
+}
+
+export default function DebatePanel({ info }: DebatePanelProps) {
+  const { stance, debateType, time, speakerNumber } = info;
+
+  const debateTypeLabel = DEBATE_TYPE_LABELS[debateType];
+
+  const isPros = stance === 'PROS';
+  const isCons = stance === 'CONS';
+  const isNeutralTimeout = debateType === 'TIME_OUT' && stance === 'NEUTRAL';
+
+  const timeStr = Formatting.formatSecondsToMinutes(time);
+
+  return (
+    <div
+      className={`flex w-full items-center ${
+        isPros ? 'justify-start' : isCons ? 'justify-end' : 'justify-center'
+      }`}
+    >
+      {(isPros || isCons) && (
+        <div
+          className={`flex w-1/2 flex-col items-center rounded-md ${
+            isPros ? 'bg-blue-500' : 'bg-red-500'
+          } p-4 font-bold text-white`}
+        >
+          <div>
+            {debateTypeLabel} / {speakerNumber}번 토론자
+          </div>
+          <div className="text-2xl">{timeStr}</div>
+        </div>
+      )}
+
+      {isNeutralTimeout && (
+        <div className="w-full rounded-md bg-gray-200 py-2 text-center">
+          <span className="font-medium text-gray-600">
+            {debateTypeLabel} | {timeStr}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/page/TableSetupPage/components/ProsAndConsTitle/PropsAndConsTitle.stories.tsx
+++ b/src/page/TableSetupPage/components/ProsAndConsTitle/PropsAndConsTitle.stories.tsx
@@ -1,0 +1,15 @@
+import { Meta, StoryObj } from '@storybook/react';
+import PropsAndConsTitle from './PropsAndConsTitle';
+
+const meta: Meta<typeof PropsAndConsTitle> = {
+  title: 'page/TableSetup/Components/PropsAndConsTitle',
+  component: PropsAndConsTitle,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof PropsAndConsTitle>;
+
+// 기본 렌더링
+export const Default: Story = {};

--- a/src/page/TableSetupPage/components/ProsAndConsTitle/PropsAndConsTitle.tsx
+++ b/src/page/TableSetupPage/components/ProsAndConsTitle/PropsAndConsTitle.tsx
@@ -1,0 +1,8 @@
+export default function PropsAndConsTitle() {
+  return (
+    <div className="mb-8 flex w-full items-center justify-around border-b border-black pb-1">
+      <span className="text-3xl font-bold text-blue-500">찬성</span>
+      <span className="text-3xl font-bold text-red-500">반대</span>
+    </div>
+  );
+}

--- a/src/page/TableSetupPage/components/TimerCreationButton/TimerCreationButton.stories.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationButton/TimerCreationButton.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, StoryObj } from '@storybook/react';
+import TimerCreationButton from './TimerCreationButton';
+
+const meta: Meta<typeof TimerCreationButton> = {
+  title: 'page/TableSetup/Components/TimerCreationButton',
+  component: TimerCreationButton,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TimerCreationButton>;
+
+export const Default: Story = {
+  args: {
+    leftOnClick: () => alert('Left button clicked!'),
+    rightOnClick: () => alert('Right button clicked!'),
+  },
+};

--- a/src/page/TableSetupPage/components/TimerCreationButton/TimerCreationButton.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationButton/TimerCreationButton.tsx
@@ -1,0 +1,24 @@
+interface TimerCreationButtonProps {
+  leftOnClick: () => void;
+  rightOnClick: () => void;
+}
+export default function TimerCreationButton(props: TimerCreationButtonProps) {
+  const { leftOnClick, rightOnClick } = props;
+  return (
+    <div className="flex w-full items-center justify-around">
+      <button
+        className="flex h-10 w-5/12 items-center justify-center rounded-md bg-gray-200 font-bold text-black"
+        onClick={leftOnClick}
+      >
+        +
+      </button>
+
+      <button
+        className="flex h-10 w-5/12 items-center justify-center rounded-md bg-gray-200 font-bold text-black"
+        onClick={rightOnClick}
+      >
+        +
+      </button>
+    </div>
+  );
+}

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -1,0 +1,17 @@
+type Stance = 'PROS' | 'CONS' | 'NEUTRAL';
+type DebateType = 'OPENING' | 'REBUTTAL' | 'CROSS' | 'CLOSING' | 'TIME_OUT';
+
+export interface DebateInfo {
+  stance: Stance;
+  debateType: DebateType;
+  time: number;
+  speakerNumber: number;
+}
+
+export const DEBATE_TYPE_LABELS: Record<DebateType, string> = {
+  OPENING: '입론',
+  REBUTTAL: '반론',
+  CROSS: '교차질의',
+  CLOSING: '최종발언',
+  TIME_OUT: '작전 시간',
+};

--- a/src/util/formatting.ts
+++ b/src/util/formatting.ts
@@ -1,0 +1,7 @@
+export const Formatting = {
+  formatSecondsToMinutes: (time: number) => {
+    const minutes = Math.floor(time / 60);
+    const seconds = time % 60;
+    return `${minutes}분 ${seconds}초`;
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,27 @@
 export default {
   content: ['./src/**/*.{js,jsx,ts,tsx}'],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        pretendard: [
+          '"Pretendard Variable"',
+          'Pretendard',
+          '-apple-system',
+          'BlinkMacSystemFont',
+          'system-ui',
+          'Roboto',
+          '"Helvetica Neue"',
+          '"Segoe UI"',
+          '"Apple SD Gothic Neo"',
+          '"Noto Sans KR"',
+          '"Malgun Gothic"',
+          '"Apple Color Emoji"',
+          '"Segoe UI Emoji"',
+          '"Segoe UI Symbol"',
+          'sans-serif',
+        ],
+      },
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
## 🚩 연관 이슈
closed #11
closed #15
## 📝 작업 내용
중첩 컴포넌트를 이용해서 기본 레이아웃을 구현했습니다. 현재는 defaultLayout이라는 명으로 구현했으나 추후에 수정될 수 있습니다.

## StickyTriSectionHeader
<img width="850" alt="image" src="https://github.com/user-attachments/assets/983ead13-e322-49a3-b1a8-0c7e6af0e08d" />
해당 헤더는 3개의 영역으로 구분되어있어, 원하는 위치에 요소를 집어넣을 수 있습니다. 

사용방법은 헤더안에 요소를 집어 넣으면 사용할 수 있습니다.
```tsx
      <DefaultLayout.Header>
        <DefaultLayout.Header.Left>left</DefaultLayout.Header.Left>
        <DefaultLayout.Header.Center>center</DefaultLayout.Header.Center>
        <DefaultLayout.Header.Right>right</DefaultLayout.Header.Right>
      </DefaultLayout.Header>
```
## FixedFooterWrapper
<img width="850" alt="image" src="https://github.com/user-attachments/assets/362c36b9-7097-467f-a689-2e37aa52093f" />

해당 footer는 스크롤하여도 하단에 고정되어 있는 footer입니다.
후에 '테이블 확정하기'버튼을 위해 구현하였습니다.
<img width="326" alt="image" src="https://github.com/user-attachments/assets/3fd2dfe2-322c-449d-be51-b808ceb84617" />

## PropsAndConsTitle
<img width="1222" alt="image" src="https://github.com/user-attachments/assets/ab27d8b9-c4e8-47a9-94d4-967f794f7b6c" />

## DebatePanel
<img width="798" alt="image" src="https://github.com/user-attachments/assets/f90852cf-7c7d-4059-b5fa-394115a4a068" />

props로 info를 받습니다. 

table |   | Array |   |  
-- | -- | -- | -- | --
  | stance | String | 찬성/ 반대 | - 찬성 : PROS- 반대 : CONS- 중립: NEUTRAL
  | type | String | 발언 유형 | - 입론: OPENING- 반론: REBUTTAL- 교차질의: CROSS- 최종발언: CLOSING- 작전시간: TIME_OUT
  | time | Number | 발언 시간 |  
  | speakerNumber | Number | 발언자 번호 |  

stance와 type에 따라 총 3가지(찬, 반, 작전시간)상태를 렌더링합니다.

## TimerCreationButton
<img width="798" alt="image" src="https://github.com/user-attachments/assets/aaa90e0c-0a63-414e-9013-0980fea7c75b" />
왼쪽 클릭과 오른쪽 클릭 이벤트를 props로 받습니다.

## 웹폰트
pretandard 웹폰트를 추가하였습니다.


## 🗣️ 리뷰 요구사항
layout에 대한 세부적인 css 구성은 임으로 작성된 부분이 있습니다. 더 수정해야할 css 속성이 있으면 의견 부탁드립니다.
