### PR TITLE
[FIX] 타임 테이블 구성 페이지 피드백 사항 반영

### DIFF
--- a/src/layout/components/footer/FixedFooterWrapper.tsx
+++ b/src/layout/components/footer/FixedFooterWrapper.tsx
@@ -4,7 +4,7 @@ export default function FixedFooterWrapper(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <footer className="fixed bottom-0 flex w-full flex-col content-center items-center gap-1">
+    <footer className="sticky bottom-0 flex w-full flex-col content-center items-center gap-1">
       {children}
     </footer>
   );

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -4,7 +4,7 @@ function StickyTriSectionHeader(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <header className="sticky top-0 h-20 bg-slate-300 px-2">
+    <header className="sticky top-0 min-h-20 bg-slate-300 px-2">
       <div className="relative flex h-full items-center justify-between gap-x-6">
         {children}
       </div>

--- a/src/layout/components/main/ContentContanier.tsx
+++ b/src/layout/components/main/ContentContanier.tsx
@@ -4,7 +4,7 @@ export default function ContentContanier(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <main className="flex flex-col items-center gap-4 px-8 py-4">
+    <main className="flex flex-grow flex-col items-center gap-4 px-8 py-4">
       {children}
     </main>
   );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,9 +3,12 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import { RouterProvider } from 'react-router-dom';
 import router from './route';
+import { GlobalPortal } from './util/GlobalPortal';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <GlobalPortal.Provider>
+      <RouterProvider router={router} />
+    </GlobalPortal.Provider>
   </StrictMode>,
 );

--- a/src/page/TableSetupPage/TableSetup.tsx
+++ b/src/page/TableSetupPage/TableSetup.tsx
@@ -33,7 +33,7 @@ export default function TableSetup() {
 
         <DefaultLayout.Header.Right>
           <div className="flex flex-wrap items-center gap-2 px-2 md:w-auto md:gap-3">
-            <span className="text-sm md:text-base">주제</span>
+            <span className="text-sm md:text-base">토론 주제</span>
             <input
               type="text"
               className="w-full rounded-md bg-slate-100 p-2 text-base md:w-[30rem] md:text-2xl"

--- a/src/page/TableSetupPage/TableSetup.tsx
+++ b/src/page/TableSetupPage/TableSetup.tsx
@@ -58,7 +58,8 @@ export default function TableSetup() {
       </DefaultLayout.FixedFooterWrapper>
       <ProsModalWrapper>
         <TimerCreationContent
-          initStance={'PROS'}
+          selectedStance={'PROS'}
+          initDate={data[data.length - 1]}
           onSubmit={(data) => {
             setDate((prev) => [...prev, data]);
           }}
@@ -68,7 +69,8 @@ export default function TableSetup() {
       </ProsModalWrapper>
       <ConsModalWrapper>
         <TimerCreationContent
-          initStance={'CONS'}
+          selectedStance={'CONS'}
+          initDate={data[data.length - 1]}
           onSubmit={(data) => {
             setDate((prev) => [...prev, data]);
           }}

--- a/src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
@@ -13,8 +13,8 @@ export default function DebatePanel({ info }: DebatePanelProps) {
   const isPros = stance === 'PROS';
   const isCons = stance === 'CONS';
   const isNeutralTimeout = debateType === 'TIME_OUT' && stance === 'NEUTRAL';
-
-  const timeStr = Formatting.formatSecondsToMinutes(time);
+  const { minutes, seconds } = Formatting.formatSecondsToMinutes(time);
+  const timeStr = `${minutes}분 ${seconds}초`;
 
   return (
     <div

--- a/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
@@ -17,15 +17,15 @@ export default function TimerCreationContent({
 }: TimerCreationContentProps) {
   const [stance, setStance] = useState<Stance>(selectedStance);
   const [debateType, setDebateType] = useState<DebateType>(
-    initDate?.debateType || 'OPENING',
+    initDate?.debateType ?? 'OPENING',
   );
   const { minutes: initMinutes, seconds: initSeconds } =
-    Formatting.formatSecondsToMinutes(initDate?.time || 180);
+    Formatting.formatSecondsToMinutes(initDate?.time ?? 180);
 
   const [minutes, setMinutes] = useState(initMinutes);
   const [seconds, setSeconds] = useState(initSeconds);
-  const [speakerNumber, setSpeakerNumber] = useState(
-    initDate?.speakerNumber || 1,
+  const [speakerNumber, setSpeakerNumber] = useState<number | null>(
+    initDate?.speakerNumber ?? 1,
   );
 
   const handleSubmit = () => {
@@ -34,7 +34,7 @@ export default function TimerCreationContent({
       stance,
       debateType,
       time: totalTime,
-      speakerNumber,
+      ...(speakerNumber !== null && { speakerNumber }),
     });
     onClose();
   };
@@ -139,10 +139,13 @@ export default function TimerCreationContent({
           <select
             id="speaker-number-input"
             className="flex-1 rounded border p-1"
-            value={speakerNumber}
+            value={stance === 'NEUTRAL' ? 0 : (speakerNumber ?? 0)}
             onChange={(e) => {
-              setSpeakerNumber(Number(e.target.value));
+              setSpeakerNumber(
+                e.target.value === '0' ? null : Number(e.target.value),
+              );
             }}
+            disabled={stance === 'NEUTRAL'}
           >
             <option value="0">없음</option>
             <option value="1">1번 토론자</option>

--- a/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
@@ -104,7 +104,7 @@ export default function TimerCreationContent({
                 type="number"
                 min={0}
                 className="min-w-10 flex-grow rounded border p-1 text-center"
-                value={minutes}
+                value={minutes.toString()}
                 onChange={(e) => setMinutes(Number(e.target.value))}
               />
               <span className="ml-1 flex-shrink-0">분</span>
@@ -115,7 +115,7 @@ export default function TimerCreationContent({
                 type="number"
                 min={0}
                 className="min-w-10 flex-grow rounded border p-1 text-center"
-                value={seconds}
+                value={seconds.toString()}
                 onChange={(e) => setSeconds(Number(e.target.value))}
               />
               <span className="ml-1 flex-shrink-0">초</span>
@@ -127,7 +127,6 @@ export default function TimerCreationContent({
           <label htmlFor="speaker-number-input" className="w-16 flex-shrink-0">
             발언자
           </label>
-          <input
           <select
             id="speaker-number-input"
             className="flex-1 rounded border p-1"

--- a/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
@@ -17,7 +17,9 @@ export default function TimerCreationContent({
 }: TimerCreationContentProps) {
   const [stance, setStance] = useState<Stance>(selectedStance);
   const [debateType, setDebateType] = useState<DebateType>(
-    initDate?.debateType ?? 'OPENING',
+    initDate?.stance === 'NEUTRAL'
+      ? 'OPENING'
+      : (initDate?.debateType ?? 'OPENING'),
   );
   const { minutes: initMinutes, seconds: initSeconds } =
     Formatting.formatSecondsToMinutes(initDate?.time ?? 180);
@@ -25,7 +27,7 @@ export default function TimerCreationContent({
   const [minutes, setMinutes] = useState(initMinutes);
   const [seconds, setSeconds] = useState(initSeconds);
   const [speakerNumber, setSpeakerNumber] = useState<number | null>(
-    initDate?.speakerNumber ?? 1,
+    initDate?.stance === 'NEUTRAL' ? 1 : (initDate?.speakerNumber ?? 1),
   );
 
   const handleSubmit = () => {

--- a/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
@@ -32,7 +32,9 @@ export default function TimerCreationContent({
 
   return (
     <div className="p-4">
-      <h2 className="mb-4 text-xl font-bold">타임박스 설정</h2>
+      <h2 className={`mb-4 text-xl font-bold ${getStanceColor()}`}>
+        타임박스 설정
+      </h2>
       <div className="flex flex-col space-y-6">
         <div className="flex items-center space-x-2">
           <label htmlFor="stance-select" className="w-16 flex-shrink-0">

--- a/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
@@ -1,23 +1,32 @@
 import { useState } from 'react';
 import { DebateInfo, DebateType, Stance } from '../../../../type/type';
+import { Formatting } from '../../../../util/formatting';
 
 interface TimerCreationContentProps {
-  initStance: Stance;
+  selectedStance: Stance;
+  initDate?: DebateInfo;
   onSubmit: (data: DebateInfo) => void;
   onClose: () => void; // 모달 닫기 함수
 }
 
 export default function TimerCreationContent({
-  initStance,
+  selectedStance,
+  initDate,
   onSubmit,
   onClose,
 }: TimerCreationContentProps) {
-  const [stance, setStance] = useState<Stance>(initStance);
-  const [debateType, setDebateType] = useState<DebateType>('OPENING');
+  const [stance, setStance] = useState<Stance>(selectedStance);
+  const [debateType, setDebateType] = useState<DebateType>(
+    initDate?.debateType || 'OPENING',
+  );
+  const { minutes: initMinutes, seconds: initSeconds } =
+    Formatting.formatSecondsToMinutes(initDate?.time || 180);
 
-  const [minutes, setMinutes] = useState(2);
-  const [seconds, setSeconds] = useState(30);
-  const [speakerNumber, setSpeakerNumber] = useState(3);
+  const [minutes, setMinutes] = useState(initMinutes);
+  const [seconds, setSeconds] = useState(initSeconds);
+  const [speakerNumber, setSpeakerNumber] = useState(
+    initDate?.speakerNumber || 1,
+  );
 
   const handleSubmit = () => {
     const totalTime = minutes * 60 + seconds;
@@ -80,7 +89,7 @@ export default function TimerCreationContent({
               if (e.target.value === 'TIME_OUT') {
                 setStance('NEUTRAL');
               } else {
-                setStance(initStance);
+                setStance(selectedStance);
               }
               setDebateType(e.target.value as DebateType);
             }}

--- a/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
@@ -114,13 +114,21 @@ export default function TimerCreationContent({
             발언자
           </label>
           <input
+          <select
             id="speaker-number-input"
-            type="number"
-            min={1}
-            className="min-w-0 flex-grow rounded border p-1 text-center"
+            className="flex-1 rounded border p-1"
             value={speakerNumber}
-            onChange={(e) => setSpeakerNumber(Number(e.target.value))}
-          />
+            onChange={(e) => {
+              setSpeakerNumber(Number(e.target.value));
+            }}
+          >
+            <option value="0">없음</option>
+            <option value="1">1번 토론자</option>
+            <option value="2">2번 토론자</option>
+            <option value="3">3번 토론자</option>
+            <option value="4">4번 토론자</option>
+            <option value="4">5번 토론자</option>
+          </select>
         </div>
 
         <button

--- a/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
@@ -62,6 +62,7 @@ export default function TimerCreationContent({
             onChange={(e) => setStance(e.target.value as Stance)}
             disabled={stance === 'NEUTRAL'}
           >
+            {stance === 'NEUTRAL' && <option value="NEUTRAL"></option>}
             <option value="PROS">찬성</option>
             <option value="CONS">반대</option>
           </select>

--- a/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableSetupPage/components/TimerCreationContent/TimerCreationContent.tsx
@@ -30,6 +30,19 @@ export default function TimerCreationContent({
     onClose();
   };
 
+  const getStanceColor = () => {
+    switch (stance) {
+      case 'PROS':
+        return 'text-blue-500';
+      case 'CONS':
+        return 'text-red-500';
+      case 'NEUTRAL':
+        return 'text-gray-400';
+      default:
+        return 'text-gray-400';
+    }
+  };
+
   return (
     <div className="p-4">
       <h2 className={`mb-4 text-xl font-bold ${getStanceColor()}`}>

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -10,7 +10,7 @@ export interface DebateInfo {
   stance: Stance;
   debateType: DebateType;
   time: number;
-  speakerNumber: number;
+  speakerNumber?: number;
 }
 
 export const DEBATE_TYPE_LABELS: Record<DebateType, string> = {

--- a/src/util/formatting.ts
+++ b/src/util/formatting.ts
@@ -2,6 +2,6 @@ export const Formatting = {
   formatSecondsToMinutes: (time: number) => {
     const minutes = Math.floor(time / 60);
     const seconds = time % 60;
-    return `${minutes}분 ${seconds}초`;
+    return { minutes, seconds };
   },
 };


### PR DESCRIPTION
## 🚩 연관 이슈
closed #28

## 📝 작업 내용
### 헤더 주제를 토로주제로 구체화
before
<img width="608" alt="image" src="https://github.com/user-attachments/assets/1125f051-e18a-4be3-8139-3ff2dff8cd36" />

after
<img width="1373" alt="image" src="https://github.com/user-attachments/assets/8f920da7-42b1-4139-99c4-0bc75a04e202" />

### 입장별 모달창 색 조정
피드백으로 모달 창 전첵 색상을 변경하는 것이 어떻냐는 의견이 있었으나 그보다는 모달의 제목의 색상을 만을 변경하는 것이 보기 좋다고 판단했습니다.

반대
<img width="914" alt="image" src="https://github.com/user-attachments/assets/ccb3a8b6-9277-4394-b320-8c529a2856f4" />

찬성
<img width="914" alt="image" src="https://github.com/user-attachments/assets/d93ae44d-a46b-4a2f-845f-0f1e69fbbf9b" />

중립
<img width="914" alt="image" src="https://github.com/user-attachments/assets/b776c8f6-94c8-40dc-bfc9-2502dbebb49d" />

### 작전시간 선택시  텍스트가 빈문자열로 변경.
<img width="914" alt="image" src="https://github.com/user-attachments/assets/b776c8f6-94c8-40dc-bfc9-2502dbebb49d" />
이제 작전시간을 선택하여 stance가 중립이 된 경우,  select 내부 문자열을 빈 문자열로 변경되게 했습니다.

### 발언자의 경우, nullable 따라서 드롭다운 리스트로 없음, 1, 2, 3, 4, 5 정도의 선택지만 있도록 변경
<img width="914" alt="image" src="https://github.com/user-attachments/assets/68709cd1-867c-4592-b7d6-6df279dd8484" />
중립일 경우 disabled 처리 추가
<img width="914" alt="image" src="https://github.com/user-attachments/assets/0eda9e5b-7a62-47ea-819e-0951474f45d9" />

### 박스를 계속 만들다보면 밑에 +창이 보이지가 않아서 +창을 띄우도록 화면이 하단으로 같이 이동하도록 수정
footerButtonWrapper가 하단 내용을 가리는 문제가 있어 layout을 수정하였습니다.
<img width="1053" alt="image" src="https://github.com/user-attachments/assets/59108a75-23dd-4078-a462-ca7a5c32e304" />

### 모달창에 시간 입력시, 0으로 기본 초기화되어 이후에 시간을 치면 앞에 0이 안없어지는 leading zero 제거

value값이 number인데 이를 브라우저에서 자체적으로 leading zero를 UI상에서 제거하지 않는 것 같습니다. 이를 toString으로 변환하여 강제로 leading zero를 없앴습니다. 
before
<img width="1484" alt="image" src="https://github.com/user-attachments/assets/61118d96-507f-4f6e-97dc-703b6209637a" />

after
<img width="1484" alt="image" src="https://github.com/user-attachments/assets/0c55d755-1734-4344-84bf-6008000787ef" />

### 타임박스 입력 기억기능
타임박스를 입력하기 위해 모달을 열었을때 이전 타임박스를 입력했던 값들을 유지해서 초기값으로 세팅되면 좋겠다는 의견이 있었습니다. 
그래서 초기값을 date의 마지막 배열에 있는 값을 props로 받아서 state의 초기값으로 설정하게 변경하였습니다. 
이때 이전 타임박스가 작전시간인 경우에는 연속적으로 설정되는 경우가 드물것으로 가정하여 이전 데이터에서 시간만을 반영하도록 수정하였습니다.

https://github.com/user-attachments/assets/e6e1654b-f3f9-478f-960e-c7f9784d6e09


### 타임박스 드롭앤다운
해당 기능은 테그크가 크다고 판단하여 현재 이슈와 PR에 반영하지 않고 후에 반영해보도록 하겠습니다.


## 🗣️ 리뷰 요구사항 (선택)
leading zero관련해서 왜 이렇게 설정해야하는지 정확히 알고 싶은데 잘 나오지 않네요. 혹시 아시는 분이 있을까요?