### PR TITLE
[FEAT] 타임박스에 수정 및 삭제 UI 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.0"
       },
       "devDependencies": {
@@ -7806,6 +7807,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {

--- a/src/layout/components/main/ContentContanier.tsx
+++ b/src/layout/components/main/ContentContanier.tsx
@@ -4,7 +4,7 @@ export default function ContentContanier(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <main className="flex flex-grow flex-col items-center gap-4 px-8 py-4">
+    <main className="flex flex-grow flex-col items-center gap-2 px-8 py-4">
       {children}
     </main>
   );

--- a/src/page/TableSetupPage/TableSetup.tsx
+++ b/src/page/TableSetupPage/TableSetup.tsx
@@ -19,9 +19,23 @@ export default function TableSetup() {
     closeModal: ConsCloseModal,
     ModalWrapper: ConsModalWrapper,
   } = useModal();
-  const [data, setDate] = useState<DebateInfo[]>([]);
+  const [data, setData] = useState<DebateInfo[]>([]);
 
   const navigate = useNavigate();
+
+  const handleSubmitEdit = (indexToEdit: number, updatedInfo: DebateInfo) => {
+    setData((prevData) =>
+      prevData.map((item, index) =>
+        index === indexToEdit ? updatedInfo : item,
+      ),
+    );
+  };
+
+  const handleSubmitDelete = (indexToRemove: number) => {
+    setData((prevData) =>
+      prevData.filter((_, index) => index !== indexToRemove),
+    );
+  };
 
   return (
     <DefaultLayout>
@@ -47,8 +61,13 @@ export default function TableSetup() {
       </DefaultLayout.Header>
       <DefaultLayout.ContentContanier>
         <PropsAndConsTitle />
-        {data.map((info) => (
-          <DebatePanel key={info.time} info={info} />
+        {data.map((info, index) => (
+          <DebatePanel
+            key={index}
+            info={info}
+            onSubmitEdit={(updatedInfo) => handleSubmitEdit(index, updatedInfo)}
+            onSubmitDelete={() => handleSubmitDelete(index)}
+          />
         ))}
 
         <TimerCreationButton
@@ -69,7 +88,7 @@ export default function TableSetup() {
           selectedStance={'PROS'}
           initDate={data[data.length - 1]}
           onSubmit={(data) => {
-            setDate((prev) => [...prev, data]);
+            setData((prev) => [...prev, data]);
           }}
           onClose={ProsCloseModal}
         />
@@ -80,7 +99,7 @@ export default function TableSetup() {
           selectedStance={'CONS'}
           initDate={data[data.length - 1]}
           onSubmit={(data) => {
-            setDate((prev) => [...prev, data]);
+            setData((prev) => [...prev, data]);
           }}
           onClose={ConsCloseModal}
         />

--- a/src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
@@ -1,12 +1,15 @@
 import { DEBATE_TYPE_LABELS, DebateInfo } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
-
+import EditDeleteButtons from '../EditDeleteButtons/EditDeleteButtons';
 interface DebatePanelProps {
   info: DebateInfo;
+  onSubmitEdit: (updatedInfo: DebateInfo) => void;
+  onSubmitDelete: () => void;
 }
 
-export default function DebatePanel({ info }: DebatePanelProps) {
-  const { stance, debateType, time, speakerNumber } = info;
+export default function DebatePanel(props: DebatePanelProps) {
+  const { stance, debateType, time, speakerNumber } = props.info;
+  const { onSubmitEdit, onSubmitDelete } = props;
 
   const debateTypeLabel = DEBATE_TYPE_LABELS[debateType];
 
@@ -26,8 +29,13 @@ export default function DebatePanel({ info }: DebatePanelProps) {
         <div
           className={`flex w-1/2 flex-col items-center rounded-md ${
             isPros ? 'bg-blue-500' : 'bg-red-500'
-          } p-4 font-bold text-white`}
+          } h-24 p-2 font-bold text-white`}
         >
+          <EditDeleteButtons
+            info={props.info}
+            onSubmitEdit={onSubmitEdit}
+            onSubmitDelete={onSubmitDelete}
+          />
           <div>
             {debateTypeLabel} / {speakerNumber}번 토론자
           </div>
@@ -36,10 +44,15 @@ export default function DebatePanel({ info }: DebatePanelProps) {
       )}
 
       {isNeutralTimeout && (
-        <div className="w-full rounded-md bg-gray-200 py-2 text-center">
-          <span className="font-medium text-gray-600">
+        <div className="flex h-24 w-full items-center text-center">
+          <div className="flex h-4/5 w-full flex-col items-center justify-start rounded-md bg-gray-200 p-2 font-medium text-gray-600">
+            <EditDeleteButtons
+              info={props.info}
+              onSubmitEdit={onSubmitEdit}
+              onSubmitDelete={onSubmitDelete}
+            />
             {debateTypeLabel} | {timeStr}
-          </span>
+          </div>
         </div>
       )}
     </div>

--- a/src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
@@ -1,6 +1,7 @@
 import { DEBATE_TYPE_LABELS, DebateInfo } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 import EditDeleteButtons from '../EditDeleteButtons/EditDeleteButtons';
+
 interface DebatePanelProps {
   info: DebateInfo;
   onSubmitEdit: (updatedInfo: DebateInfo) => void;
@@ -12,49 +13,55 @@ export default function DebatePanel(props: DebatePanelProps) {
   const { onSubmitEdit, onSubmitDelete } = props;
 
   const debateTypeLabel = DEBATE_TYPE_LABELS[debateType];
+  const { minutes, seconds } = Formatting.formatSecondsToMinutes(time);
+  const timeStr = `${minutes}분 ${seconds}초`;
 
   const isPros = stance === 'PROS';
   const isCons = stance === 'CONS';
   const isNeutralTimeout = debateType === 'TIME_OUT' && stance === 'NEUTRAL';
-  const { minutes, seconds } = Formatting.formatSecondsToMinutes(time);
-  const timeStr = `${minutes}분 ${seconds}초`;
+
+  const containerClass = isPros
+    ? 'justify-start'
+    : isCons
+      ? 'justify-end'
+      : 'justify-center';
+
+  const renderProsConsPanel = () => (
+    <div
+      className={`flex w-1/2 flex-col items-center rounded-md ${
+        isPros ? 'bg-blue-500' : 'bg-red-500'
+      } h-24 p-2 font-bold text-white`}
+    >
+      <EditDeleteButtons
+        info={props.info}
+        onSubmitEdit={onSubmitEdit}
+        onSubmitDelete={onSubmitDelete}
+      />
+      <div>
+        {debateTypeLabel} / {speakerNumber}번 토론자
+      </div>
+      <div className="text-2xl">{timeStr}</div>
+    </div>
+  );
+
+  const renderNeutralTimeoutPanel = () => (
+    <div className="flex h-24 w-full items-center text-center">
+      <div className="flex h-4/5 w-full flex-col items-center justify-start rounded-md bg-gray-200 p-2 font-medium text-gray-600">
+        <EditDeleteButtons
+          info={props.info}
+          onSubmitEdit={onSubmitEdit}
+          onSubmitDelete={onSubmitDelete}
+        />
+        {debateTypeLabel} | {timeStr}
+      </div>
+    </div>
+  );
 
   return (
-    <div
-      className={`flex w-full items-center ${
-        isPros ? 'justify-start' : isCons ? 'justify-end' : 'justify-center'
-      }`}
-    >
-      {(isPros || isCons) && (
-        <div
-          className={`flex w-1/2 flex-col items-center rounded-md ${
-            isPros ? 'bg-blue-500' : 'bg-red-500'
-          } h-24 p-2 font-bold text-white`}
-        >
-          <EditDeleteButtons
-            info={props.info}
-            onSubmitEdit={onSubmitEdit}
-            onSubmitDelete={onSubmitDelete}
-          />
-          <div>
-            {debateTypeLabel} / {speakerNumber}번 토론자
-          </div>
-          <div className="text-2xl">{timeStr}</div>
-        </div>
-      )}
+    <div className={`flex w-full items-center ${containerClass}`}>
+      {(isPros || isCons) && renderProsConsPanel()}
 
-      {isNeutralTimeout && (
-        <div className="flex h-24 w-full items-center text-center">
-          <div className="flex h-4/5 w-full flex-col items-center justify-start rounded-md bg-gray-200 p-2 font-medium text-gray-600">
-            <EditDeleteButtons
-              info={props.info}
-              onSubmitEdit={onSubmitEdit}
-              onSubmitDelete={onSubmitDelete}
-            />
-            {debateTypeLabel} | {timeStr}
-          </div>
-        </div>
-      )}
+      {isNeutralTimeout && renderNeutralTimeoutPanel()}
     </div>
   );
 }

--- a/src/page/TableSetupPage/components/DeleteConfirmContent/DeleteConfirmContent.tsx
+++ b/src/page/TableSetupPage/components/DeleteConfirmContent/DeleteConfirmContent.tsx
@@ -1,0 +1,29 @@
+interface DeleteConfirmContentProps {
+  onDelete: () => void;
+  onClose: () => void; // 모달 닫기 함수
+}
+
+export default function DeleteConfirmContent({
+  onDelete,
+  onClose,
+}: DeleteConfirmContentProps) {
+  const handleDelete = () => {
+    onDelete();
+    onClose();
+  };
+  return (
+    <div className="p-10">
+      <h2 className={`mb-4 text-xl font-bold`}>
+        타임 박스를 삭제하시겠습니까?
+      </h2>
+      <div className="flex flex-col space-y-6">
+        <button
+          className="mt-4 w-full rounded bg-amber-300 p-2 hover:bg-amber-500"
+          onClick={handleDelete}
+        >
+          삭제하기
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.stories.tsx
+++ b/src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.stories.tsx
@@ -1,0 +1,41 @@
+import { Meta, StoryObj } from '@storybook/react';
+import EditDeleteButtons from './EditDeleteButtons';
+import { DebateInfo } from '../../../../type/type';
+import { MemoryRouter } from 'react-router-dom';
+import { GlobalPortal } from '../../../../util/GlobalPortal';
+
+const meta: Meta<typeof EditDeleteButtons> = {
+  title: 'page/TableSetup/components/EditDeleteButtons',
+  component: EditDeleteButtons,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <GlobalPortal.Provider>
+          <div className="h-screen">
+            <Story />
+          </div>
+        </GlobalPortal.Provider>
+      </MemoryRouter>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EditDeleteButtons>;
+
+const mockInfo: DebateInfo = {
+  stance: 'PROS',
+  debateType: 'OPENING',
+  time: 150,
+  speakerNumber: 1,
+};
+
+export const Default: Story = {
+  args: {
+    info: mockInfo,
+    onSubmitEdit: () => {},
+    onSubmitDelete: () => {},
+  },
+};

--- a/src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -1,0 +1,38 @@
+import { AiOutlineDelete, AiOutlineEdit } from 'react-icons/ai';
+import { useModal } from '../../../../hooks/useModal';
+import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
+import { DebateInfo } from '../../../../type/type';
+
+interface EditDeleteButtonsPros {
+  info: DebateInfo;
+  onSubmitEdit: (updatedInfo: DebateInfo) => void;
+  onSubmitDelete: () => void;
+}
+
+export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
+  const { openModal, closeModal, ModalWrapper } = useModal();
+  const { info, onSubmitEdit, onSubmitDelete } = props;
+  return (
+    <>
+      <div className="flex w-full justify-end gap-2">
+        <button onClick={openModal}>
+          <AiOutlineEdit />
+        </button>
+        <button>
+          <AiOutlineDelete onClick={onSubmitDelete} />
+        </button>
+      </div>
+      <ModalWrapper>
+        <TimerCreationContent
+          selectedStance={info.stance}
+          initDate={info}
+          onSubmit={(newInfo) => {
+            onSubmitEdit(newInfo);
+          }}
+          onClose={closeModal}
+        />
+        ,
+      </ModalWrapper>
+    </>
+  );
+}

--- a/src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -25,10 +25,10 @@ export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
   return (
     <>
       <div className="flex w-full justify-end gap-2">
-        <button onClick={openEditModal}>
+        <button onClick={openEditModal} aria-label="수정하기">
           <AiOutlineEdit />
         </button>
-        <button onClick={deleteOpenModal}>
+        <button onClick={deleteOpenModal} aria-label="삭제하기">
           <AiOutlineDelete />
         </button>
       </div>

--- a/src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -2,6 +2,7 @@ import { AiOutlineDelete, AiOutlineEdit } from 'react-icons/ai';
 import { useModal } from '../../../../hooks/useModal';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 import { DebateInfo } from '../../../../type/type';
+import DeleteConfirmContent from '../DeleteConfirmContent/DeleteConfirmContent';
 
 interface EditDeleteButtonsPros {
   info: DebateInfo;
@@ -10,29 +11,43 @@ interface EditDeleteButtonsPros {
 }
 
 export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
-  const { openModal, closeModal, ModalWrapper } = useModal();
+  const {
+    openModal: openEditModal,
+    closeModal: closeEditModal,
+    ModalWrapper: EditModalWrapper,
+  } = useModal();
+  const {
+    openModal: deleteOpenModal,
+    closeModal: deleteCloseModal,
+    ModalWrapper: DeleteModalWrapper,
+  } = useModal();
   const { info, onSubmitEdit, onSubmitDelete } = props;
   return (
     <>
       <div className="flex w-full justify-end gap-2">
-        <button onClick={openModal}>
+        <button onClick={openEditModal}>
           <AiOutlineEdit />
         </button>
-        <button>
-          <AiOutlineDelete onClick={onSubmitDelete} />
+        <button onClick={deleteOpenModal}>
+          <AiOutlineDelete />
         </button>
       </div>
-      <ModalWrapper>
+      <EditModalWrapper>
         <TimerCreationContent
           selectedStance={info.stance}
           initDate={info}
           onSubmit={(newInfo) => {
             onSubmitEdit(newInfo);
           }}
-          onClose={closeModal}
+          onClose={closeEditModal}
         />
-        ,
-      </ModalWrapper>
+      </EditModalWrapper>
+      <DeleteModalWrapper>
+        <DeleteConfirmContent
+          onDelete={onSubmitDelete}
+          onClose={deleteCloseModal}
+        />
+      </DeleteModalWrapper>
     </>
   );
 }


### PR DESCRIPTION
## 🚩 연관 이슈
closed #40

## 📝 작업 내용
### 개요
타임박스에 수정 및  삭제 UI 추가
- 수정 버튼과 삭제 버튼을 위한 react-icons를 추가
- 수정 버튼과 삭제 버튼의 재사용을 위한 EditDeleteButtons 구현
- DebatePanel의 분기 처리에 따른 컴퍼넌트의 높이를 동일하게 수정
- defaultlayout의 gap 수정

<img width="1105" alt="image" src="https://github.com/user-attachments/assets/64d7bd71-f2cd-43a1-a74f-9c3a773752bf" />

### 소스 코드 변경 사항
- src/page/TableSetupPage/TableSetup.tsx
- src/page/TableSetupPage/components/DebatePanel/DebatePanel.tsx
- src/page/TableSetupPage/components/EditDeleteButtons/EditDeleteButtons.tsx
- src/layout/components/main/ContentContanier.tsx
- package.json
