### PR TITLE
[FEAT] 테이블 수정 및 삭제 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/eslint-plugin-query": "^5.62.9",
-        "@tanstack/react-query": "^5.62.11",
+        "@tanstack/react-query": "^5.62.12",
         "axios": "^1.7.9",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.4.0",
         "react-router-dom": "^7.1.0"
       },
       "devDependencies": {
@@ -2608,9 +2609,9 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.62.9",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.9.tgz",
-      "integrity": "sha512-lwePd8hNYhyQ4nM/iRQ+Wz2cDtspGeZZHFZmCzHJ7mfKXt+9S301fULiY2IR2byJYY6Z03T427E5PoVfMexHjw==",
+      "version": "5.62.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.62.12.tgz",
+      "integrity": "sha512-6igFeBgymHkCxVgaEk+yiLwkMf9haui/EQLmI3o9CatOyDThEoFKe8toLWvWliZC/Jf+h7NwHi/zjfyLArr1ow==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2618,12 +2619,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.62.11",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.11.tgz",
-      "integrity": "sha512-Xb1nw0cYMdtFmwkvH9+y5yYFhXvLRCnXoqlzSw7UkqtCVFq3cG8q+rHZ2Yz1XrC+/ysUaTqbLKJqk95mCgC1oQ==",
+      "version": "5.62.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.62.12.tgz",
+      "integrity": "sha512-yt8p7l5MlHA3QCt6xF1Cu9dw1Anf93yTK+DMDJQ64h/mshAymVAtcwj8TpsyyBrZNWAAZvza/m76bnTSR79ZtQ==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.62.9"
+        "@tanstack/query-core": "5.62.12"
       },
       "funding": {
         "type": "github",
@@ -8425,6 +8426,15 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -18,10 +18,11 @@
   },
   "dependencies": {
     "@tanstack/eslint-plugin-query": "^5.62.9",
-    "@tanstack/react-query": "^5.62.11",
+    "@tanstack/react-query": "^5.62.12",
     "axios": "^1.7.9",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.4.0",
     "react-router-dom": "^7.1.0"
   },
   "devDependencies": {

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -34,6 +34,7 @@ export function useModal(options: UseModalOptions = {}) {
 
   const handleOverlayClick = useCallback(
     (e: React.MouseEvent) => {
+      e.stopPropagation();
       if (e.target === e.currentTarget && closeOnOverlayClick) {
         closeModal();
       }

--- a/src/page/TableListPage/TableListPage.test.tsx
+++ b/src/page/TableListPage/TableListPage.test.tsx
@@ -107,7 +107,7 @@ describe('TableListPage', () => {
 
     // Check first table
     const firstTable = tables[0];
-    expect(firstTable).toHaveTextContent('테이블1');
+    expect(firstTable).toHaveTextContent('테이블 1');
     expect(firstTable).toHaveTextContent('의회식 토론');
     expect(firstTable).toHaveTextContent('30');
 

--- a/src/page/TableListPage/TableListPage.tsx
+++ b/src/page/TableListPage/TableListPage.tsx
@@ -5,7 +5,7 @@ import AddTable from './components/Table/AddTable';
 import Table from './components/Table/Table';
 
 const initialData = [
-  { name: '테이블1', type: '의회식 토론', time: 30, onDelete: () => {} },
+  { name: '테이블 1', type: '의회식 토론', time: 30, onDelete: () => {} },
   { name: '테이블 2', type: '의회식 토론', time: 30, onDelete: () => {} },
   { name: '테이블 3', type: '의회식 토론', time: 30, onDelete: () => {} },
   { name: '테이블 4', type: '의회식 토론', time: 30, onDelete: () => {} },

--- a/src/page/TableListPage/TableListPage.tsx
+++ b/src/page/TableListPage/TableListPage.tsx
@@ -11,11 +11,17 @@ const initialData = [
   { name: '테이블 4', type: '의회식 토론', time: 30, onDelete: () => {} },
 ];
 
+interface DebateTableWithDelete extends DebateTable {
+  onDelete: (name: string) => void;
+}
+
 export default function TableListPage() {
-  const [tables, setTables] = useState<DebateTable[]>(initialData);
+  const [tables, setTables] = useState<DebateTableWithDelete[]>(initialData);
 
   const handleDelete = (targetName: string) => {
-    setTables(tables.filter((table) => table.name !== targetName));
+    setTables((prevTables) =>
+      prevTables.filter((table) => table.name !== targetName),
+    );
   };
 
   return (
@@ -25,7 +31,7 @@ export default function TableListPage() {
       </DefaultLayout.Header>
       <div className="flex h-screen flex-col px-4 py-6">
         <main className="grid grid-cols-3 justify-items-center gap-6">
-          {tables.map((table: DebateTable, idx: number) => (
+          {tables.map((table: DebateTableWithDelete, idx: number) => (
             <Table
               key={idx}
               name={table.name}

--- a/src/page/TableListPage/TableListPage.tsx
+++ b/src/page/TableListPage/TableListPage.tsx
@@ -1,16 +1,23 @@
+import { useState } from 'react';
 import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
 import { DebateTable } from '../../type/type';
 import AddTable from './components/Table/AddTable';
 import Table from './components/Table/Table';
 
-const data = [
-  { name: '테이블1', type: '의회식 토론', time: 30 },
-  { name: '테이블 2', type: '의회식 토론', time: 30 },
-  { name: '테이블 3', type: '의회식 토론', time: 30 },
-  { name: '테이블 4', type: '의회식 토론', time: 30 },
+const initialData = [
+  { name: '테이블1', type: '의회식 토론', time: 30, onDelete: () => {} },
+  { name: '테이블 2', type: '의회식 토론', time: 30, onDelete: () => {} },
+  { name: '테이블 3', type: '의회식 토론', time: 30, onDelete: () => {} },
+  { name: '테이블 4', type: '의회식 토론', time: 30, onDelete: () => {} },
 ];
 
 export default function TableListPage() {
+  const [tables, setTables] = useState<DebateTable[]>(initialData);
+
+  const handleDelete = (targetName: string) => {
+    setTables(tables.filter((table) => table.name !== targetName));
+  };
+
   return (
     <DefaultLayout>
       <DefaultLayout.Header>
@@ -18,12 +25,13 @@ export default function TableListPage() {
       </DefaultLayout.Header>
       <div className="flex h-screen flex-col px-4 py-6">
         <main className="grid grid-cols-3 justify-items-center gap-6">
-          {data.map((table: DebateTable, idx: number) => (
+          {tables.map((table: DebateTable, idx: number) => (
             <Table
               key={idx}
               name={table.name}
               type={table.type}
               time={table.time}
+              onDelete={handleDelete}
             />
           ))}
           <AddTable />

--- a/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
@@ -1,0 +1,45 @@
+import { AiOutlineDelete } from 'react-icons/ai';
+import { useModal } from '../../../../hooks/useModal';
+
+export default function DeleteModalButton({
+  name,
+  onDelete,
+}: {
+  name: string;
+  onDelete: (name: string) => void;
+}) {
+  const { openModal, closeModal, ModalWrapper } = useModal();
+
+  const handleOpenModal = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    openModal();
+  };
+
+  const handleDelete = () => {
+    onDelete(name);
+    closeModal();
+  };
+
+  return (
+    <>
+      <button
+        onClick={handleOpenModal}
+        className="transform text-lg duration-200 hover:scale-125  lg:text-2xl"
+      >
+        <AiOutlineDelete />
+      </button>
+      <ModalWrapper>
+        <div className="flex flex-col items-center gap-6 py-8">
+          <h1 className="text-xl font-bold">삭제하시겠습니까?</h1>
+          <h2 className="text-lg font-semibold">테이블명: {name}</h2>
+          <button
+            className="mt-8 rounded-lg bg-red-500 px-8 py-2 text-white"
+            onClick={handleDelete}
+          >
+            삭제
+          </button>
+        </div>
+      </ModalWrapper>
+    </>
+  );
+}

--- a/src/page/TableListPage/components/Modal/EditModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditModalButton.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { AiOutlineEdit } from 'react-icons/ai';
 import { useModal } from '../../../../hooks/useModal';
-import CreateTableModal from './CreateTableModal';
+import EditTableModal from './EditTableModal';
 
 export default function EditModalButton() {
   const { openModal, ModalWrapper } = useModal();
@@ -20,7 +20,7 @@ export default function EditModalButton() {
         <AiOutlineEdit />
       </button>
       <ModalWrapper>
-        <CreateTableModal />
+        <EditTableModal />
       </ModalWrapper>
     </>
   );

--- a/src/page/TableListPage/components/Modal/EditModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditModalButton.tsx
@@ -1,0 +1,26 @@
+import React, { Fragment } from 'react';
+import { AiOutlineEdit } from 'react-icons/ai';
+import { useModal } from '../../../../hooks/useModal';
+
+export default function EditModalButton() {
+  const { openModal, closeModal, ModalWrapper } = useModal();
+
+  const handleEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    openModal();
+  };
+
+  return (
+    <Fragment>
+      <button
+        onClick={handleEdit}
+        className="transform text-lg  duration-200 hover:scale-125 lg:text-2xl"
+      >
+        <AiOutlineEdit />
+      </button>
+      <ModalWrapper>
+        <div>hi!</div>
+      </ModalWrapper>
+    </Fragment>
+  );
+}

--- a/src/page/TableListPage/components/Modal/EditModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditModalButton.tsx
@@ -3,7 +3,7 @@ import { AiOutlineEdit } from 'react-icons/ai';
 import { useModal } from '../../../../hooks/useModal';
 import EditTableModal from './EditTableModal';
 
-export default function EditModalButton() {
+export default function EditModalButton({ name }: { name: string }) {
   const { openModal, ModalWrapper } = useModal();
 
   const handleEdit = (e: React.MouseEvent) => {
@@ -20,7 +20,7 @@ export default function EditModalButton() {
         <AiOutlineEdit />
       </button>
       <ModalWrapper>
-        <EditTableModal />
+        <EditTableModal name={name} />
       </ModalWrapper>
     </>
   );

--- a/src/page/TableListPage/components/Modal/EditModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditModalButton.tsx
@@ -10,7 +10,7 @@ export default function EditModalButton({
   name: string;
   type: string;
 }) {
-  const { openModal, ModalWrapper } = useModal();
+  const { openModal, closeModal, ModalWrapper } = useModal();
 
   const handleEdit = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -26,7 +26,7 @@ export default function EditModalButton({
         <AiOutlineEdit />
       </button>
       <ModalWrapper>
-        <EditTableModal name={name} type={type} />
+        <EditTableModal name={name} type={type} closeModal={closeModal} />
       </ModalWrapper>
     </>
   );

--- a/src/page/TableListPage/components/Modal/EditModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditModalButton.tsx
@@ -3,7 +3,13 @@ import { AiOutlineEdit } from 'react-icons/ai';
 import { useModal } from '../../../../hooks/useModal';
 import EditTableModal from './EditTableModal';
 
-export default function EditModalButton({ name }: { name: string }) {
+export default function EditModalButton({
+  name,
+  type,
+}: {
+  name: string;
+  type: string;
+}) {
   const { openModal, ModalWrapper } = useModal();
 
   const handleEdit = (e: React.MouseEvent) => {
@@ -20,7 +26,7 @@ export default function EditModalButton({ name }: { name: string }) {
         <AiOutlineEdit />
       </button>
       <ModalWrapper>
-        <EditTableModal name={name} />
+        <EditTableModal name={name} type={type} />
       </ModalWrapper>
     </>
   );

--- a/src/page/TableListPage/components/Modal/EditModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditModalButton.tsx
@@ -4,7 +4,7 @@ import { useModal } from '../../../../hooks/useModal';
 import CreateTableModal from './CreateTableModal';
 
 export default function EditModalButton() {
-  const { openModal, closeModal, ModalWrapper } = useModal();
+  const { openModal, ModalWrapper } = useModal();
 
   const handleEdit = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/page/TableListPage/components/Modal/EditModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditModalButton.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { AiOutlineEdit } from 'react-icons/ai';
 import { useModal } from '../../../../hooks/useModal';
 import CreateTableModal from './CreateTableModal';
@@ -12,7 +12,7 @@ export default function EditModalButton() {
   };
 
   return (
-    <Fragment>
+    <>
       <button
         onClick={handleEdit}
         className="transform text-lg  duration-200 hover:scale-125 lg:text-2xl"
@@ -22,6 +22,6 @@ export default function EditModalButton() {
       <ModalWrapper>
         <CreateTableModal />
       </ModalWrapper>
-    </Fragment>
+    </>
   );
 }

--- a/src/page/TableListPage/components/Modal/EditModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditModalButton.tsx
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import { AiOutlineEdit } from 'react-icons/ai';
 import { useModal } from '../../../../hooks/useModal';
+import CreateTableModal from './CreateTableModal';
 
 export default function EditModalButton() {
   const { openModal, closeModal, ModalWrapper } = useModal();
@@ -19,7 +20,7 @@ export default function EditModalButton() {
         <AiOutlineEdit />
       </button>
       <ModalWrapper>
-        <div>hi!</div>
+        <CreateTableModal />
       </ModalWrapper>
     </Fragment>
   );

--- a/src/page/TableListPage/components/Modal/EditTableButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditTableButton.tsx
@@ -1,0 +1,18 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function EditTableButton() {
+  const navigate = useNavigate();
+
+  const handleClick = () => {
+    navigate('/');
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="h-[80px] w-full bg-amber-500 text-4xl font-semibold transition duration-300 hover:bg-amber-600"
+    >
+      테이블 수정하기
+    </button>
+  );
+}

--- a/src/page/TableListPage/components/Modal/EditTableButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditTableButton.tsx
@@ -1,10 +1,10 @@
-import { useNavigate } from 'react-router-dom';
-
-export default function EditTableButton() {
-  const navigate = useNavigate();
-
+export default function EditTableButton({
+  closeModal,
+}: {
+  closeModal: () => void;
+}) {
   const handleClick = () => {
-    navigate('/');
+    closeModal();
   };
 
   return (

--- a/src/page/TableListPage/components/Modal/EditTableModal.tsx
+++ b/src/page/TableListPage/components/Modal/EditTableModal.tsx
@@ -1,7 +1,13 @@
 import DropdownForDebateType from './DropdownForDebateType';
 import EditTableButton from './EditTableButton';
 
-export default function EditTableModal({ name }: { name: string }) {
+export default function EditTableModal({
+  name,
+  type,
+}: {
+  name: string;
+  type: string;
+}) {
   return (
     <div className="flex h-[700px] w-full flex-col">
       <div className="flex h-[100px] items-center justify-center bg-neutral-300 text-3xl font-semibold lg:text-5xl">
@@ -17,7 +23,9 @@ export default function EditTableModal({ name }: { name: string }) {
         </div>
         <div className="flex w-full items-center justify-between">
           <h1 className="text-md font-bold lg:text-5xl">토론 유형</h1>
-          <DropdownForDebateType />
+          <div className="w-8/12 bg-neutral-300 p-6 text-center text-3xl font-semibold text-white">
+            {type} (수정 불가)
+          </div>
         </div>
       </section>
       <EditTableButton />

--- a/src/page/TableListPage/components/Modal/EditTableModal.tsx
+++ b/src/page/TableListPage/components/Modal/EditTableModal.tsx
@@ -3,9 +3,11 @@ import EditTableButton from './EditTableButton';
 export default function EditTableModal({
   name,
   type,
+  closeModal,
 }: {
   name: string;
   type: string;
+  closeModal: () => void;
 }) {
   return (
     <div className="flex h-[700px] w-full flex-col">
@@ -27,7 +29,7 @@ export default function EditTableModal({
           </div>
         </div>
       </section>
-      <EditTableButton />
+      <EditTableButton closeModal={closeModal} />
     </div>
   );
 }

--- a/src/page/TableListPage/components/Modal/EditTableModal.tsx
+++ b/src/page/TableListPage/components/Modal/EditTableModal.tsx
@@ -1,0 +1,26 @@
+import DropdownForDebateType from './DropdownForDebateType';
+import EditTableButton from './EditTableButton';
+
+export default function EditTableModal() {
+  return (
+    <div className="flex h-[700px] w-full flex-col">
+      <div className="flex h-[100px] items-center justify-center bg-neutral-300 text-3xl font-semibold lg:text-5xl">
+        <h1>테이블 수정</h1>
+      </div>
+      <section className="flex flex-1 flex-col justify-center gap-14 p-8 lg:items-center">
+        <div className="flex w-full items-center justify-between">
+          <h1 className="text-md font-bold lg:text-5xl">토론 시간표 이름</h1>
+          <input
+            placeholder="시간표#1(디폴트 값)"
+            className="w-8/12 rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
+          />
+        </div>
+        <div className="flex w-full items-center justify-between">
+          <h1 className="text-md font-bold lg:text-5xl">토론 유형</h1>
+          <DropdownForDebateType />
+        </div>
+      </section>
+      <EditTableButton />
+    </div>
+  );
+}

--- a/src/page/TableListPage/components/Modal/EditTableModal.tsx
+++ b/src/page/TableListPage/components/Modal/EditTableModal.tsx
@@ -1,11 +1,11 @@
 import DropdownForDebateType from './DropdownForDebateType';
 import EditTableButton from './EditTableButton';
 
-export default function EditTableModal() {
+export default function EditTableModal({ name }: { name: string }) {
   return (
     <div className="flex h-[700px] w-full flex-col">
       <div className="flex h-[100px] items-center justify-center bg-neutral-300 text-3xl font-semibold lg:text-5xl">
-        <h1>테이블 수정</h1>
+        <h1>{name} 수정</h1>
       </div>
       <section className="flex flex-1 flex-col justify-center gap-14 p-8 lg:items-center">
         <div className="flex w-full items-center justify-between">

--- a/src/page/TableListPage/components/Modal/EditTableModal.tsx
+++ b/src/page/TableListPage/components/Modal/EditTableModal.tsx
@@ -1,4 +1,3 @@
-import DropdownForDebateType from './DropdownForDebateType';
 import EditTableButton from './EditTableButton';
 
 export default function EditTableModal({
@@ -23,8 +22,8 @@ export default function EditTableModal({
         </div>
         <div className="flex w-full items-center justify-between">
           <h1 className="text-md font-bold lg:text-5xl">토론 유형</h1>
-          <div className="w-8/12 bg-neutral-300 p-6 text-center text-3xl font-semibold text-white">
-            {type} (수정 불가)
+          <div className="w-8/12 bg-neutral-300 p-6 text-center text-3xl font-semibold text-white hover:cursor-not-allowed">
+            {type}
           </div>
         </div>
       </section>

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router-dom';
 import { DebateTable } from '../../../../type/type';
-import { AiOutlineDelete, AiOutlineEdit } from 'react-icons/ai';
+import { AiOutlineDelete } from 'react-icons/ai';
+import EditModalButton from '../Modal/EditModalButton';
 
 export default function Table({ name, type, time, onDelete }: DebateTable) {
   const navigate = useNavigate();
@@ -20,9 +21,7 @@ export default function Table({ name, type, time, onDelete }: DebateTable) {
       className="flex h-[200px] w-11/12 flex-col items-center rounded-md bg-amber-500 p-5 duration-200 hover:scale-105"
     >
       <div className="flex w-full justify-end gap-4 pb-2 lg:pb-0">
-        <button className="transform text-lg  duration-200 hover:scale-125 lg:text-2xl">
-          <AiOutlineEdit />
-        </button>
+        <EditModalButton />
         <button
           onClick={handleDelete}
           className="transform text-lg duration-200 hover:scale-125  lg:text-2xl"

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -16,7 +16,7 @@ export default function Table({ name, type, time, onDelete }: DebateTable) {
       className="flex h-[200px] w-11/12 flex-col items-center rounded-md bg-amber-500 p-5 duration-200 hover:scale-105"
     >
       <div className="flex w-full justify-end gap-4 pb-2 lg:pb-0">
-        <EditModalButton />
+        <EditModalButton name={name} />
         <DeleteModalButton name={name} onDelete={onDelete} />
       </div>
       <h1 className="text-3xl font-semibold lg:text-5xl">{name}</h1>

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -2,11 +2,16 @@ import { useNavigate } from 'react-router-dom';
 import { DebateTable } from '../../../../type/type';
 import { AiOutlineDelete, AiOutlineEdit } from 'react-icons/ai';
 
-export default function Table({ name, type, time }: DebateTable) {
+export default function Table({ name, type, time, onDelete }: DebateTable) {
   const navigate = useNavigate();
 
   const handleClick = () => {
     navigate('/');
+  };
+
+  const handleDelete = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onDelete(name);
   };
 
   return (
@@ -18,7 +23,10 @@ export default function Table({ name, type, time }: DebateTable) {
         <button className="transform text-lg  duration-200 hover:scale-125 lg:text-2xl">
           <AiOutlineEdit />
         </button>
-        <button className="transform text-lg duration-200 hover:scale-125  lg:text-2xl">
+        <button
+          onClick={handleDelete}
+          className="transform text-lg duration-200 hover:scale-125  lg:text-2xl"
+        >
           <AiOutlineDelete />
         </button>
       </div>

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -25,7 +25,7 @@ export default function Table({
       className="flex h-[200px] w-11/12 flex-col items-center rounded-md bg-amber-500 p-5 duration-200 hover:scale-105"
     >
       <div className="flex w-full justify-end gap-4 pb-2 lg:pb-0">
-        <EditModalButton name={name} />
+        <EditModalButton name={name} type={type} />
         <DeleteModalButton name={name} onDelete={onDelete} />
       </div>
       <h1 className="text-3xl font-semibold lg:text-5xl">{name}</h1>

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -3,7 +3,16 @@ import { DebateTable } from '../../../../type/type';
 import EditModalButton from '../Modal/EditModalButton';
 import DeleteModalButton from '../Modal/DeleteModalButton';
 
-export default function Table({ name, type, time, onDelete }: DebateTable) {
+interface DebateTableWithDelete extends DebateTable {
+  onDelete: () => void;
+}
+
+export default function Table({
+  name,
+  type,
+  time,
+  onDelete,
+}: DebateTableWithDelete) {
   const navigate = useNavigate();
 
   const handleClick = () => {

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -4,7 +4,7 @@ import EditModalButton from '../Modal/EditModalButton';
 import DeleteModalButton from '../Modal/DeleteModalButton';
 
 interface DebateTableWithDelete extends DebateTable {
-  onDelete: () => void;
+  onDelete: (name: string) => void;
 }
 
 export default function Table({

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { DebateTable } from '../../../../type/type';
+import { AiOutlineDelete, AiOutlineEdit } from 'react-icons/ai';
 
 export default function Table({ name, type, time }: DebateTable) {
   const navigate = useNavigate();
@@ -13,6 +14,14 @@ export default function Table({ name, type, time }: DebateTable) {
       onClick={handleClick}
       className="flex h-[200px] w-11/12 flex-col items-center rounded-md bg-amber-500 p-5 duration-200 hover:scale-105"
     >
+      <div className="flex w-full justify-end gap-4 pb-2 lg:pb-0">
+        <button className="transform text-lg  duration-200 hover:scale-125 lg:text-2xl">
+          <AiOutlineEdit />
+        </button>
+        <button className="transform text-lg duration-200 hover:scale-125  lg:text-2xl">
+          <AiOutlineDelete />
+        </button>
+      </div>
       <h1 className="text-3xl font-semibold lg:text-5xl">{name}</h1>
       <div className="flex w-full flex-grow flex-col items-start justify-center text-lg font-semibold lg:text-2xl">
         <h1>유형 : {type}</h1>

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -1,18 +1,13 @@
 import { useNavigate } from 'react-router-dom';
 import { DebateTable } from '../../../../type/type';
-import { AiOutlineDelete } from 'react-icons/ai';
 import EditModalButton from '../Modal/EditModalButton';
+import DeleteModalButton from '../Modal/DeleteModalButton';
 
 export default function Table({ name, type, time, onDelete }: DebateTable) {
   const navigate = useNavigate();
 
   const handleClick = () => {
     navigate('/');
-  };
-
-  const handleDelete = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    onDelete(name);
   };
 
   return (
@@ -22,12 +17,7 @@ export default function Table({ name, type, time, onDelete }: DebateTable) {
     >
       <div className="flex w-full justify-end gap-4 pb-2 lg:pb-0">
         <EditModalButton />
-        <button
-          onClick={handleDelete}
-          className="transform text-lg duration-200 hover:scale-125  lg:text-2xl"
-        >
-          <AiOutlineDelete />
-        </button>
+        <DeleteModalButton name={name} onDelete={onDelete} />
       </div>
       <h1 className="text-3xl font-semibold lg:text-5xl">{name}</h1>
       <div className="flex w-full flex-grow flex-col items-start justify-center text-lg font-semibold lg:text-2xl">

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -25,5 +25,4 @@ export interface DebateTable {
   name: string;
   type: string;
   time: number;
-  onDelete: (name: string) => void;
 }

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -25,4 +25,5 @@ export interface DebateTable {
   name: string;
   type: string;
   time: number;
+  onDelete: (name: string) => void;
 }


### PR DESCRIPTION
## 🚩 연관 이슈
closed #43

## 📝 작업 내용
1. Table 컴포넌트에 수정 및 삭제 컴포넌트 추가
```ts
      <div className="flex w-full justify-end gap-4 pb-2 lg:pb-0">
        <EditModalButton />
        <DeleteModalButton name={name} onDelete={onDelete} />
      </div>
```

2.  테이블 수정 - EditModalButton 컴포넌트
```ts
import React from 'react';
import { AiOutlineEdit } from 'react-icons/ai';
import { useModal } from '../../../../hooks/useModal';
import EditTableModal from './EditTableModal';

export default function EditModalButton({ name }: { name: string }) {
  const { openModal, ModalWrapper } = useModal();

  const handleEdit = (e: React.MouseEvent) => {
    e.stopPropagation();
    openModal();
  };

  return (
    <>
      <button
        onClick={handleEdit}
        className="transform text-lg  duration-200 hover:scale-125 lg:text-2xl"
      >
        <AiOutlineEdit />
      </button>
      <ModalWrapper>
        <EditTableModal name={name} />
      </ModalWrapper>
    </>
  );
}

```

3. EditTableModal 컴포넌트
```ts
import DropdownForDebateType from './DropdownForDebateType';
import EditTableButton from './EditTableButton';

export default function EditTableModal({ name }: { name: string }) {
  return (
    <div className="flex h-[700px] w-full flex-col">
      <div className="flex h-[100px] items-center justify-center bg-neutral-300 text-3xl font-semibold lg:text-5xl">
        <h1>{name} 수정</h1>
      </div>
      <section className="flex flex-1 flex-col justify-center gap-14 p-8 lg:items-center">
        <div className="flex w-full items-center justify-between">
          <h1 className="text-md font-bold lg:text-5xl">토론 시간표 이름</h1>
          <input
            placeholder="시간표#1(디폴트 값)"
            className="w-8/12 rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
          />
        </div>
        <div className="flex w-full items-center justify-between">
          <h1 className="text-md font-bold lg:text-5xl">토론 유형</h1>
          <DropdownForDebateType />
        </div>
      </section>
      <EditTableButton />
    </div>
  );
}


```

4. 테이블삭제 - DeleteModalButton 컴포넌트
```ts
import { AiOutlineDelete } from 'react-icons/ai';
import { useModal } from '../../../../hooks/useModal';

export default function DeleteModalButton({
  name,
  onDelete,
}: {
  name: string;
  onDelete: (name: string) => void;
}) {
  const { openModal, closeModal, ModalWrapper } = useModal();

  const handleOpenModal = (e: React.MouseEvent) => {
    e.stopPropagation();
    openModal();
  };

  const handleDelete = () => {
    onDelete(name);
    closeModal();
  };

  return (
    <>
      <button
        onClick={handleOpenModal}
        className="transform text-lg duration-200 hover:scale-125  lg:text-2xl"
      >
        <AiOutlineDelete />
      </button>
      <ModalWrapper>
        <div className="flex flex-col items-center gap-6 py-8">
          <h1 className="text-xl font-bold">삭제하시겠습니까?</h1>
          <h2 className="text-lg font-semibold">테이블명: {name}</h2>
          <button
            className="mt-8 rounded-lg bg-red-500 px-8 py-2 text-white"
            onClick={handleDelete}
          >
            삭제
          </button>
        </div>
      </ModalWrapper>
    </>
  );
}

```
5. EditTableButton 컴포넌트 - 이후 백엔드 수정 RestAPI 로직 추가
```ts
import { useNavigate } from 'react-router-dom';

export default function EditTableButton() {
  const navigate = useNavigate();

  const handleClick = () => {
    navigate('/');
  };

  return (
    <button
      onClick={handleClick}
      className="h-[80px] w-full bg-amber-500 text-4xl font-semibold transition duration-300 hover:bg-amber-600"
    >
      테이블 수정하기
    </button>
  );
}

```

6. useModal 훅 수정

- e.stopPropagation(); 를 추가하여  버튼 클릭 이벤트가 상위로 전파되는 것을 막기 위해서 추가함

```ts
  const handleOverlayClick = useCallback(
    (e: React.MouseEvent) => {
      e.stopPropagation();
      if (e.target === e.currentTarget && closeOnOverlayClick) {
        closeModal();
      }
    },
    [closeModal, closeOnOverlayClick],
  );
```

## 🏞️ 스크린샷 (선택)

1. 삭제 icon 눌렀을 때
![image](https://github.com/user-attachments/assets/a0f86338-7509-485e-a306-c2d2bf16b26f)

1-2. 삭제 후
![image](https://github.com/user-attachments/assets/4413b52b-e672-47cb-be3a-8e85f8013870)


2. 수정 icon 눌렀을 때
![image](https://github.com/user-attachments/assets/ddd1e1f7-3984-49b4-b07a-60aa7f336acd)




## 🗣️ 리뷰 요구사항 (선택)
- 백엔드 Rest API 관련 로직은 이후 리팩토링으로 추가할 예정입니다.
- 수정 및 보완할 부분이 있을 시 리뷰 부탁드립니다.


## 피드백 반영 후

1. DebateTable 에서 extends를 통해 DebateTableWithDelete 타입 정의

```ts
interface DebateTableWithDelete extends DebateTable {
  onDelete: (name: string) => void;
}

export default function TableListPage() {
  const [tables, setTables] = useState<DebateTableWithDelete[]>(initialData);
```

2. 함수형 업데이트 적용

```ts
  const handleDelete = (targetName: string) => {
    setTables((prevTables) =>
      prevTables.filter((table) => table.name !== targetName),
    );
  };
```

3.  EditTableModal 컴포넌트에서 토론 유형 부분은 수정못하도록 hover:cursor-not-allowed  적용

```ts
        <div className="flex w-full items-center justify-between">
          <h1 className="text-md font-bold lg:text-5xl">토론 유형</h1>
          <div className="w-8/12 bg-neutral-300 p-6 text-center text-3xl font-semibold text-white hover:cursor-not-allowed">
            {type}
          </div>
        </div>
```
