### PR TITLE
[FEAT] `ErrorBoundary` 도입

### DIFF
--- a/src/apis/responseTypes.ts
+++ b/src/apis/responseTypes.ts
@@ -43,10 +43,5 @@ export interface PutDebateTableResponseType {
 
 // Response types for error cases
 export interface ErrorResponseType {
-  type: string;
-  title: string;
-  status: number;
-  detail: string;
-  instance: string;
   message: string;
 }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+import ErrorPage from './ErrorPage';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  message: string;
+  stack: string;
+}
+
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = {
+      hasError: false,
+      message: '오류 정보 없음',
+      stack: '스택 정보 없음',
+    };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    const message = error.message;
+    const stack = error.stack ? error.stack : '스택 정보 없음';
+    return { hasError: true, message: message, stack: stack };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // You can also log the error to an error reporting service
+    console.log(error, errorInfo);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <ErrorPage message={this.state.message} stack={this.state.stack} />
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -11,20 +11,23 @@ interface ErrorBoundaryState {
   stack: string;
 }
 
+const defaultMessage = '오류 정보 없음';
+const defaultStack = '오류 정보 없음';
+
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = {
       hasError: false,
-      message: '오류 정보 없음',
-      stack: '스택 정보 없음',
+      message: defaultMessage,
+      stack: defaultStack,
     };
   }
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     // Update state so the next render will show the fallback UI.
-    const message = error.message;
-    const stack = error.stack ? error.stack : '스택 정보 없음';
+    const message = error.message === '' ? defaultMessage : error.message;
+    const stack = error.stack === undefined ? defaultStack : error.stack;
     return { hasError: true, message: message, stack: stack };
   }
 

--- a/src/components/ErrorBoundary/ErrorBoundaryWrapper.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundaryWrapper.tsx
@@ -1,0 +1,10 @@
+import { Outlet } from 'react-router-dom';
+import ErrorBoundary from './ErrorBoundary';
+
+export default function ErrorBoundaryWrapper() {
+  return (
+    <ErrorBoundary>
+      <Outlet />
+    </ErrorBoundary>
+  );
+}

--- a/src/components/ErrorBoundary/ErrorPage.tsx
+++ b/src/components/ErrorBoundary/ErrorPage.tsx
@@ -1,0 +1,40 @@
+import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
+
+interface ErrorPageProps {
+  message: string;
+  stack: string;
+}
+
+export default function ErrorPage({ message, stack }: ErrorPageProps) {
+  return (
+    <DefaultLayout>
+      <DefaultLayout.Header>
+        <DefaultLayout.Header.Left>
+          <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
+            <h1 className="mr-2">오류 발생</h1>
+          </div>
+        </DefaultLayout.Header.Left>
+      </DefaultLayout.Header>
+
+      <DefaultLayout.ContentContanier>
+        <div className="flex w-full flex-col justify-start px-8 py-20">
+          <div className="mb-20 flex flex-col">
+            <h1 className="text-4xl font-bold md:text-5xl">
+              오류가 발생했어요... 😭
+            </h1>
+          </div>
+
+          <div className="mb-10 flex flex-col space-y-2">
+            <h1 className="text-xl font-bold">오류 내용</h1>
+            <p className="text-lg">{message}</p>
+          </div>
+
+          <div className="mb-10 flex flex-col space-y-2">
+            <h1 className="text-xl font-bold">스택</h1>
+            <p className="text-lg">{stack}</p>
+          </div>
+        </div>
+      </DefaultLayout.ContentContanier>
+    </DefaultLayout>
+  );
+}

--- a/src/components/ErrorBoundary/ErrorPage.tsx
+++ b/src/components/ErrorBoundary/ErrorPage.tsx
@@ -41,7 +41,7 @@ export default function ErrorPage({ message, stack }: ErrorPageProps) {
             onClick={() => window.location.reload()}
           >
             <div className="flex flex-row items-center justify-center space-x-4">
-              <IoRefresh className="size-[30px]" />
+              <IoRefresh size={30} />
               <h1 className="mt-0.5 text-2xl font-bold">다시 시도해보기</h1>
             </div>
           </button>

--- a/src/components/ErrorBoundary/ErrorPage.tsx
+++ b/src/components/ErrorBoundary/ErrorPage.tsx
@@ -1,3 +1,4 @@
+import { IoRefresh } from 'react-icons/io5';
 import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
 
 interface ErrorPageProps {
@@ -17,7 +18,7 @@ export default function ErrorPage({ message, stack }: ErrorPageProps) {
       </DefaultLayout.Header>
 
       <DefaultLayout.ContentContanier>
-        <div className="flex w-full flex-col justify-start px-8 py-20">
+        <div className="flex w-full flex-col items-start justify-start px-8 py-20">
           <div className="mb-20 flex flex-col">
             <h1 className="text-4xl font-bold md:text-5xl">
               오류가 발생했어요... 😭
@@ -29,10 +30,21 @@ export default function ErrorPage({ message, stack }: ErrorPageProps) {
             <p className="text-lg">{message}</p>
           </div>
 
-          <div className="mb-10 flex flex-col space-y-2">
+          <div className="mb-20 flex flex-col space-y-2">
             <h1 className="text-xl font-bold">스택</h1>
             <p className="text-lg">{stack}</p>
           </div>
+
+          <button
+            className="rounded-full bg-zinc-300 px-8 py-4 hover:bg-zinc-400"
+            type="button"
+            onClick={() => window.location.reload()}
+          >
+            <div className="flex flex-row items-center justify-center space-x-4">
+              <IoRefresh className="size-[30px]" />
+              <h1 className="mt-0.5 text-2xl font-bold">다시 시도해보기</h1>
+            </div>
+          </button>
         </div>
       </DefaultLayout.ContentContanier>
     </DefaultLayout>

--- a/src/index.css
+++ b/src/index.css
@@ -7,6 +7,11 @@
     @apply font-pretendard;
   }
 }
+
+p {
+  white-space: pre-wrap;
+}
+
 .gradient-timer-running {
   background-image: linear-gradient(270deg, #21c494, #21bdc4, #21c45d);
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -40,7 +40,16 @@ if (import.meta.env.VITE_MOCK_API === 'true') {
 // Function that initializes main React app
 function initializeApp() {
   // Call queryClient for TanStack Query
-  const queryClient = new QueryClient();
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        throwOnError: true,
+      },
+      mutations: {
+        throwOnError: true,
+      },
+    },
+  });
 
   createRoot(document.getElementById('root')!).render(
     <StrictMode>

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -4,7 +4,6 @@ import TimerComponent from './components/TimerComponent';
 import { useQuery } from '@tanstack/react-query';
 import { getParliamentaryTableData, queryKeyIdentifier } from '../../apis/apis';
 import DebateInfoSummary from './components/DebateInfoSummary';
-import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary';
 
 export default function TimerPage() {
   // Load sounds
@@ -21,7 +20,7 @@ export default function TimerPage() {
   ];
 
   // Get query
-  const { data, isLoading, isError } = useQuery({
+  const { data, isLoading } = useQuery({
     queryKey: queryKey,
     queryFn: () => getParliamentaryTableData(tableId, memberId),
   });
@@ -166,94 +165,88 @@ export default function TimerPage() {
     );
   }
 
-  if (isError || data === null) {
-    throw new Error('Failed to get data from server.');
-  }
-
   // console.log(`# index = ${index}, data = ` + data!.table[index].time);
   // console.log(`# isRunning = ${isRunning}`);
 
   // Return React component
   return (
-    <ErrorBoundary>
-      <DefaultLayout>
-        <DefaultLayout.Header>
-          <DefaultLayout.Header.Left>
-            <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
-              <h1 className="mr-2">
-                {data === undefined
-                  ? '테이블 이름 불러오기 실패'
-                  : data!.info.name}
-              </h1>
-              <div className="mx-3 h-6 w-[2px] bg-black"></div>
-              <span className="text-lg font-normal md:text-xl">의회식</span>
+    <DefaultLayout>
+      <DefaultLayout.Header>
+        <DefaultLayout.Header.Left>
+          <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
+            <h1 className="mr-2">
+              {data === undefined
+                ? '테이블 이름 불러오기 실패'
+                : data!.info.name}
+            </h1>
+            <div className="mx-3 h-6 w-[2px] bg-black"></div>
+            <span className="text-lg font-normal md:text-xl">의회식</span>
+          </div>
+        </DefaultLayout.Header.Left>
+        <DefaultLayout.Header.Right>
+          <div className="flex flex-row items-center space-x-3 md:w-auto md:gap-3">
+            <h1 className="text-lg md:text-xl">토론 주제</h1>
+            <h1 className="text-xl font-bold md:w-auto md:text-2xl">
+              {data === undefined ? '주제 불러오기 실패' : data!.info.agenda}
+            </h1>
+          </div>
+        </DefaultLayout.Header.Right>
+      </DefaultLayout.Header>
+
+      <DefaultLayout.ContentContanier>
+        <audio ref={dingOnceRef} src="/sounds/ding-once-edit.mp3" />
+        <audio ref={dingTwiceRef} src="/sounds/ding-twice-edit.mp3" />
+
+        <div className="relative z-10 h-full">
+          <div className="flex h-full flex-row items-center space-x-4">
+            <div className="flex-1">
+              {index !== 0 && (
+                <DebateInfoSummary
+                  isPrev={true}
+                  moveToOtherItem={(isPrev: boolean) => {
+                    moveToOtherItem(isPrev);
+                  }}
+                  debateInfo={data!.table[index - 1]}
+                />
+              )}
+              {index === 0 && <div className="m-8 w-[240px]"></div>}
             </div>
-          </DefaultLayout.Header.Left>
-          <DefaultLayout.Header.Right>
-            <div className="flex flex-row items-center space-x-3 md:w-auto md:gap-3">
-              <h1 className="text-lg md:text-xl">토론 주제</h1>
-              <h1 className="text-xl font-bold md:w-auto md:text-2xl">
-                {data === undefined ? '주제 불러오기 실패' : data!.info.agenda}
-              </h1>
-            </div>
-          </DefaultLayout.Header.Right>
-        </DefaultLayout.Header>
 
-        <DefaultLayout.ContentContanier>
-          <audio ref={dingOnceRef} src="/sounds/ding-once-edit.mp3" />
-          <audio ref={dingTwiceRef} src="/sounds/ding-twice-edit.mp3" />
+            <TimerComponent
+              debateInfo={data!.table[index]}
+              timer={timer}
+              startTimer={() => {
+                startTimer();
+              }}
+              pauseTimer={() => {
+                pauseTimer();
+              }}
+              resetTimer={() => {
+                resetTimer();
+              }}
+            />
 
-          <div className="relative z-10 h-full">
-            <div className="flex h-full flex-row items-center space-x-4">
-              <div className="flex-1">
-                {index !== 0 && (
-                  <DebateInfoSummary
-                    isPrev={true}
-                    moveToOtherItem={(isPrev: boolean) => {
-                      moveToOtherItem(isPrev);
-                    }}
-                    debateInfo={data!.table[index - 1]}
-                  />
-                )}
-                {index === 0 && <div className="m-8 w-[240px]"></div>}
-              </div>
-
-              <TimerComponent
-                debateInfo={data!.table[index]}
-                timer={timer}
-                startTimer={() => {
-                  startTimer();
-                }}
-                pauseTimer={() => {
-                  pauseTimer();
-                }}
-                resetTimer={() => {
-                  resetTimer();
-                }}
-              />
-
-              <div className="flex-1">
-                {index !== data!.table.length - 1 && (
-                  <DebateInfoSummary
-                    isPrev={false}
-                    moveToOtherItem={(isPrev: boolean) => {
-                      moveToOtherItem(isPrev);
-                    }}
-                    debateInfo={data!.table[index + 1]}
-                  />
-                )}
-                {index === data!.table.length - 1 && (
-                  <div className="m-8 w-[240px]"></div>
-                )}
-              </div>
+            <div className="flex-1">
+              {index !== data!.table.length - 1 && (
+                <DebateInfoSummary
+                  isPrev={false}
+                  moveToOtherItem={(isPrev: boolean) => {
+                    moveToOtherItem(isPrev);
+                  }}
+                  debateInfo={data!.table[index + 1]}
+                />
+              )}
+              {index === data!.table.length - 1 && (
+                <div className="m-8 w-[240px]"></div>
+              )}
             </div>
           </div>
+        </div>
 
-          <div
-            className={`absolute inset-0 top-[80px] z-0 animate-gradient opacity-80 ${bg}`}
-          ></div>
-        </DefaultLayout.ContentContanier>
-      </DefaultLayout>
-    </ErrorBoundary>
+        <div
+          className={`absolute inset-0 top-[80px] z-0 animate-gradient opacity-80 ${bg}`}
+        ></div>
+      </DefaultLayout.ContentContanier>
+    </DefaultLayout>
   );
 }

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -3,8 +3,8 @@ import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
 import TimerComponent from './components/TimerComponent';
 import { useQuery } from '@tanstack/react-query';
 import { getParliamentaryTableData, queryKeyIdentifier } from '../../apis/apis';
-import { RiErrorWarningLine } from 'react-icons/ri';
 import DebateInfoSummary from './components/DebateInfoSummary';
+import ErrorBoundary from '../../components/ErrorBoundary/ErrorBoundary';
 
 export default function TimerPage() {
   // Load sounds
@@ -167,14 +167,7 @@ export default function TimerPage() {
   }
 
   if (isError || data === null) {
-    return (
-      <div className="flex h-full w-full flex-col items-center justify-center space-y-5">
-        <RiErrorWarningLine className="size-[120px]" />
-        <h1 className="text-xl font-bold">
-          데이터를 불러오는 중 오류가 발생했어요.
-        </h1>
-      </div>
-    );
+    throw new Error('Failed to get data from server.');
   }
 
   // console.log(`# index = ${index}, data = ` + data!.table[index].time);
@@ -182,83 +175,85 @@ export default function TimerPage() {
 
   // Return React component
   return (
-    <DefaultLayout>
-      <DefaultLayout.Header>
-        <DefaultLayout.Header.Left>
-          <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
-            <h1 className="mr-2">
-              {data === undefined
-                ? '테이블 이름 불러오기 실패'
-                : data!.info.name}
-            </h1>
-            <div className="mx-3 h-6 w-[2px] bg-black"></div>
-            <span className="text-lg font-normal md:text-xl">의회식</span>
-          </div>
-        </DefaultLayout.Header.Left>
-        <DefaultLayout.Header.Right>
-          <div className="flex flex-row items-center space-x-3 md:w-auto md:gap-3">
-            <h1 className="text-lg md:text-xl">토론 주제</h1>
-            <h1 className="text-xl font-bold md:w-auto md:text-2xl">
-              {data === undefined ? '주제 불러오기 실패' : data!.info.agenda}
-            </h1>
-          </div>
-        </DefaultLayout.Header.Right>
-      </DefaultLayout.Header>
-
-      <DefaultLayout.ContentContanier>
-        <audio ref={dingOnceRef} src="/sounds/ding-once-edit.mp3" />
-        <audio ref={dingTwiceRef} src="/sounds/ding-twice-edit.mp3" />
-
-        <div className="relative z-10 h-full">
-          <div className="flex h-full flex-row items-center space-x-4">
-            <div className="flex-1">
-              {index !== 0 && (
-                <DebateInfoSummary
-                  isPrev={true}
-                  moveToOtherItem={(isPrev: boolean) => {
-                    moveToOtherItem(isPrev);
-                  }}
-                  debateInfo={data!.table[index - 1]}
-                />
-              )}
-              {index === 0 && <div className="m-8 w-[240px]"></div>}
+    <ErrorBoundary>
+      <DefaultLayout>
+        <DefaultLayout.Header>
+          <DefaultLayout.Header.Left>
+            <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
+              <h1 className="mr-2">
+                {data === undefined
+                  ? '테이블 이름 불러오기 실패'
+                  : data!.info.name}
+              </h1>
+              <div className="mx-3 h-6 w-[2px] bg-black"></div>
+              <span className="text-lg font-normal md:text-xl">의회식</span>
             </div>
+          </DefaultLayout.Header.Left>
+          <DefaultLayout.Header.Right>
+            <div className="flex flex-row items-center space-x-3 md:w-auto md:gap-3">
+              <h1 className="text-lg md:text-xl">토론 주제</h1>
+              <h1 className="text-xl font-bold md:w-auto md:text-2xl">
+                {data === undefined ? '주제 불러오기 실패' : data!.info.agenda}
+              </h1>
+            </div>
+          </DefaultLayout.Header.Right>
+        </DefaultLayout.Header>
 
-            <TimerComponent
-              debateInfo={data!.table[index]}
-              timer={timer}
-              startTimer={() => {
-                startTimer();
-              }}
-              pauseTimer={() => {
-                pauseTimer();
-              }}
-              resetTimer={() => {
-                resetTimer();
-              }}
-            />
+        <DefaultLayout.ContentContanier>
+          <audio ref={dingOnceRef} src="/sounds/ding-once-edit.mp3" />
+          <audio ref={dingTwiceRef} src="/sounds/ding-twice-edit.mp3" />
 
-            <div className="flex-1">
-              {index !== data!.table.length - 1 && (
-                <DebateInfoSummary
-                  isPrev={false}
-                  moveToOtherItem={(isPrev: boolean) => {
-                    moveToOtherItem(isPrev);
-                  }}
-                  debateInfo={data!.table[index + 1]}
-                />
-              )}
-              {index === data!.table.length - 1 && (
-                <div className="m-8 w-[240px]"></div>
-              )}
+          <div className="relative z-10 h-full">
+            <div className="flex h-full flex-row items-center space-x-4">
+              <div className="flex-1">
+                {index !== 0 && (
+                  <DebateInfoSummary
+                    isPrev={true}
+                    moveToOtherItem={(isPrev: boolean) => {
+                      moveToOtherItem(isPrev);
+                    }}
+                    debateInfo={data!.table[index - 1]}
+                  />
+                )}
+                {index === 0 && <div className="m-8 w-[240px]"></div>}
+              </div>
+
+              <TimerComponent
+                debateInfo={data!.table[index]}
+                timer={timer}
+                startTimer={() => {
+                  startTimer();
+                }}
+                pauseTimer={() => {
+                  pauseTimer();
+                }}
+                resetTimer={() => {
+                  resetTimer();
+                }}
+              />
+
+              <div className="flex-1">
+                {index !== data!.table.length - 1 && (
+                  <DebateInfoSummary
+                    isPrev={false}
+                    moveToOtherItem={(isPrev: boolean) => {
+                      moveToOtherItem(isPrev);
+                    }}
+                    debateInfo={data!.table[index + 1]}
+                  />
+                )}
+                {index === data!.table.length - 1 && (
+                  <div className="m-8 w-[240px]"></div>
+                )}
+              </div>
             </div>
           </div>
-        </div>
 
-        <div
-          className={`absolute inset-0 top-[80px] z-0 animate-gradient opacity-80 ${bg}`}
-        ></div>
-      </DefaultLayout.ContentContanier>
-    </DefaultLayout>
+          <div
+            className={`absolute inset-0 top-[80px] z-0 animate-gradient opacity-80 ${bg}`}
+          ></div>
+        </DefaultLayout.ContentContanier>
+      </DefaultLayout>
+    </ErrorBoundary>
   );
 }

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -4,6 +4,7 @@ import TableListPage from './page/TableListPage/TableListPage';
 import TableOverview from './page/TableOverviewPage/TableOverview';
 import TimerPage from './page/TimerPage/TimerPage';
 import TableSetup from './page/TableSetupPage/TableSetup';
+import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
 
 const router = createBrowserRouter([
   {
@@ -24,7 +25,11 @@ const router = createBrowserRouter([
   },
   {
     path: '/table/parliamentary/:id',
-    element: <TimerPage />,
+    element: (
+      <ErrorBoundary>
+        <TimerPage />
+      </ErrorBoundary>
+    ),
   },
 ]);
 

--- a/src/route.tsx
+++ b/src/route.tsx
@@ -4,32 +4,33 @@ import TableListPage from './page/TableListPage/TableListPage';
 import TableOverview from './page/TableOverviewPage/TableOverview';
 import TimerPage from './page/TimerPage/TimerPage';
 import TableSetup from './page/TableSetupPage/TableSetup';
-import ErrorBoundary from './components/ErrorBoundary/ErrorBoundary';
+import ErrorBoundaryWrapper from './components/ErrorBoundary/ErrorBoundaryWrapper';
 
 const router = createBrowserRouter([
   {
-    path: '/',
-    element: <TableSetup />,
-  },
-  {
-    path: '/login',
-    element: <LoginPage />,
-  },
-  {
-    path: '/table',
-    element: <TableListPage />,
-  },
-  {
-    path: '/overview/:id',
-    element: <TableOverview />,
-  },
-  {
-    path: '/table/parliamentary/:id',
-    element: (
-      <ErrorBoundary>
-        <TimerPage />
-      </ErrorBoundary>
-    ),
+    element: <ErrorBoundaryWrapper />,
+    children: [
+      {
+        path: '/',
+        element: <TableSetup />,
+      },
+      {
+        path: '/login',
+        element: <LoginPage />,
+      },
+      {
+        path: '/table',
+        element: <TableListPage />,
+      },
+      {
+        path: '/overview/:id',
+        element: <TableOverview />,
+      },
+      {
+        path: '/table/parliamentary/:id',
+        element: <TimerPage />,
+      },
+    ],
   },
 ]);
 


### PR DESCRIPTION
## 🚩 연관 이슈
closed #64 

## 📝 작업 내용
### 개요
- `ErrorBoundary` 도입
- BE와의 협의 사항에 따라 `ErrorResponseType` 수정

### 파일 변경 내역
- /src/components/ErrorBoundary/ErrorPage.tsx
  예외 발생 시 출력되는 UI
- /src/components/ErrorBoundary/ErrorBoundary.tsx
  예외 발생을 탐지하고 이를 핸들링하는 클래스

### 사용 방법
1. 예외가 발생할 수 있는 컴포넌트의 ***가능한 바로 상단***에서 해당 컴포넌트를 아래와 같이 감싼다:
```tsx
export function PossibleErrorComponent() {
  return (
    <ErrorBoundary>
      {/* 컴포넌트 코드 */}
    </ErrorBoundary>
  )
}
```

2. 의도하지 않은 동작이 발생하는 경우, 아래 코드와 같이 `throw`를 사용하여 예외를 던진다. 여기서 `Error`의 매개변수로 들어가는 `string` 매개변수는 ErrorBoundary에서 `error.message`로 접근할 수 있다.
```tsx
// TimerPage.tsx
if (isError || data === null) {
  throw new Error('Failed to get data from server.');
}

// ErrorBoundary.tsx
class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
  // 생략
  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
    const message = error.message; // 이런 식으로 오류 메시지를 긁어올 수 있다
    // 생략
  }
  // 생략
}
```

3. 예외가 발생하면 예외 메시지는 `message` 변수에, 런타임 스택은 `stack` 변수에 저장된다:
```tsx
// ErrorBoundary.tsx

interface ErrorBoundaryState {
  hasError: boolean;
  message: string;
  stack: string;
}
```

### 어느 지점에서 사용해야 하는가?
이 주제가 이견의 소지가 가장 많을 것 같은 부분이라서, 읽어보실 수 있게 GitHub Copilot의 답변을 첨부합니다 (파파고 번역본):

일반적으로 모든 구성 요소를 `ErrorBoundary`로 감쌀 필요는 없습니다. 대신 가장 좋은 방법은 `ErrorBoundary` 구성 요소가 가장 큰 가치를 제공할 수 있는 곳에 전략적으로 배치하는 것입니다. 다음은 몇 가지 지침입니다:

**루트 구성 요소 감싸기**

- 장점: 이렇게 하면 애플리케이션에서 발생하는 모든 오류가 감지되어 전체 앱이 충돌하는 것을 방지하고 폴백 UI를 표시할 수 있습니다.
- 단점: 오류 발생 시 폴백 UI가 표시되며, 이는 최상의 사용자 경험을 제공하지 못할 수 있습니다. 앱의 어느 부분이 실패했는지 명확하지 않을 수 있습니다.

**특정 하위 트리 또는 구성 요소 감싸기**

- 장점: 이를 통해 보다 구체적이고 사용자 친화적인 오류 처리를 제공할 수 있습니다. 예를 들어, 앱의 각 섹션에 대해 서로 다른 폴백 UI를 표시하여 오류가 발생한 위치를 더 명확하게 파악할 수 있습니다.
- 단점: 애플리케이션의 중요한 부분을 식별하고 포장하는 데 더 많은 노력이 필요합니다.

**모범 사례**
- 중요 섹션: 애플리케이션의 기능에 중요한 주요 섹션이나 구성 요소를 감쌀 수 있습니다. 예를 들어, 주요 레이아웃 구성 요소나 API에서 데이터를 가져오는 모든 구성 요소를 감쌀 수 있습니다.
- 재사용 가능한 구성 요소: 데이터 문제로 인해 실패할 수 있는 목록이나 표와 같이 애플리케이션의 여러 부분에서 사용되는 구성 요소를 감쌀 수 있습니다.
타사 구성 요소: 제어하지 않고 오류가 발생할 수 있는 타사 라이브러리의 구성 요소를 랩합니다.

다만, 어떤 이유에서인지 /src/main.tsx에서 전역적으로 `ErrorBoundary`를 적용하면 제대로 작동하지 않는 문제가 식별되었습니다. 또한 개인적인 의견으로는, "오류 경계"라는 구성 요소의 이름에 걸맞게 오류가 발생할 여지가 있는 부분의 경계선에서만 선택적으로 감싸는 것이 더 적절하지 않을까 생각합니다.

## 🏞️ 스크린샷 (선택)
### 치코님 리뷰 반영하여 새로고침 버튼을 추가한 스크린샷
![스크린샷_16-1-2025_205057_localhost](https://github.com/user-attachments/assets/dbd18092-fab3-4e41-8174-14a711c832dd)

## 🗣️ 리뷰 요구사항 (선택)
- 별도 없습니다.