### PR TITLE
[HOTFIX] GitHub Actions 빌드 실패 문제 해결

### DIFF
--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -36,7 +36,7 @@ const useTableFrom = (
     },
   );
   const isNewMoimCreation =
-    currentStep === '이름타입입력' && navigationType === 'PUSH';
+    currentStep === 'NameAndType' && navigationType === 'PUSH';
 
   if (isNewMoimCreation) {
     removeValue();
@@ -50,7 +50,7 @@ const useTableFrom = (
   }, [initData]);
 
   useEffect(() => {
-    if (currentStep === '타임박스입력' && navigationType === 'POP') {
+    if (currentStep === 'TimeBox' && navigationType === 'POP') {
       navigate('/table');
     }
   }, [currentStep, navigationType, navigate]);

--- a/src/page/TableListPage/components/Table/Table.stories.tsx
+++ b/src/page/TableListPage/components/Table/Table.stories.tsx
@@ -34,7 +34,7 @@ const CurrentRoute = () => {
 export const Default: Story = {
   args: {
     name: '테이블 1',
-    type: '의회식 토론',
+    type: 'PARLIAMENTARY',
     duration: 30,
   },
 };


### PR DESCRIPTION


## 🚩 연관 이슈
closed #72 

## 📝 작업 내용
### 개요
현재 GitHub Actions의 [Deploy-Production](https://github.com/debate-timer/debate-timer-fe/actions/workflows/deploy-production.yml) 시나리오가 계속 실패하는 오류가 있어, 문제와 관련된 파일을 수정하였습니다. 제 개인 로컬 환경에서의 빌드 및 Deploy-Production 시나리오를 [수동으로 실행](https://github.com/debate-timer/debate-timer-fe/actions/runs/12879212393) - 단, AWS 배포 직전에 수동으로 취소하여 배포가 실제로 진행되진 않음 - 하여 빌드가 잘 되는 것을 확인하고 PR을 올립니다.

### 관련 파일
**\src\page\TableComposition\hook\useTableFrom.tsx**
\src\page\TableComposition\TableComposition.tsx에서 정의된 TableCompositionStep 상수 값이 한글(타임박스입력 등)에서 영어(TimeBox)로 바뀌면서 발생한 오류 해결

**\src\page\TableListPage\components\Table\Table.stories.tsx**
\src\type.ts에서 정의된 Type 상수 값이 한글(의회식 토론 등)에서 영어(PARLIAMENTARY)로 바뀌면서 발생한 오류 해결

## 🏞️ 스크린샷 (선택)
![스크린샷 2025-01-21 120012](https://github.com/user-attachments/assets/efa44810-7ecb-4601-9a42-e2f26acb7648)

## 🗣️ 리뷰 요구사항 (선택)
- 치코(@jaeml06)님 작업과 관련된 사항으로 판단되어, 혹시 제가 잘못 수정한 부분이 있는지 확인해주시면 감사하겠습니다.
- 추가로 현재 GitHub Actions의 [CI 시나리오](https://github.com/debate-timer/debate-timer-fe/blob/develop/.github/workflows/CI.yml)에서는 린팅과 테스트만 진행하고 있습니다. 그러나 빌드는 dev, main 등 배포 브랜치에 병합이 발생할 때만 이루어지기 때문에, 빌드 관련 오류는 해당 시나리오에서 잡아낼 수 없는 상태로 인지됩니다. 따라서, ***CI 시 빌드 명령어를 추가하여 빌드 시 오류까지 잡아낼 수 있도록 하는 방안***을 제안해봅니다.