### PR TITLE
[FEAT] 추가 작전 시간 타이머 구현 외

### DIFF
--- a/.env.dev-mock
+++ b/.env.dev-mock
@@ -1,2 +1,0 @@
-VITE_MOCK_API=true
-VITE_API_BASE_URL=''

--- a/.env.dev-mock
+++ b/.env.dev-mock
@@ -1,1 +1,2 @@
 VITE_MOCK_API=true
+VITE_API_BASE_URL=''

--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,0 @@
-VITE_MOCK_API=false
-VITE_API_BASE_URL=''

--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,2 @@
 VITE_MOCK_API=false
+VITE_API_BASE_URL=''

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,4 @@ yarn-error.log*
 .eslintcache
 .idea
 
-
-
 *storybook.log

--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,8 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
+*.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -1,4 +1,8 @@
-import { makeUrl } from './primitives';
+// Function that makes URLs that is going to be used to call APIs
+function makeUrl(endpoint: string): string {
+  // return BASE_URL + endpoint;
+  return '/api' + endpoint;
+}
 
 // URL 테이블
 export const ApiUrl = {

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -3,11 +3,11 @@ import { AxiosResponse, AxiosError } from 'axios';
 import { ErrorResponseType } from './responseTypes';
 
 // Base URL
-const BASE_URL = 'http://example.debatetimer.com/api';
+const BASE_URL = 'http://api.dev.debate-timer.com';
 
 // Singleton Axios instance
 const axiosInstance = axios.create({
-  baseURL: BASE_URL,
+  // baseURL: BASE_URL,
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
@@ -19,7 +19,8 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
 // Function that makes URLs that is going to be used to call APIs
 export function makeUrl(endpoint: string): string {
-  return BASE_URL + endpoint;
+  // return BASE_URL + endpoint;
+  return '/api' + endpoint;
 }
 
 // Low-level http request function

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -3,7 +3,7 @@ import { AxiosResponse, AxiosError } from 'axios';
 import { ErrorResponseType } from './responseTypes';
 
 // Base URL
-const BASE_URL = 'http://api.dev.debate-timer.com';
+// const BASE_URL = 'http://api.dev.debate-timer.com';
 
 // Singleton Axios instance
 const axiosInstance = axios.create({

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -46,7 +46,7 @@ export async function request<T>(
       const axiosError = error as AxiosError<ErrorResponseType>;
       console.error('Error message:', axiosError.message);
       if (axiosError.response) {
-        console.error('Error response data:', axiosError.response.data);
+        console.error('Error response data:', axiosError.response.data.message);
       }
     } else {
       console.error('Unexpected error:', error);

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -2,12 +2,8 @@ import axios from 'axios';
 import { AxiosResponse, AxiosError } from 'axios';
 import { ErrorResponseType } from './responseTypes';
 
-// Base URL
-// const BASE_URL = 'http://api.dev.debate-timer.com';
-
 // Singleton Axios instance
 const axiosInstance = axios.create({
-  // baseURL: BASE_URL,
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',
@@ -17,12 +13,6 @@ const axiosInstance = axios.create({
 // HTTP request methods
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
 
-// Function that makes URLs that is going to be used to call APIs
-export function makeUrl(endpoint: string): string {
-  // return BASE_URL + endpoint;
-  return '/api' + endpoint;
-}
-
 // Low-level http request function
 export async function request<T>(
   method: HttpMethod,
@@ -30,6 +20,8 @@ export async function request<T>(
   data: object | null,
   params: object | null,
 ): Promise<AxiosResponse<T>> {
+  // console.log(`# endpoint = ${endpoint}`);
+
   try {
     // Get response
     const response: AxiosResponse<T> = await axiosInstance({

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -23,7 +23,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
       stack: defaultStack,
     };
   }
-  
+
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     // Update state so the next render will show the fallback UI.
     const message = error.message === '' ? defaultMessage : error.message;

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,5 +1,7 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import ErrorPage from './ErrorPage';
+import { AxiosError } from 'axios';
+import { ErrorResponseType } from '../../apis/responseTypes';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -26,8 +28,14 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
   static getDerivedStateFromError(error: Error): ErrorBoundaryState {
     // Update state so the next render will show the fallback UI.
-    const message = error.message === '' ? defaultMessage : error.message;
     const stack = error.stack === undefined ? defaultStack : error.stack;
+    let message: string;
+
+    if (error instanceof AxiosError && error.response) {
+      message = (error.response.data as ErrorResponseType).message;
+    } else {
+      message = error.message;
+    }
     return { hasError: true, message: message, stack: stack };
   }
 

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -51,7 +51,7 @@ export function useModal(options: UseModalOptions = {}) {
           className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
           onClick={handleOverlayClick}
         >
-          <div className="relative w-2/3 rounded-lg bg-white shadow-lg">
+          <div className="relative rounded-lg bg-white shadow-lg">
             {children}
             <button
               type="button"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import router from './route';
 import './index.css';
 
+// console.log(`# URL = ${import.meta.env.VITE_API_BASE_URL}`);
+
 // Functions that calls msw mocking worker
 if (import.meta.env.VITE_MOCK_API === 'true') {
   console.log('[msw] Mocking enabled.');

--- a/src/page/TableComposition/components/DeleteConfirmContent/DeleteConfirmContent.tsx
+++ b/src/page/TableComposition/components/DeleteConfirmContent/DeleteConfirmContent.tsx
@@ -12,7 +12,7 @@ export default function DeleteConfirmContent({
     onClose();
   };
   return (
-    <div className="p-10">
+    <div className="px-12 py-8">
       <h2 className={`mb-4 text-xl font-bold`}>
         타임 박스를 삭제하시겠습니까?
       </h2>

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -22,6 +22,7 @@ export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
     ModalWrapper: DeleteModalWrapper,
   } = useModal();
   const { info, onSubmitEdit, onSubmitDelete } = props;
+
   return (
     <>
       <div className="flex justify-end gap-2">

--- a/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
@@ -30,7 +30,7 @@ export default function DeleteModalButton({
         <AiOutlineDelete />
       </button>
       <ModalWrapper>
-        <div className="flex flex-col items-center gap-6 py-8">
+        <div className="flex flex-col items-center gap-6 px-12 py-8">
           <h1 className="text-xl font-bold">삭제하시겠습니까?</h1>
           <h2 className="text-lg font-semibold">테이블명: {name}</h2>
           <button

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
-import TimerComponent from './components/TimerComponent';
+import TimerComponent from './components/Timer/TimerComponent';
 import DebateInfoSummary from './components/DebateInfoSummary';
 import { useParams, useSearchParams } from 'react-router-dom';
 import TimerLoadingPage from './TimerLoadingPage';
 import { useGetParliamentaryTableData } from '../../hooks/query/useGetParliamentaryTableData';
+import { useModal } from '../../hooks/useModal';
+import AdditionalTimerComponent from './components/AdditionalTimer/AdditionalTimerComponent';
 
 export default function TimerPage() {
   // Load sounds
@@ -27,6 +29,9 @@ export default function TimerPage() {
   } else if (memberId === null) {
     throw new Error("Failed to resolve 'memberId' from request URL");
   }
+
+  // Prepare for modal
+  const { isOpen, openModal, ModalWrapper } = useModal();
 
   // Get query
   const { data, isLoading } = useGetParliamentaryTableData(
@@ -109,6 +114,10 @@ export default function TimerPage() {
         event.target.blur();
       }
 
+      if (isOpen) {
+        return;
+      }
+
       switch (event.code) {
         case 'Space':
           if (intervalRef.current) {
@@ -142,7 +151,7 @@ export default function TimerPage() {
       // Remove listener when component is rendered
       window.removeEventListener('keydown', handleKeyDown);
     };
-  }, [pauseTimer, startTimer, timer, moveToOtherItem, resetTimer]);
+  }, [pauseTimer, startTimer, timer, moveToOtherItem, resetTimer, isOpen]);
 
   // Let timer play sounds when only 30 seconds left or timeout
   useEffect(() => {
@@ -170,86 +179,105 @@ export default function TimerPage() {
 
   // Return React component
   return (
-    <DefaultLayout>
-      <DefaultLayout.Header>
-        <DefaultLayout.Header.Left>
-          <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
-            <h1 className="mr-2">
-              {data === undefined
-                ? '테이블 이름 불러오기 실패'
-                : data!.info.name}
-            </h1>
-            <div className="mx-3 h-6 w-[2px] bg-black"></div>
-            <span className="text-lg font-normal md:text-xl">의회식</span>
-          </div>
-        </DefaultLayout.Header.Left>
-        <DefaultLayout.Header.Right>
-          <div className="flex flex-row items-center space-x-3 md:w-auto md:gap-3">
-            <h1 className="text-lg md:text-xl">토론 주제</h1>
-            <h1 className="text-xl font-bold md:w-auto md:text-2xl">
-              {data === undefined ? '주제 불러오기 실패' : data!.info.agenda}
-            </h1>
-          </div>
-        </DefaultLayout.Header.Right>
-      </DefaultLayout.Header>
+    <>
+      <audio ref={dingOnceRef} src="/sounds/ding-once-edit.mp3" />
+      <audio ref={dingTwiceRef} src="/sounds/ding-twice-edit.mp3" />
 
-      <DefaultLayout.ContentContanier>
-        <audio ref={dingOnceRef} src="/sounds/ding-once-edit.mp3" />
-        <audio ref={dingTwiceRef} src="/sounds/ding-twice-edit.mp3" />
-
-        <div className="relative z-10 h-full">
-          <div className="flex h-full flex-row items-center space-x-4">
-            <div className="flex-1">
-              {index !== 0 && (
-                <DebateInfoSummary
-                  isPrev={true}
-                  moveToOtherItem={(isPrev: boolean) => {
-                    moveToOtherItem(isPrev);
-                  }}
-                  debateInfo={data!.table[index - 1]}
-                />
-              )}
-              {index === 0 && <div className="m-8 w-[240px]"></div>}
+      <DefaultLayout>
+        <DefaultLayout.Header>
+          <DefaultLayout.Header.Left>
+            <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
+              <h1 className="mr-2">
+                {data === undefined
+                  ? '테이블 이름 불러오기 실패'
+                  : data!.info.name}
+              </h1>
+              <div className="mx-3 h-6 w-[2px] bg-black"></div>
+              <span className="text-lg font-normal md:text-xl">의회식</span>
             </div>
-
-            <TimerComponent
-              debateInfo={data!.table[index]}
-              timer={timer}
-              startTimer={() => {
-                startTimer();
-                changeBg(intervalRef.current, timer);
-              }}
-              pauseTimer={() => {
-                pauseTimer();
-                changeBg(intervalRef.current, timer);
-              }}
-              resetTimer={() => {
-                resetTimer();
-                changeBg(intervalRef.current, timer);
-              }}
-            />
-
-            <div className="flex-1">
-              {index !== data!.table.length - 1 && (
-                <DebateInfoSummary
-                  isPrev={false}
-                  moveToOtherItem={(isPrev: boolean) => {
-                    moveToOtherItem(isPrev);
-                  }}
-                  debateInfo={data!.table[index + 1]}
-                />
-              )}
-              {index === data!.table.length - 1 && (
-                <div className="m-8 w-[240px]"></div>
-              )}
+          </DefaultLayout.Header.Left>
+          <DefaultLayout.Header.Right>
+            <div className="flex flex-row items-center space-x-3 md:w-auto md:gap-3">
+              <h1 className="text-lg md:text-xl">토론 주제</h1>
+              <h1 className="text-xl font-bold md:w-auto md:text-2xl">
+                {data === undefined ? '주제 불러오기 실패' : data!.info.agenda}
+              </h1>
             </div>
-          </div>
-        </div>
+          </DefaultLayout.Header.Right>
+        </DefaultLayout.Header>
 
-        <div
-          className={`absolute inset-0 top-[80px] z-0 animate-gradient opacity-80 ${bg}`}
-        ></div>
-      </DefaultLayout.ContentContanier>
-    </DefaultLayout>
+        <DefaultLayout.ContentContanier>
+          {!isOpen && (
+            <div className="relative z-10 h-full">
+              <div className="flex h-full flex-row items-center space-x-4">
+                <div className="flex-1">
+                  {index !== 0 && (
+                    <DebateInfoSummary
+                      isPrev={true}
+                      moveToOtherItem={(isPrev: boolean) => {
+                        moveToOtherItem(isPrev);
+                      }}
+                      debateInfo={data!.table[index - 1]}
+                    />
+                  )}
+                  {index === 0 && <div className="m-8 w-[240px]"></div>}
+                </div>
+
+                <TimerComponent
+                  debateInfo={data!.table[index]}
+                  timer={timer}
+                  onOpenModal={() => openModal()}
+                  startTimer={() => {
+                    startTimer();
+                    changeBg(intervalRef.current, timer);
+                  }}
+                  pauseTimer={() => {
+                    pauseTimer();
+                    changeBg(intervalRef.current, timer);
+                  }}
+                  resetTimer={() => {
+                    resetTimer();
+                    changeBg(intervalRef.current, timer);
+                  }}
+                />
+
+                <div className="flex-1">
+                  {index !== data!.table.length - 1 && (
+                    <DebateInfoSummary
+                      isPrev={false}
+                      moveToOtherItem={(isPrev: boolean) => {
+                        moveToOtherItem(isPrev);
+                      }}
+                      debateInfo={data!.table[index + 1]}
+                    />
+                  )}
+                  {index === data!.table.length - 1 && (
+                    <div className="m-8 w-[240px]"></div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div
+            className={`absolute inset-0 top-[80px] z-0 animate-gradient opacity-80 ${bg}`}
+          ></div>
+        </DefaultLayout.ContentContanier>
+      </DefaultLayout>
+
+      <ModalWrapper>
+        <AdditionalTimerComponent
+          prevItem={
+            data !== null && index > 0 ? data!.table[index - 1] : undefined
+          }
+          currItem={data!.table[index]}
+          nextItem={
+            data !== null && index < data!.table.length - 1
+              ? data!.table[index + 1]
+              : undefined
+          }
+        />
+      </ModalWrapper>
+    </>
   );
 }

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
@@ -1,0 +1,75 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import TimerDisplay from '../common/TimerDisplay';
+import AdditionalTimerController from './AdditionalTimerController';
+import AdditionalTimerSummary from './AdditionalTimerSummary';
+import { DebateInfo } from '../../../../type/type';
+
+interface AdditionalTimerComponentProps {
+  prevItem?: DebateInfo;
+  currItem: DebateInfo;
+  nextItem?: DebateInfo;
+}
+
+export default function AdditionalTimerComponent({
+  prevItem,
+  currItem,
+  nextItem,
+}: AdditionalTimerComponentProps) {
+  // Load sounds
+  const dingOnceRef = useRef<HTMLAudioElement>(null);
+  const dingTwiceRef = useRef<HTMLAudioElement>(null);
+
+  const [timer, setTimer] = useState<number>(0);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  const startTimer = useCallback(() => {
+    if (!intervalRef.current) {
+      intervalRef.current = setInterval(() => {
+        setTimer((prev) => prev - 1);
+      }, 1000);
+    }
+  }, []);
+
+  const pauseTimer = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // Let timer play sounds when only 30 seconds left or timeout
+  useEffect(() => {
+    if (dingOnceRef.current && timer === 30 && intervalRef.current) {
+      dingOnceRef.current.play();
+    } else if (timer === 0 && intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+      if (dingTwiceRef.current) dingTwiceRef.current.play();
+    }
+  }, [timer]);
+
+  return (
+    <div className="flex flex-col items-center space-y-12 px-12 pb-8">
+      <audio ref={dingOnceRef} src="/sounds/ding-once-edit.mp3" />
+      <audio ref={dingTwiceRef} src="/sounds/ding-twice-edit.mp3" />
+
+      <h1 className="text-4xl font-bold">추가 작전 시간 타이머</h1>
+
+      <TimerDisplay timer={timer} />
+      <AdditionalTimerController
+        addOnTimer={(value: number) =>
+          setTimer((prev: number) => (prev + value > 0 ? prev + value : 0))
+        }
+        onPause={() => pauseTimer()}
+        onStart={() => {
+          if (timer > 0) startTimer();
+        }}
+      />
+      <AdditionalTimerSummary
+        prevItem={prevItem}
+        currItem={currItem}
+        nextItem={nextItem}
+      />
+    </div>
+  );
+}

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerController.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerController.tsx
@@ -1,0 +1,56 @@
+import { IoPauseOutline, IoPlayOutline } from 'react-icons/io5';
+import TimerIconButton from '../common/TimerIconButton';
+import TimerTextButton from '../common/TimerTextButton';
+
+interface AdditionalTimerControllerProps {
+  onPause: () => void;
+  onStart: () => void;
+  addOnTimer: (value: number) => void;
+}
+
+const iconSize = 40;
+
+export default function AdditionalTimerController({
+  onPause,
+  onStart,
+  addOnTimer,
+}: AdditionalTimerControllerProps) {
+  return (
+    <div className="flex flex-col items-center space-y-4">
+      <div className="flex flex-row items-center space-x-8">
+        {/* Timer start button */}
+        <TimerIconButton
+          icon={<IoPlayOutline size={iconSize} />}
+          style={{
+            bgColor: 'bg-emerald-500',
+            hoverColor: 'hover:bg-emerald-600',
+            contentColor: 'text-zinc-50',
+          }}
+          onClick={() => {
+            onStart();
+          }}
+        />
+
+        {/* Timer pause button */}
+        <TimerIconButton
+          icon={<IoPauseOutline size={iconSize} />}
+          style={{
+            bgColor: 'bg-amber-500',
+            hoverColor: 'hover:bg-amber-600',
+            contentColor: 'text-zinc-50',
+          }}
+          onClick={() => {
+            onPause();
+          }}
+        />
+      </div>
+
+      <div className="flex flex-row items-center space-x-4">
+        <TimerTextButton name={'- 1분'} onClick={() => addOnTimer(-60)} />
+        <TimerTextButton name={'- 30초'} onClick={() => addOnTimer(-30)} />
+        <TimerTextButton name={'+ 30초'} onClick={() => addOnTimer(30)} />
+        <TimerTextButton name={'+ 1분'} onClick={() => addOnTimer(60)} />
+      </div>
+    </div>
+  );
+}

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummary.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummary.tsx
@@ -1,0 +1,52 @@
+import { DebateInfo } from '../../../../type/type';
+import AdditionalTimerSummaryItem from './AdditionalTimerSummaryItem';
+
+type SummaryItemType = 'PREV' | 'CURR' | 'NEXT';
+
+const SummaryItemTypeToString: Record<SummaryItemType, string> = {
+  PREV: '이전 순서',
+  CURR: '현재 순서',
+  NEXT: '다음 순서',
+};
+
+interface AdditionalTimerSummaryProps {
+  prevItem?: DebateInfo;
+  currItem: DebateInfo;
+  nextItem?: DebateInfo;
+}
+
+export default function AdditionalTimerSummary({
+  prevItem,
+  currItem,
+  nextItem,
+}: AdditionalTimerSummaryProps) {
+  return (
+    <div className="flex h-full flex-row items-start space-x-4">
+      <div className="mt-4 flex flex-1 flex-col items-center space-y-2">
+        {/* Text that displays item's sequence */}
+        <h1 className="font-bold ">{SummaryItemTypeToString['PREV']}</h1>
+
+        {prevItem !== undefined && (
+          <AdditionalTimerSummaryItem item={prevItem} />
+        )}
+        {prevItem === undefined && <div className="w-[150px]"></div>}
+      </div>
+
+      <div className="flex flex-1 flex-col items-center space-y-2">
+        {/* Text that displays item's sequence */}
+        <h1 className="font-bold ">{SummaryItemTypeToString['CURR']}</h1>
+        <AdditionalTimerSummaryItem item={currItem} />
+      </div>
+
+      <div className="mt-4 flex flex-1 flex-col items-center space-y-2">
+        {/* Text that displays item's sequence */}
+        <h1 className="font-bold ">{SummaryItemTypeToString['NEXT']}</h1>
+
+        {nextItem !== undefined && (
+          <AdditionalTimerSummaryItem item={nextItem} />
+        )}
+        {nextItem === undefined && <div className="w-[150px]"></div>}
+      </div>
+    </div>
+  );
+}

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummary.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummary.tsx
@@ -22,7 +22,7 @@ export default function AdditionalTimerSummary({
 }: AdditionalTimerSummaryProps) {
   return (
     <div className="flex h-full flex-row items-start space-x-4">
-      <div className="mt-4 flex flex-1 flex-col items-center space-y-2">
+      <div className="flex flex-1 flex-col items-center space-y-2">
         {/* Text that displays item's sequence */}
         <h1 className="font-bold ">{SummaryItemTypeToString['PREV']}</h1>
 
@@ -38,7 +38,7 @@ export default function AdditionalTimerSummary({
         <AdditionalTimerSummaryItem item={currItem} />
       </div>
 
-      <div className="mt-4 flex flex-1 flex-col items-center space-y-2">
+      <div className="flex flex-1 flex-col items-center space-y-2">
         {/* Text that displays item's sequence */}
         <h1 className="font-bold ">{SummaryItemTypeToString['NEXT']}</h1>
 

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummaryItem.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummaryItem.tsx
@@ -1,0 +1,51 @@
+import { IoTimeOutline } from 'react-icons/io5';
+import {
+  DebateInfo,
+  DebateTypeToString,
+  StanceToString,
+} from '../../../../type/type';
+
+interface AdditionalTimerSummaryItemProps {
+  item: DebateInfo;
+}
+
+export default function AdditionalTimerSummaryItem({
+  item,
+}: AdditionalTimerSummaryItemProps) {
+  const titleText =
+    item.type !== 'TIME_OUT'
+      ? `${StanceToString[item.stance]} ${DebateTypeToString[item.type]}`
+      : DebateTypeToString[item.type];
+  const bgColor =
+    item.stance === 'NEUTRAL'
+      ? 'bg-zinc-500'
+      : item.stance === 'PROS'
+        ? 'bg-blue-500'
+        : 'bg-red-500';
+  let timeText: string;
+
+  if (item.time < 60) {
+    timeText = `${item.time % 60}초`;
+  } else {
+    if (item.time % 60 === 0) {
+      timeText = `${Math.floor(item.time / 60)}분`;
+    } else {
+      timeText = `${Math.floor(item.time / 60)}분 ${item.time % 60}초`;
+    }
+  }
+
+  return (
+    <div
+      className={`flex w-[150px] flex-col items-center rounded-2xl ${bgColor} px-6 py-3`}
+    >
+      {/* Stance and sequence (e.g., Pros final) */}
+      <h1 className="text-lg font-bold text-zinc-50">{titleText}</h1>
+
+      {/* Time */}
+      <div className="flex flex-row items-center justify-center space-x-2">
+        <IoTimeOutline size={15} className="text-zinc-50" />
+        <h1 className="text-m text-zinc-50">{timeText}</h1>
+      </div>
+    </div>
+  );
+}

--- a/src/page/TimerPage/components/Timer/TimerComponent.tsx
+++ b/src/page/TimerPage/components/Timer/TimerComponent.tsx
@@ -2,9 +2,9 @@ import {
   DebateInfo,
   DebateTypeToString,
   StanceToString,
-} from '../../../type/type';
-import Timer from './Timer/Timer';
-import TimerController from './Timer/TimerController';
+} from '../../../../type/type';
+import TimerDisplay from '../common/TimerDisplay';
+import TimerController from './TimerController';
 import { IoPerson } from 'react-icons/io5';
 
 interface TimerComponentProps {
@@ -13,6 +13,7 @@ interface TimerComponentProps {
   startTimer: () => void;
   pauseTimer: () => void;
   resetTimer: () => void;
+  onOpenModal: () => void;
 }
 
 // Main timer component that user can control
@@ -22,6 +23,7 @@ export default function TimerComponent({
   startTimer,
   pauseTimer,
   resetTimer,
+  onOpenModal,
 }: TimerComponentProps) {
   // Set texts to be displayed
   const titleText =
@@ -57,13 +59,14 @@ export default function TimerComponent({
         </div>
 
         {/* Timer */}
-        <Timer timer={timer} />
+        <TimerDisplay timer={timer} />
 
         {/* Timer controller that includes buttons that can handle timer */}
         <TimerController
           onReset={resetTimer}
           onStart={startTimer}
           onPause={pauseTimer}
+          onOpenModal={onOpenModal}
         />
       </div>
     </div>

--- a/src/page/TimerPage/components/Timer/TimerController.tsx
+++ b/src/page/TimerPage/components/Timer/TimerController.tsx
@@ -5,6 +5,7 @@ interface TimerControllerProps {
   onPause: () => void;
   onStart: () => void;
   onReset: () => void;
+  onOpenModal: () => void;
 }
 
 const iconSize = 40;
@@ -13,6 +14,7 @@ export default function TimerController({
   onPause,
   onStart,
   onReset,
+  onOpenModal,
 }: TimerControllerProps) {
   return (
     <div className="flex flex-row items-center space-x-8">
@@ -54,6 +56,17 @@ export default function TimerController({
           onReset();
         }}
       />
+
+      {/*Additional discussion time button*/}
+      <button
+        className="rounded-full border-2 border-zinc-50 bg-zinc-200 px-8 py-4 hover:bg-zinc-300"
+        onClick={() => {
+          console.log('# Additional discussion time button clicked');
+          onOpenModal();
+        }}
+      >
+        <h1 className="text-2xl font-bold">추가 작전 시간</h1>
+      </button>
     </div>
   );
 }

--- a/src/page/TimerPage/components/common/TimerDisplay.tsx
+++ b/src/page/TimerPage/components/common/TimerDisplay.tsx
@@ -3,9 +3,9 @@ import { Formatting } from '../../../../util/formatting';
 interface TimerProps {
   timer: number;
 }
-export default function Timer({ timer }: TimerProps) {
+export default function TimerDisplay({ timer }: TimerProps) {
   return (
-    <div className="mb-12 flex flex-row items-center justify-center space-x-4 rounded-[50px] bg-zinc-50 p-8">
+    <div className="mb-12 flex flex-row items-center justify-center space-x-4 rounded-[50px] bg-zinc-100 p-8">
       {/* Prints -(minus) if remaining time is negative */}
       {timer < 0 && <h1 className="py-2 text-9xl font-bold">-</h1>}
 

--- a/src/page/TimerPage/components/common/TimerTextButton.tsx
+++ b/src/page/TimerPage/components/common/TimerTextButton.tsx
@@ -10,7 +10,7 @@ export default function TimerTextButton({
   return (
     <button
       onClick={onClick}
-      className="w-[160px] rounded-2xl bg-zinc-50 px-6 py-3 text-2xl font-bold text-zinc-900 hover:bg-zinc-400"
+      className="rounded-full bg-zinc-200 px-6 py-2 text-lg font-bold text-zinc-900 hover:bg-zinc-400"
     >
       {name}
     </button>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,18 +1,22 @@
-import { defineConfig as defineViteConfig, mergeConfig } from 'vite';
+import { defineConfig as defineViteConfig, loadEnv, mergeConfig } from 'vite';
 import { defineConfig as defineVitestConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
-const viteConfig = defineViteConfig({
-  plugins: [react()],
-  server: {
-    proxy: {
-      '/api': {
-        target: 'https://api.dev.debate-timer.com',
-        changeOrigin: true,
-        ws: true,
+const viteConfig = defineViteConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': {
+          target: env.VITE_API_BASE_URL,
+          changeOrigin: true,
+          ws: true,
+        },
       },
     },
-  },
+  };
 });
 
 const vitestConfig = defineVitestConfig({
@@ -23,4 +27,6 @@ const vitestConfig = defineVitestConfig({
   },
 });
 
-export default mergeConfig(viteConfig, vitestConfig);
+export default defineViteConfig((configEnv) => {
+  return mergeConfig(viteConfig(configEnv), vitestConfig);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,6 +11,7 @@ const viteConfig = defineViteConfig(({ mode }) => {
       proxy: {
         '/api': {
           target: env.VITE_API_BASE_URL,
+          rewrite: (path: string) => path.replace(/^\/api/, ''),
           changeOrigin: true,
           ws: true,
         },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,15 @@ import react from '@vitejs/plugin-react';
 
 const viteConfig = defineViteConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': {
+        target: 'https://api.dev.debate-timer.com',
+        changeOrigin: true,
+        ws: true,
+      },
+    },
+  },
 });
 
 const vitestConfig = defineVitestConfig({


### PR DESCRIPTION
## 🚩 연관 이슈
closed #74 

## 📝 작업 내용
### 개요
**추가 작전 시간 타이머 관련**
- 추가 작전 시간 타이머 구현
- `useModal` 훅에 기본 지정되어 있던 TailwindCSS 너비 제거 및 이에 영향을 받는 모든 모달 컴포넌트의 모양 수정

**API 관련**
- API 요청을 위한 기본 URL을 'https://api.dev.debate-timer.com' 으로 변경
- API 요청 시 CORS 오류가 발생하지 않도록 API 요청 관련 소스 코드 및 Vite 프로젝트 설정 수정

### 추가 작전 시간 타이머 특징
- 추가 작전 시간 타이머는 타이머 화면에서 '추가 작전 시간'이라고 적힌 버튼을 눌러 사용 가능
- 남은 시간에 따른 배경색 변경이 없음
- 30초에 1번, 0초에 2번 종이 울림
- 시작 버튼을 통해 타이머를 시작할 수 있고, 일시정지 버튼을 통해 타이머를 일시정지할 수 있음
- 30초 및 1분 단위로 사용자가 원하는 만큼 타이머 잔여 시간을 더하거나 뺄 수 있음 (단, 0 이하로 감소하지 않음)
- 타이머가 0초에 다다르면, 토론 타이머와는 다르게 음수로 내려가지 않으며 0에서 타이머가 정지함
- 추가 작전 시간 타이머를 호출한 순서를 기준으로, 이전 순서 / 현재 순서 / 다음 순서의 정보를 요약하여 화면 하단에 표시
- 추가 작전 시간 타이머를 열었을 때, 타이머 화면에서 사용 가능한 키보드 이벤트(스페이스, 화살표 등)는 비활성화되며, 오직 마우스로만 조작 가능

## 🏞️ 스크린샷 (선택)
### 추가 작전 시간 타이머 스크린샷
![스크린샷_22-1-2025_153220_localhost](https://github.com/user-attachments/assets/739d9dd6-e02d-49c1-b549-af3ac0e000e6)

## 🗣️ 리뷰 요구사항 (선택)
- @coli-geonwoo 의도하셨던 기능과 디자인이 잘 적용되어 있는지 의견 남겨주시면 감사하겠습니다!