### PR TITLE
[FIX, CHORE] mock에서 드래그앤 드롭 UI가 깨지는 문제 수정, Storybook 자동 배포 yml 작성

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,29 @@
+name: Deploy-storybook
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: ['develop']
+    types: ['closed']
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup .env
+        run: echo "${{secrets.DEVELOPMENT_ENV}}" > .env
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Deploy Storybook
+        run: npx chromatic --project-token="${{ secrets.CHROMATIC_PROJECT_TOKEN }}"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "preview": "vite preview",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "test": "vitest",
-    "chromatic": "npx chromatic --project-token=chpt_a6dc39eba6488b2"
+    "test": "vitest"
   },
   "dependencies": {
     "@tanstack/eslint-plugin-query": "^5.62.9",

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -63,7 +63,7 @@ export const handlers = [
         },
         {
           stance: 'NEUTRAL',
-          type: 'CROSS',
+          type: 'TIME_OUT',
           time: 32,
           speakerNumber: null,
         },

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -15,7 +15,6 @@ interface TimeBoxStepProps {
 }
 export default function TimeBoxStep(props: TimeBoxStepProps) {
   const { initTimeBox, onTimeBoxChange, onButtonClick } = props;
-  console.log(initTimeBox);
   const {
     openModal: ProsOpenModal,
     closeModal: ProsCloseModal,
@@ -77,9 +76,9 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
         <PropsAndConsTitle />
         <DragAndDropWrapper>
           {initTimeBox.map((info, index) => (
-            <div key={info.time} style={getDraggingStyles(index)}>
+            <div key={index + info.stance} style={getDraggingStyles(index)}>
               <DebatePanel
-                key={index}
+                key={index + info.stance}
                 info={info}
                 onSubmitEdit={(updatedInfo) =>
                   handleSubmitEdit(index, updatedInfo)


### PR DESCRIPTION
## 🚩 연관 이슈
closed #80

## 📝 작업 내용
1. mock에서 드래그앤 드롭이 다음과 같이 UI가 깨지는 문제가 있어서 로직의 문제인줄 알았으나 mock에서 type이 CROSS여서 해당 UI가 비어서 발생한 문제였습니다.

https://github.com/user-attachments/assets/7abc394f-6c25-4eaa-aa7b-e0623c190d74



여기서 궁금증이 현재는 중립 상태는 Time_Out일 경우에만 존재하게 작성했습니다. CROSS도 중립인 것인지 궁금합니다.

2. 지금까지는 storybook을 배포하기 위해서는 명령어를 직접 입력해야했으나 PR이 닫히면 자동으로 배포되도록 변경하였습니다.

