### PR TITLE
[HOTFIX] 배포된 앱이 서버와 통신하지 못하는 문제 수정

### DIFF
--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -4,6 +4,10 @@ import { ErrorResponseType } from './responseTypes';
 
 // Singleton Axios instance
 const axiosInstance = axios.create({
+  baseURL:
+    import.meta.env.MODE !== 'production'
+      ? undefined
+      : import.meta.env.VITE_API_BASE_URL,
   timeout: 10000,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
## 🚩 연관 이슈
- #83
- 이슈 완전히 해결 시 수동으로 닫을 예정

## 📝 작업 내용
### 문제의 원인
- Vite의 `development` 모드에서 우리는 vite.config.ts에서 정의된 프록시 정책을 통해 '/api/endpoint' 형태의 URL을 'https://서버.주소.어쩌구/api/endpoint' 형태로 변환하여 사용했었음 (자세한 설명은 [링크](https://github.com/debate-timer/debate-timer-fe/pull/77#issuecomment-2607009303) 참고)
- 그러나 해당 프록시 정책은 Vite의 `production` 모드에서 제대로 동작하지 않는다는 사실을 확인

### 해결책
```ts
// Singleton Axios instance
const axiosInstance = axios.create({
  baseURL:
    import.meta.env.MODE !== 'production'
      ? undefined
      : import.meta.env.VITE_API_BASE_URL,
  timeout: 10000,
  headers: {
    'Content-Type': 'application/json',
  },
});
```
- `production` 모드에서만 모든 통신의 기반이 되는 `AxiosInstance`에 `baseURL` 변수를 설정해주면 해결 가능

### 비고
- 일단 `npm run preview` 명령어를 통해 CORS 오류를 보았고, 적절한 URL에 요청이 이루어지고 있는 것은 확인함
- 다만 요청이 'https://서버.주소.어쩌구/api/api/endpoint' 형태로 이루어지고 있음
- 이 부분은 아마 /src/apis/endpoints.ts의 함수 `makeUrl`에 의해 1번, `DEPLOY_DEV` 및 `DEPLOY_PROD`의 환경 변수 `ENV`에서 맨 뒤에 붙은 '/api'로 인해 1번, 이상 2번 추가되었을 것으로 추정됨
- 그러나 현재 개발 환경에서는 /api 문자열을 프록시 정책으로 대체하는 방법으로 CORS 오류를 회피하고 있기 때문에, 함수 `makeUrl`은 그 용도가 분명하여 이 함수를 수정할 수 없어, 각 배포 환경에서의 환경 변수를 수정하는 쪽으로 대응함

## 🏞️ 스크린샷 (선택)
### `npm run preview` 상태에서 CORS 오류
![스크린샷 2025-01-23 233420](https://github.com/user-attachments/assets/b3123780-e6cc-4c92-af63-81fa12a0328d)

## 🗣️ 리뷰 요구사항 (선택)
- 별도 없음