### PR TITLE
[FIX] QA에서 식별한 버그 해결 - 숀

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9849,9 +9849,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.16",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.16.tgz",
-      "integrity": "sha512-TI4Cyx7gDiZ6r44ewaJmt0o6BrMCT5aK5e0rmJ/G9Xq3w7CX/5VXl/zIPEJZFUK5VEqwByyhqNPycPlvcK4ZNw==",
+      "version": "3.4.17",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
+      "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -4,8 +4,8 @@ function StickyTriSectionHeader(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <header className="sticky top-0 min-h-20 bg-slate-300 px-2">
-      <div className="relative flex h-full items-center justify-between gap-x-6">
+    <header className="sticky top-0 min-h-20 bg-slate-100 px-6">
+      <div className="relative flex h-full items-center justify-between">
         {children}
       </div>
     </header>
@@ -14,17 +14,17 @@ function StickyTriSectionHeader(props: PropsWithChildren) {
 
 StickyTriSectionHeader.Left = function Left(props: PropsWithChildren) {
   const { children } = props;
-  return <div>{children}</div>;
+  return <div className="flex-1 items-start text-start">{children}</div>;
 };
 
 StickyTriSectionHeader.Center = function Center(props: PropsWithChildren) {
   const { children } = props;
-  return <div>{children}</div>;
+  return <div className="flex-1 items-center text-center">{children}</div>;
 };
 
 StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
   const { children } = props;
-  return <div>{children}</div>;
+  return <div className="flex-1 items-end text-right">{children}</div>;
 };
 
 export default StickyTriSectionHeader;

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -4,7 +4,7 @@ function StickyTriSectionHeader(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <header className="sticky top-0 min-h-20 bg-slate-100 px-6">
+    <header className="sticky top-0 min-h-20 bg-slate-200 px-6">
       <div className="relative flex h-full items-center justify-between">
         {children}
       </div>

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -39,8 +39,8 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left></DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center>
-          <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
-            <h1 className="mr-2">어떤 토론을 원하시나요?</h1>
+          <div className="flex flex-wrap items-center justify-center px-2 text-2xl font-bold md:text-3xl">
+            <h1>어떤 토론을 원하시나요?</h1>
           </div>
         </DefaultLayout.Header.Center>
         <DefaultLayout.Header.Right></DefaultLayout.Header.Right>

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -57,13 +57,14 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
             <span className="text-lg font-normal md:text-xl">의회식</span>
           </div>
         </DefaultLayout.Header.Left>
-
         <DefaultLayout.Header.Right>
-          <div className="flex flex-wrap items-center gap-2 px-2 md:w-auto md:gap-3">
-            <span className="text-sm md:text-base">토론 주제</span>
+          <div className="flex flex-wrap items-center justify-end gap-2 p-2 md:gap-3">
+            <span className="flex basis-full items-start whitespace-nowrap text-sm md:basis-auto md:text-base">
+              토론 주제
+            </span>
             <input
               type="text"
-              className="w-full rounded-md bg-slate-100 p-2 text-base md:w-[30rem] md:text-2xl"
+              className="w-full rounded-md bg-slate-100 p-2 text-base md:flex-1 md:text-2xl"
               placeholder="주제를 입력해주세요"
             />
           </div>

--- a/src/page/TableListPage/TableListPage.test.tsx
+++ b/src/page/TableListPage/TableListPage.test.tsx
@@ -80,7 +80,7 @@ describe('TableListPage', () => {
     renderTableListPage();
     const headerLeft = screen.getByTestId('header-left');
     expect(headerLeft).toBeInTheDocument();
-    expect(headerLeft).toHaveTextContent('테이블 목록화면');
+    expect(headerLeft).toHaveTextContent('테이블 목록');
   });
 
   it('Table 렌더링 검증', async () => {

--- a/src/page/TableListPage/TableListPage.tsx
+++ b/src/page/TableListPage/TableListPage.tsx
@@ -14,7 +14,11 @@ export default function TableListPage() {
   return (
     <DefaultLayout>
       <DefaultLayout.Header>
-        <DefaultLayout.Header.Left>테이블 목록화면</DefaultLayout.Header.Left>
+        <DefaultLayout.Header.Left>
+          <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
+            <h1 className="mr-2">테이블 목록</h1>
+          </div>
+        </DefaultLayout.Header.Left>
       </DefaultLayout.Header>
       <div className="flex h-screen flex-col px-4 py-6">
         <main className="grid grid-cols-3 justify-items-center gap-6">

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -24,9 +24,11 @@ export default function TableOverview() {
         </DefaultLayout.Header.Left>
 
         <DefaultLayout.Header.Right>
-          <div className="flex flex-wrap items-center gap-2 px-2 md:w-auto md:gap-3">
-            <span className="text-sm md:text-base">토론 주제</span>
-            <span className="w-full rounded-md bg-slate-100 p-2 text-base md:w-[30rem] md:text-2xl">
+          <div className="flex flex-wrap items-center justify-end gap-2 p-2 md:gap-3">
+            <span className="flex basis-full items-start whitespace-nowrap text-sm md:basis-auto md:text-base">
+              토론 주제
+            </span>
+            <span className="flex w-full items-start rounded-md bg-slate-100 p-2 text-base md:flex-1 md:text-2xl">
               {data?.info.agenda}
             </span>
           </div>

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -4,6 +4,7 @@ import { useGetParliamentaryTableData } from '../../hooks/query/useGetParliament
 import { useNavigate, useParams } from 'react-router-dom';
 import DebatePanel from '../TableComposition/components/DebatePanel/DebatePanel';
 import { getMemberIdToken } from '../../util/memberIdToken';
+import { IoMdHome } from 'react-icons/io';
 
 export default function TableOverview() {
   const pathParams = useParams();
@@ -16,22 +17,38 @@ export default function TableOverview() {
     <DefaultLayout>
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
-          <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
-            <h1 className="mr-2">테이블 1</h1>
+          <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
+            <h1 className="mr-2">
+              {data === undefined || data!.info.name.trim() === ''
+                ? '테이블 이름 없음'
+                : data!.info.name}
+            </h1>
             <div className="mx-3 h-6 w-[2px] bg-black"></div>
             <span className="text-lg font-normal md:text-xl">의회식</span>
           </div>
         </DefaultLayout.Header.Left>
-
-        <DefaultLayout.Header.Right>
-          <div className="flex flex-wrap items-center justify-end gap-2 p-2 md:gap-3">
-            <span className="flex basis-full items-start whitespace-nowrap text-sm md:basis-auto md:text-base">
-              토론 주제
-            </span>
-            <span className="flex w-full items-start rounded-md bg-slate-100 p-2 text-base md:flex-1 md:text-2xl">
-              {data?.info.agenda}
-            </span>
+        <DefaultLayout.Header.Center>
+          <div className="flex flex-col items-center">
+            <h1 className="text-m md:text-lg">토론 주제</h1>
+            <h1 className="text-xl font-bold md:text-2xl">
+              {data === undefined || data!.info.agenda.trim() === ''
+                ? '주제 없음'
+                : data!.info.agenda}
+            </h1>
           </div>
+        </DefaultLayout.Header.Center>
+        <DefaultLayout.Header.Right>
+          <button
+            onClick={() => {
+              navigate('/');
+            }}
+            className="rounded-full bg-slate-300 px-6 py-2 text-lg font-bold text-zinc-900 hover:bg-zinc-400"
+          >
+            <div className="flex flex-row items-center space-x-4">
+              <IoMdHome size={24} />
+              <h1>홈 화면</h1>
+            </div>
+          </button>
         </DefaultLayout.Header.Right>
       </DefaultLayout.Header>
       <DefaultLayout.ContentContanier>

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -155,9 +155,9 @@ export default function TimerPage() {
 
   // Let timer play sounds when only 30 seconds left or timeout
   useEffect(() => {
-    if (dingOnceRef.current && timer === 30) {
+    if (dingOnceRef.current && timer === 30 && intervalRef) {
       dingOnceRef.current.play();
-    } else if (dingTwiceRef.current && timer === 0) {
+    } else if (dingTwiceRef.current && timer === 0 && intervalRef) {
       dingTwiceRef.current.play();
     }
   }, [timer]);
@@ -186,7 +186,7 @@ export default function TimerPage() {
       <DefaultLayout>
         <DefaultLayout.Header>
           <DefaultLayout.Header.Left>
-            <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
+            <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
               <h1 className="mr-2">
                 {data === undefined
                   ? '테이블 이름 불러오기 실패'
@@ -196,13 +196,21 @@ export default function TimerPage() {
               <span className="text-lg font-normal md:text-xl">의회식</span>
             </div>
           </DefaultLayout.Header.Left>
-          <DefaultLayout.Header.Right>
-            <div className="flex flex-row items-center space-x-3 md:w-auto md:gap-3">
-              <h1 className="text-lg md:text-xl">토론 주제</h1>
-              <h1 className="text-xl font-bold md:w-auto md:text-2xl">
+          <DefaultLayout.Header.Center>
+            <div className="flex flex-col items-center">
+              <h1 className="text-m md:text-lg">토론 주제</h1>
+              <h1 className="text-xl font-bold md:text-2xl">
                 {data === undefined ? '주제 불러오기 실패' : data!.info.agenda}
               </h1>
             </div>
+          </DefaultLayout.Header.Center>
+          <DefaultLayout.Header.Right>
+            <button
+              onClick={() => {}}
+              className="rounded-full bg-zinc-200 py-2 text-lg font-bold text-zinc-900 hover:bg-zinc-400"
+            >
+              <h1>홈 화면으로 </h1>
+            </button>
           </DefaultLayout.Header.Right>
         </DefaultLayout.Header>
 

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -2,16 +2,18 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
 import TimerComponent from './components/Timer/TimerComponent';
 import DebateInfoSummary from './components/DebateInfoSummary';
-import { useParams, useSearchParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import TimerLoadingPage from './TimerLoadingPage';
 import { useGetParliamentaryTableData } from '../../hooks/query/useGetParliamentaryTableData';
 import { useModal } from '../../hooks/useModal';
 import AdditionalTimerComponent from './components/AdditionalTimer/AdditionalTimerComponent';
+import { IoMdHome } from 'react-icons/io';
 
 export default function TimerPage() {
   // Load sounds
   const dingOnceRef = useRef<HTMLAudioElement>(null);
   const dingTwiceRef = useRef<HTMLAudioElement>(null);
+  const navigate = useNavigate();
 
   // Prepare data before requesting query
   const [searchParams] = useSearchParams();
@@ -153,11 +155,11 @@ export default function TimerPage() {
     };
   }, [pauseTimer, startTimer, timer, moveToOtherItem, resetTimer, isOpen]);
 
-  // Let timer play sounds when only 30 seconds left or timeout
+  // Let timer play sounds when o nly 30 seconds left or timeout
   useEffect(() => {
-    if (dingOnceRef.current && timer === 30 && intervalRef) {
+    if (dingOnceRef.current && timer === 30 && intervalRef.current) {
       dingOnceRef.current.play();
-    } else if (dingTwiceRef.current && timer === 0 && intervalRef) {
+    } else if (dingTwiceRef.current && timer === 0 && intervalRef.current) {
       dingTwiceRef.current.play();
     }
   }, [timer]);
@@ -206,10 +208,15 @@ export default function TimerPage() {
           </DefaultLayout.Header.Center>
           <DefaultLayout.Header.Right>
             <button
-              onClick={() => {}}
-              className="rounded-full bg-zinc-200 py-2 text-lg font-bold text-zinc-900 hover:bg-zinc-400"
+              onClick={() => {
+                navigate('/');
+              }}
+              className="rounded-full bg-slate-300 px-6 py-2 text-lg font-bold text-zinc-900 hover:bg-zinc-400"
             >
-              <h1>홈 화면으로 </h1>
+              <div className="flex flex-row items-center space-x-4">
+                <IoMdHome size={24} />
+                <h1>홈 화면</h1>
+              </div>
             </button>
           </DefaultLayout.Header.Right>
         </DefaultLayout.Header>

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -190,8 +190,8 @@ export default function TimerPage() {
           <DefaultLayout.Header.Left>
             <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
               <h1 className="mr-2">
-                {data === undefined
-                  ? '테이블 이름 불러오기 실패'
+                {data === undefined || data!.info.name.trim() === ''
+                  ? '테이블 이름 없음'
                   : data!.info.name}
               </h1>
               <div className="mx-3 h-6 w-[2px] bg-black"></div>
@@ -202,7 +202,9 @@ export default function TimerPage() {
             <div className="flex flex-col items-center">
               <h1 className="text-m md:text-lg">토론 주제</h1>
               <h1 className="text-xl font-bold md:text-2xl">
-                {data === undefined ? '주제 불러오기 실패' : data!.info.agenda}
+                {data === undefined || data!.info.agenda.trim() === ''
+                  ? '주제 없음'
+                  : data!.info.agenda}
               </h1>
             </div>
           </DefaultLayout.Header.Center>

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
@@ -21,12 +21,14 @@ export default function AdditionalTimerComponent({
 
   const [timer, setTimer] = useState<number>(0);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [isRunning, setRunning] = useState<boolean>(false);
 
   const startTimer = useCallback(() => {
     if (!intervalRef.current) {
       intervalRef.current = setInterval(() => {
         setTimer((prev) => prev - 1);
       }, 1000);
+      setRunning(true);
     }
   }, []);
 
@@ -34,6 +36,7 @@ export default function AdditionalTimerComponent({
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
+      setRunning(false);
     }
   }, []);
 
@@ -57,6 +60,7 @@ export default function AdditionalTimerComponent({
 
       <TimerDisplay timer={timer} />
       <AdditionalTimerController
+        isRunning={isRunning}
         addOnTimer={(value: number) =>
           setTimer((prev: number) => (prev + value > 0 ? prev + value : 0))
         }

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerController.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerController.tsx
@@ -3,6 +3,7 @@ import TimerIconButton from '../common/TimerIconButton';
 import TimerTextButton from '../common/TimerTextButton';
 
 interface AdditionalTimerControllerProps {
+  isRunning: boolean;
   onPause: () => void;
   onStart: () => void;
   addOnTimer: (value: number) => void;
@@ -11,6 +12,7 @@ interface AdditionalTimerControllerProps {
 const iconSize = 40;
 
 export default function AdditionalTimerController({
+  isRunning,
   onPause,
   onStart,
   addOnTimer,
@@ -18,31 +20,33 @@ export default function AdditionalTimerController({
   return (
     <div className="flex flex-col items-center space-y-4">
       <div className="flex flex-row items-center space-x-8">
-        {/* Timer start button */}
-        <TimerIconButton
-          icon={<IoPlayOutline size={iconSize} />}
-          style={{
-            bgColor: 'bg-emerald-500',
-            hoverColor: 'hover:bg-emerald-600',
-            contentColor: 'text-zinc-50',
-          }}
-          onClick={() => {
-            onStart();
-          }}
-        />
+        {isRunning && (
+          <TimerIconButton
+            icon={<IoPauseOutline size={iconSize} />}
+            style={{
+              bgColor: 'bg-amber-500',
+              hoverColor: 'hover:bg-amber-600',
+              contentColor: 'text-zinc-50',
+            }}
+            onClick={() => {
+              onPause();
+            }}
+          />
+        )}
 
-        {/* Timer pause button */}
-        <TimerIconButton
-          icon={<IoPauseOutline size={iconSize} />}
-          style={{
-            bgColor: 'bg-amber-500',
-            hoverColor: 'hover:bg-amber-600',
-            contentColor: 'text-zinc-50',
-          }}
-          onClick={() => {
-            onPause();
-          }}
-        />
+        {!isRunning && (
+          <TimerIconButton
+            icon={<IoPlayOutline size={iconSize} />}
+            style={{
+              bgColor: 'bg-emerald-500',
+              hoverColor: 'hover:bg-emerald-600',
+              contentColor: 'text-zinc-50',
+            }}
+            onClick={() => {
+              onStart();
+            }}
+          />
+        )}
       </div>
 
       <div className="flex flex-row items-center space-x-4">

--- a/src/page/TimerPage/components/common/TimerDisplay.tsx
+++ b/src/page/TimerPage/components/common/TimerDisplay.tsx
@@ -1,11 +1,16 @@
 import { Formatting } from '../../../../util/formatting';
 
 interface TimerProps {
+  bg?: string;
   timer: number;
 }
-export default function TimerDisplay({ timer }: TimerProps) {
+export default function TimerDisplay({ bg, timer }: TimerProps) {
+  const bgText = bg === undefined ? 'bg-zinc-100' : bg;
+
   return (
-    <div className="mb-12 flex flex-row items-center justify-center space-x-4 rounded-[50px] bg-zinc-100 p-8">
+    <div
+      className={`mb-12 flex flex-row items-center justify-center space-x-4 rounded-[50px] ${bgText} p-8`}
+    >
       {/* Prints -(minus) if remaining time is negative */}
       {timer < 0 && <h1 className="py-2 text-9xl font-bold">-</h1>}
 


### PR DESCRIPTION
## 🚩 연관 이슈
closed #89

## 📝 작업 내용
### 개요
- TimerPage에서 기존 헤더 오른쪽에 표시되던 주제를 헤더 가운데로 이동
- TimerPage 헤더에 테이블 조회 화면으로 돌아가는 버튼 추가
- TimerPage에서 타이머가 동작하지 않을 때 의도하지 않은 벨이 울리는 버그 수정
- TimerPage의 작전 시간 타이머에서 동작 중인 경우 일시정지 버튼, 정지 중인 경우 시작 버튼만 표시되도록 하여, 동작 여부에 대한 사용자의 시인성 개선
- TimerPage에서 주제를 불러오지 못했을 경우의 예외 처리 코드 보강
- 헤더의 각 하위 요소(`Right`, `Center`, `Left`)에 `flex-1` 태그를 추가하여 각자 동일한 너비를 분배받을 수 있도록 개선
- TableOverviewPage에서 헤더 왼쪽에 표시되는 페이지 이름의 시인성 개선

## 🏞️ 스크린샷 (선택)
### 수정된 `TimerPage`
![스크린샷_25-1-2025_164216_localhost](https://github.com/user-attachments/assets/6ee6b251-8641-4f19-a716-aaa8da9cafdb)

## 🗣️ 리뷰 요구사항 (선택)
별도 없음