### PR TITLE
[FIX] QA에서 식별한 버그 해결 - 엘

### DIFF
--- a/src/hooks/mutations/useDeleteParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/useDeleteParliamentaryDebateTable.ts
@@ -7,14 +7,20 @@ interface DeleteParliamentaryTableParams {
 }
 
 export function useDeleteParliamentaryDebateTable() {
-  return useMutation<boolean, Error, DeleteParliamentaryTableParams>({
-    mutationFn: ({ tableId, memberId }) =>
-      deleteParliamentaryDebateTable(tableId, memberId),
+  return useMutation({
+    mutationFn: async ({ tableId, memberId }: DeleteParliamentaryTableParams) =>
+      await deleteParliamentaryDebateTable(tableId, memberId),
+
     onSuccess: () => {
       alert('테이블이 제거되었습니다.');
+
+      // 삭제 성공 후 페이지 강제 새로고침
+      window.location.reload();
     },
+
     onError: (error) => {
       console.error('Error deleting parliamentary table:', error);
+      alert('테이블 삭제에 실패했습니다.');
     },
   });
 }

--- a/src/page/LoginPage/LoginPage.test.tsx
+++ b/src/page/LoginPage/LoginPage.test.tsx
@@ -33,11 +33,6 @@ describe('LoginPage', () => {
       </TestWrapper>,
     );
 
-    // 헤더 텍스트 확인
-    expect(screen.getByText('헤더')).toBeInTheDocument();
-    expect(screen.getByText('의회식')).toBeInTheDocument();
-    expect(screen.getByText('제목')).toBeInTheDocument();
-
     // 제목 텍스트 확인
     expect(screen.getByText('Debate Timer')).toBeInTheDocument();
 

--- a/src/page/LoginPage/LoginPage.tsx
+++ b/src/page/LoginPage/LoginPage.tsx
@@ -26,9 +26,11 @@ export default function LoginPage() {
   return (
     <DefaultLayout>
       <DefaultLayout.Header>
-        <DefaultLayout.Header.Left>헤더</DefaultLayout.Header.Left>
-        <DefaultLayout.Header.Center>의회식</DefaultLayout.Header.Center>
-        <DefaultLayout.Header.Right>제목</DefaultLayout.Header.Right>
+        <DefaultLayout.Header.Left>
+          <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
+            <h1 className="mr-2">로그인 페이지</h1>
+          </div>
+        </DefaultLayout.Header.Left>
       </DefaultLayout.Header>
       <div className="flex h-screen flex-col items-center justify-center">
         <div className="pb-48">

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -30,7 +30,9 @@ export default function Table({
       </div>
       <h1 className="text-3xl font-semibold lg:text-5xl">{name}</h1>
       <div className="flex w-full flex-grow flex-col items-start justify-center text-lg font-semibold lg:text-2xl">
-        <h1>유형 : {type}</h1>
+        <h1>
+          유형 : {type === 'PARLIAMENTARY' ? '의회식 토론' : '시간 총량제 토론'}
+        </h1>
         <h1>소요시간 : {duration}분</h1>
       </div>
     </button>

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { DebateTable } from '../../../../type/type';
 import EditButton from '../Modal/EditButton';
 import DeleteModalButton from '../Modal/DeleteModalButton';
+import { typeMapping } from '../../../../constants/languageMapping';
 
 interface DebateTableWithDelete extends DebateTable {
   onDelete: (name: string) => void;
@@ -30,9 +31,7 @@ export default function Table({
       </div>
       <h1 className="text-3xl font-semibold lg:text-5xl">{name}</h1>
       <div className="flex w-full flex-grow flex-col items-start justify-center text-lg font-semibold lg:text-2xl">
-        <h1>
-          유형 : {type === 'PARLIAMENTARY' ? '의회식 토론' : '시간 총량제 토론'}
-        </h1>
+        <h1>유형 : {typeMapping[type]}</h1>
         <h1>소요시간 : {duration}초</h1>
       </div>
     </button>

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -33,7 +33,7 @@ export default function Table({
         <h1>
           유형 : {type === 'PARLIAMENTARY' ? '의회식 토론' : '시간 총량제 토론'}
         </h1>
-        <h1>소요시간 : {duration}분</h1>
+        <h1>소요시간 : {duration}초</h1>
       </div>
     </button>
   );


### PR DESCRIPTION
## 🚩 연관 이슈
closed #90

## 📝 작업 내용
- TableList 화면에서 토론 유형이 영어(PARLIAMENTARY)로 표시되는 문제
- TableList 화면에서 토론 시간이 초가 아니라 분으로 표시되는 문제
- TableList 화면에서 테이블을 삭제한 후 화면이 다시 렌더링되지 않는 문제
- Login 화면에서 상단 바에 "헤더", "의회식", "제목"이라고 적힌 불필요한 텍스트가 표시되는 문제

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
- TableList 화면에서 테이블을 삭제한 후 화면이 다시 렌더링되지 않는 문제 해결하기 위해

```ts
import { useMutation } from '@tanstack/react-query';
import { deleteParliamentaryDebateTable } from '../../apis/apis';

interface DeleteParliamentaryTableParams {
  tableId: number;
  memberId: number;
}

export function useDeleteParliamentaryDebateTable() {
  return useMutation({
    mutationFn: async ({ tableId, memberId }: DeleteParliamentaryTableParams) =>
      await deleteParliamentaryDebateTable(tableId, memberId),

    onSuccess: () => {
      alert('테이블이 제거되었습니다.');

      // 삭제 성공 후 페이지 강제 새로고침
      window.location.reload();
    },

    onError: (error) => {
      console.error('Error deleting parliamentary table:', error);
      alert('테이블 삭제에 실패했습니다.');
    },
  });
}

```

에서
```ts
      // 삭제 성공 후 페이지 강제 새로고침
      window.location.reload();
``` 

이렇게 일단 해결하였지만 추후 더 효율적인 방법으로 해결해보겠습니다.
