### PR TITLE
[FEAT] invalidateQueries 사용하여 Table 삭제 시 즉시 업데이트 반영

### DIFF
--- a/src/hooks/mutations/useDeleteParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/useDeleteParliamentaryDebateTable.ts
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { deleteParliamentaryDebateTable } from '../../apis/apis';
 
 interface DeleteParliamentaryTableParams {
@@ -7,20 +7,16 @@ interface DeleteParliamentaryTableParams {
 }
 
 export function useDeleteParliamentaryDebateTable() {
-  return useMutation({
-    mutationFn: async ({ tableId, memberId }: DeleteParliamentaryTableParams) =>
-      await deleteParliamentaryDebateTable(tableId, memberId),
+  const queryClient = useQueryClient();
 
+  return useMutation<boolean, Error, DeleteParliamentaryTableParams>({
+    mutationFn: ({ tableId, memberId }) =>
+      deleteParliamentaryDebateTable(tableId, memberId),
     onSuccess: () => {
-      alert('테이블이 제거되었습니다.');
-
-      // 삭제 성공 후 페이지 강제 새로고침
-      window.location.reload();
+      queryClient.invalidateQueries({ queryKey: ['DebateTableList'] });
     },
-
     onError: (error) => {
       console.error('Error deleting parliamentary table:', error);
-      alert('테이블 삭제에 실패했습니다.');
     },
   });
 }

--- a/src/hooks/mutations/useDeleteParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/useDeleteParliamentaryDebateTable.ts
@@ -14,6 +14,10 @@ export function useDeleteParliamentaryDebateTable() {
       deleteParliamentaryDebateTable(tableId, memberId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['DebateTableList'] });
+
+      setTimeout(() => {
+        alert('테이블이 제거되었습니다.');
+      }, 300);
     },
     onError: (error) => {
       console.error('Error deleting parliamentary table:', error);


### PR DESCRIPTION
## 🚩 연관 이슈
closed #98 

## 📝 작업 내용

###  기존 코드
```ts
export function useDeleteParliamentaryDebateTable() {
  return useMutation({
    mutationFn: async ({ tableId, memberId }: DeleteParliamentaryTableParams) =>
      await deleteParliamentaryDebateTable(tableId, memberId),

    onSuccess: () => {
      alert('테이블이 제거되었습니다.');

      // 삭제 성공 후 페이지 강제 새로고침
      window.location.reload();
    },

    onError: (error) => {
      console.error('Error deleting parliamentary table:', error);
      alert('테이블 삭제에 실패했습니다.');
    },
  });
}
```

🚨 기존 코드 (window.location.reload())의 문제점
현재 코드에서는 테이블 삭제 후 전체 페이지를 강제로 새로고침 (window.location.reload()) 합니다.
이는 다음과 같은 문제점이 있습니다.

🔴 문제점
불필요한 전체 페이지 리로드

페이지 전체를 새로고침하면 불필요한 네트워크 요청이 발생하여 속도가 느려짐.
React Query의 캐싱 기능을 제대로 활용하지 못함.
기존 상태(state) 유지 불가

새로고침되면 **현재 보고 있던 상태(스크롤 위치, UI 상태 등)**가 모두 사라짐.
예를 들어 사용자가 특정 필터링을 하고 있었다면, 삭제 후 다시 처음 상태로 돌아감.
비효율적인 사용자 경험(UX)

새로고침 때문에 전체 화면이 깜빡임.
API 응답을 기다리는 동안 불필요한 로딩 화면이 다시 나타남.

***

## 해결책: invalidateQueries 사용

### invalidateQueries를 사용하여 Table를 삭제한 후 성공할 시 최신 데이터를 반영하도록 하였습니다.

-  queryKey: ['DebateTableList']  에 해당되는 query data를 무효화하여 최신 데이터 업데이트 하는 방식으로 구현하였습니다.
- 또한, setTimeout을 사용하여 먼저 UI를 갱신한 후 alert을 표시하여 사용자경험(UX)를 향상시켰습니다.

```ts
import { useMutation, useQueryClient } from '@tanstack/react-query';
import { deleteParliamentaryDebateTable } from '../../apis/apis';

interface DeleteParliamentaryTableParams {
  tableId: number;
  memberId: number;
}

export function useDeleteParliamentaryDebateTable() {
  const queryClient = useQueryClient();

  return useMutation<boolean, Error, DeleteParliamentaryTableParams>({
    mutationFn: ({ tableId, memberId }) =>
      deleteParliamentaryDebateTable(tableId, memberId),
    onSuccess: () => {
      queryClient.invalidateQueries({ queryKey: ['DebateTableList'] });

      setTimeout(() => {
        alert('테이블이 제거되었습니다.');
      }, 300);
    },
    onError: (error) => {
      console.error('Error deleting parliamentary table:', error);
    },
  });
}


```

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
- merge충돌이 있어서 먼저 해결하겠습니다. git merge conflict 해결하는 도중에 너무 꼬였어서 develop branch 최신 코드들을 가져와서 그 위에 새로 작성하였습니다.