### PR TITLE
[REFACTOR] 1차 UT에 있었던 1, 2순위 수정 사항 반영

### DIFF
--- a/src/hooks/useDragAndDrop.tsx
+++ b/src/hooks/useDragAndDrop.tsx
@@ -81,10 +81,6 @@ export function useDragAndDrop<T>({
         };
       }
     }
-
-    return {
-      transform: 'translateY(0)',
-    };
   };
 
   const DragAndDropWrapper = ({ children }: { children: ReactNode }) => {

--- a/src/layout/components/main/ContentContanier.tsx
+++ b/src/layout/components/main/ContentContanier.tsx
@@ -4,7 +4,7 @@ export default function ContentContanier(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <main className="flex flex-grow flex-col items-center gap-2 px-8 py-4">
+    <main className="relative flex flex-grow flex-col items-center gap-2 overflow-auto px-8 py-4">
       {children}
     </main>
   );

--- a/src/page/TableComposition/TableComposition.test.tsx
+++ b/src/page/TableComposition/TableComposition.test.tsx
@@ -70,10 +70,10 @@ describe('TableComposition', () => {
 
     expect(
       screen.findByRole('heading', {
-        name: '어떤 토론을 원하시나요?',
+        name: '토론 정보를 수정해주세요',
       }),
     );
-    const nameInput = await screen.findByPlaceholderText('시간표#1(디폴트 값)');
+    const nameInput = await screen.findByPlaceholderText('테이블 1(디폴트 값)');
 
     expect((nameInput as HTMLInputElement).value).toBe('테이블 1');
   });

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -78,8 +78,8 @@ export default function TableComposition() {
           ),
           TimeBox: (
             <TimeBoxStep
-              initAgenda={formData.info.agenda}
-              initTimeBox={formData.table}
+              initData={formData}
+              isEdit={mode === 'edit'}
               onAgendaChange={updateInfo}
               onTimeBoxChange={updateTable}
               onButtonClick={handleButtonClick}

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -2,7 +2,7 @@ import { HTMLAttributes } from 'react';
 import EditDeleteButtons from '../EditDeleteButtons/EditDeleteButtons';
 import { DebateInfo, DebateTypeToString } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
-
+import { LuArrowUpDown } from 'react-icons/lu';
 interface DebatePanelProps extends HTMLAttributes<HTMLDivElement> {
   info: DebateInfo;
   onSubmitEdit?: (updatedInfo: DebateInfo) => void;
@@ -27,6 +27,17 @@ export default function DebatePanel(props: DebatePanelProps) {
       ? 'justify-end'
       : 'justify-center';
 
+  const renderDragHandle = () => (
+    <div
+      className="left-0x absolute top-4 flex h-2/3 w-4 flex-1 cursor-grab items-center 
+                justify-center rounded-md bg-slate-100 "
+      onMouseDown={onMouseDown}
+      title="위아래로 드래그"
+    >
+      {/* 세로줄 아이콘을 중앙에 표시해줍니다 */}
+      <LuArrowUpDown className="text-gray-600" />
+    </div>
+  );
   const renderProsConsPanel = () => (
     <div
       className={`flex w-1/2 flex-col items-center rounded-md ${
@@ -36,11 +47,7 @@ export default function DebatePanel(props: DebatePanelProps) {
       {onSubmitEdit && onSubmitDelete && (
         <div className="flex h-4 w-full items-center gap-2">
           <div className="flex-1" />
-          <div
-            className="h-2 flex-1 rounded-sm bg-gray-300"
-            onMouseDown={onMouseDown}
-          />
-
+          {renderDragHandle()}
           <div className="flex-1">
             <EditDeleteButtons
               info={props.info}
@@ -63,10 +70,7 @@ export default function DebatePanel(props: DebatePanelProps) {
         {onSubmitEdit && onSubmitDelete && (
           <div className="flex h-4 w-full items-center gap-2">
             <div className="flex-1" />
-            <div
-              className="h-2 flex-1 rounded-sm bg-gray-300"
-              onMouseDown={onMouseDown}
-            />
+            {renderDragHandle()}
             <div className="flex-1">
               <EditDeleteButtons
                 info={props.info}

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -40,7 +40,7 @@ export default function DebatePanel(props: DebatePanelProps) {
   );
   const renderProsConsPanel = () => (
     <div
-      className={`flex w-1/2 flex-col items-center rounded-md ${
+      className={`relative flex w-1/2 flex-col items-center rounded-md ${
         isPros ? 'bg-blue-500' : 'bg-red-500'
       } h-24 select-none p-2 font-bold text-white`}
     >
@@ -65,7 +65,7 @@ export default function DebatePanel(props: DebatePanelProps) {
   );
 
   const renderNeutralTimeoutPanel = () => (
-    <div className="flex h-24 w-full select-none items-center text-center">
+    <div className="relative flex h-24 w-full select-none items-center text-center">
       <div className="flex h-4/5 w-full flex-col items-center justify-start rounded-md bg-gray-200 p-2 font-medium text-gray-600">
         {onSubmitEdit && onSubmitDelete && (
           <div className="flex h-4 w-full items-center gap-2">

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -40,7 +40,9 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
         <DefaultLayout.Header.Left></DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center>
           <div className="flex flex-wrap items-center justify-center px-2 text-2xl font-bold md:text-3xl">
-            <h1>어떤 토론을 원하시나요?</h1>
+            <h1>
+              {isEdit ? '토론 정보를 수정해주세요' : '어떤 토론을 원하시나요?'}
+            </h1>
           </div>
         </DefaultLayout.Header.Center>
         <DefaultLayout.Header.Right></DefaultLayout.Header.Right>
@@ -50,7 +52,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
           <div className="flex w-full items-center justify-between">
             <h3 className="text-md font-bold lg:text-5xl">토론 시간표 이름</h3>
             <input
-              placeholder="시간표#1(디폴트 값)"
+              placeholder="테이블 1(디폴트 값)"
               className="w-8/12 rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
               value={info.name}
               onChange={handleNameChange}
@@ -74,7 +76,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
           onClick={onButtonClick}
           className="h-20 w-full bg-amber-500 text-2xl font-semibold transition duration-300 hover:bg-amber-600"
         >
-          타임박스 만들기
+          {isEdit ? '타임박스 수정하기' : '타임박스 만들기'}
         </button>
       </DefaultLayout.StickyFooterWrapper>
     </DefaultLayout>

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -6,25 +6,27 @@ import { DebateInfo, Type } from '../../../../type/type';
 import { useDragAndDrop } from '../../../../hooks/useDragAndDrop';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import PropsAndConsTitle from '../../../../components/ProsAndConsTitle/PropsAndConsTitle';
+import { TableFormData } from '../../hook/useTableFrom';
 
 interface TimeBoxStepProps {
-  initAgenda: string;
-  initTimeBox: DebateInfo[];
+  initData: TableFormData;
   onTimeBoxChange: React.Dispatch<React.SetStateAction<DebateInfo[]>>;
   onButtonClick: () => void;
   onAgendaChange: React.Dispatch<
     React.SetStateAction<{ name: string; agenda: string; type: Type }>
   >;
+  isEdit?: boolean;
 }
 export default function TimeBoxStep(props: TimeBoxStepProps) {
   const {
-    initAgenda,
-    initTimeBox,
+    initData,
     onTimeBoxChange,
     onButtonClick,
     onAgendaChange,
+    isEdit = false,
   } = props;
-
+  const initAgenda = initData.info.agenda;
+  const initTimeBox = initData.table;
   const {
     openModal: ProsOpenModal,
     closeModal: ProsCloseModal,
@@ -64,7 +66,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
           <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
-            <h1 className="mr-2">테이블 1</h1>
+            <h1 className="mr-2">{initData.info.name}</h1>
             <div className="mx-3 h-6 w-[2px] bg-black"></div>
             <span className="text-lg font-normal md:text-xl">의회식</span>
           </div>
@@ -124,7 +126,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
           onClick={onButtonClick}
           disabled={!isAbledSummitButton}
         >
-          테이블 추가하기
+          {isEdit ? '테이블 수정하기' : '테이블 추가하기'}
         </button>
       </DefaultLayout.StickyFooterWrapper>
 


### PR DESCRIPTION
## 🚩 연관 이슈
closed #100

## 📝 작업 내용
- 테이블 수정과 생성의 플로우가 같아 뷰 상으로 유저가 생성과 수정과정을 구분할 수 있도록 반영
- 타임박스가 헤더를 침범하는 문제를 수정
- 드래그&드롭 기능을 사용자가 인지할 수 있도록 시인성 개선

### 테이블 수정과 생성의 플로우가 같아 뷰 상으로 유저가 생성과 수정과정을 구분할 수 있도록 반영
mode에 따라 TableComposition내의 버튼과 헤더 문구가 수정되도록 변경하였습니다.

기존 수정 시 화면
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/aba11864-ac52-4a76-a980-a103ac164f27" />
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/b2094fb1-3f63-4661-9b6a-6e18cce332ab" />

변경 후 수정 시, 화면 
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/ff581e3b-8c76-4392-a236-dfce42273fd4" />
<img width="1230" alt="image" src="https://github.com/user-attachments/assets/d19a34f0-7a05-4879-ab7e-fde41e6b36d3" />

헤더 문구를 -> 토론 정보를 수정해주세요 로 변경
버튼 문구를 -> 타임박스 수정하기, 테이블 수정하기 로 변경

### 타임박스가 헤더를 침범하는 문제를 수정
useDragAndDrop의 getDraggingStyles에서  transform: 'translateY(0)', 때문에 css 스택이 헤더 위로 올라가는 문제가 발생.
해당 css를 이용하지 않고 DefaultLayout의 ContentContanier에 overflow-auto를 사용하여 헤더를 침범하지않게 수정


### 드래그&드롭 기능을 사용자가 인지할 수 있도록 시인성 개선
기존 디자인
<img width="584" alt="image" src="https://github.com/user-attachments/assets/94f09993-9eb9-4680-b3f5-c501459dcb0e" />

수정후 디자인
<img width="584" alt="image" src="https://github.com/user-attachments/assets/3fd6f074-ed17-4c87-8d4e-020f6c76413c" />


## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
