### PR TITLE
[FEAT] 1차 UT에서 발생한 피드백 반영

### DIFF
--- a/src/hooks/useMobile.ts
+++ b/src/hooks/useMobile.ts
@@ -1,0 +1,18 @@
+import { useState, useEffect } from 'react';
+
+export default function useMobile() {
+  const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+
+  useEffect(() => {
+    const handleResize = () => {
+      setIsMobile(window.innerWidth < 768);
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return isMobile;
+}

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -9,6 +9,8 @@ import { useModal } from '../../hooks/useModal';
 import AdditionalTimerComponent from './components/AdditionalTimer/AdditionalTimerComponent';
 import { IoMdHome } from 'react-icons/io';
 import { useTimer } from './hooks/useTimer';
+import FirstUseToolTip from './components/common/FirstUseToolTip';
+import useMobile from '../../hooks/useMobile';
 
 export default function TimerPage() {
   // Load sounds
@@ -56,8 +58,10 @@ export default function TimerPage() {
   } = useTimer();
 
   // Declare states
-  const [index, setIndex] = useState<number>(0);
-  const [bg, setBg] = useState<string>('');
+  const [index, setIndex] = useState(0);
+  const [isFirst, setIsFirst] = useState(false);
+  const [bg, setBg] = useState('');
+  const isMobile = useMobile();
 
   // Declare function to manage parent component's index
   const moveToOtherItem = useCallback(
@@ -173,6 +177,13 @@ export default function TimerPage() {
     }
   }, [data, index, setDefaultValue, setTimer]);
 
+  useEffect(() => {
+    const storedIsFirst = localStorage.getItem('isFirst');
+    if (storedIsFirst) {
+      setIsFirst(storedIsFirst.trim() === 'true' ? true : false);
+    }
+  }, []);
+
   // Handle exceptions
   if (isLoading) {
     return <TimerLoadingPage />;
@@ -201,7 +212,7 @@ export default function TimerPage() {
             </div>
           </DefaultLayout.Header.Left>
           <DefaultLayout.Header.Center>
-            <div className="flex flex-col items-center">
+            <div className="my-2 flex flex-col items-center">
               <h1 className="text-m md:text-lg">토론 주제</h1>
               <h1 className="text-xl font-bold md:text-2xl">
                 {data === undefined || data!.info.agenda.trim() === ''
@@ -219,7 +230,7 @@ export default function TimerPage() {
             >
               <div className="flex flex-row items-center space-x-4">
                 <IoMdHome size={24} />
-                <h1>홈 화면</h1>
+                {!isMobile && <h1>홈 화면</h1>}
               </div>
             </button>
           </DefaultLayout.Header.Right>
@@ -228,7 +239,16 @@ export default function TimerPage() {
         <DefaultLayout.ContentContanier>
           {!isOpen && (
             <div className="relative z-10 h-full">
-              <div className="flex h-full flex-row items-center space-x-4">
+              {!isFirst && (
+                <FirstUseToolTip
+                  onClose={() => {
+                    setIsFirst(true);
+                    localStorage.setItem('isFirst', 'true');
+                  }}
+                />
+              )}
+
+              <div className="z-2 absolute inset-0 flex h-full flex-row items-center justify-center space-x-4">
                 <div className="flex-1">
                   {index !== 0 && (
                     <DebateInfoSummary

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -239,11 +239,11 @@ export default function TimerPage() {
         <DefaultLayout.ContentContanier>
           {!isOpen && (
             <div className="relative z-10 h-full">
-              {!isFirst && (
+              {isFirst && (
                 <FirstUseToolTip
                   onClose={() => {
-                    setIsFirst(true);
-                    localStorage.setItem('isFirst', 'true');
+                    setIsFirst(false);
+                    localStorage.setItem('isFirst', 'false');
                   }}
                 />
               )}

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -241,6 +241,7 @@ export default function TimerPage() {
                 </div>
 
                 <TimerComponent
+                  isRunning={intervalRef.current !== null}
                   debateInfo={data!.table[index]}
                   timer={timer}
                   onOpenModal={() => openModal()}

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import TimerDisplay from '../common/TimerDisplay';
 import AdditionalTimerController from './AdditionalTimerController';
 import AdditionalTimerSummary from './AdditionalTimerSummary';
 import { DebateInfo } from '../../../../type/type';
+import { useTimer } from '../../hooks/useTimer';
 
 interface AdditionalTimerComponentProps {
   prevItem?: DebateInfo;
@@ -19,37 +20,25 @@ export default function AdditionalTimerComponent({
   const dingOnceRef = useRef<HTMLAudioElement>(null);
   const dingTwiceRef = useRef<HTMLAudioElement>(null);
 
-  const [timer, setTimer] = useState<number>(0);
-  const intervalRef = useRef<NodeJS.Timeout | null>(null);
-  const [isRunning, setRunning] = useState<boolean>(false);
-
-  const startTimer = useCallback(() => {
-    if (!intervalRef.current) {
-      intervalRef.current = setInterval(() => {
-        setTimer((prev) => prev - 1);
-      }, 1000);
-      setRunning(true);
-    }
-  }, []);
-
-  const pauseTimer = useCallback(() => {
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-      setRunning(false);
-    }
-  }, []);
+  const { timer, isRunning, startTimer, pauseTimer, setTimer, actOnTime } =
+    useTimer({
+      initialTimer: 0,
+    });
 
   // Let timer play sounds when only 30 seconds left or timeout
   useEffect(() => {
-    if (dingOnceRef.current && timer === 30 && intervalRef.current) {
-      dingOnceRef.current.play();
-    } else if (timer === 0 && intervalRef.current) {
-      clearInterval(intervalRef.current);
-      intervalRef.current = null;
-      if (dingTwiceRef.current) dingTwiceRef.current.play();
-    }
-  }, [timer]);
+    actOnTime(30, () => {
+      if (dingOnceRef.current && isRunning) {
+        dingOnceRef.current.play();
+      }
+    });
+
+    actOnTime(0, () => {
+      if (dingTwiceRef.current && isRunning) {
+        dingTwiceRef.current.play();
+      }
+    });
+  }, [actOnTime, isRunning]);
 
   return (
     <div className="flex flex-col items-center space-y-12 px-12 pb-8">

--- a/src/page/TimerPage/components/Timer/TimerComponent.tsx
+++ b/src/page/TimerPage/components/Timer/TimerComponent.tsx
@@ -47,31 +47,29 @@ export default function TimerComponent({
 
   // Return React component
   return (
-    <div className="flex h-full flex-row items-center space-x-4">
-      <div
-        className={`flex w-min flex-col ${bgColor} items-center rounded-[50px] border-4 border-zinc-50 px-8 py-8 shadow-2xl`}
-      >
-        {/* Title */}
-        <div className="m-2 mb-8 flex flex-col items-center space-y-3">
-          <h1 className="text-6xl font-bold text-zinc-50">{titleText}</h1>
-          <div className="flex flex-row items-center space-x-3 text-zinc-50">
-            {debateInfo.stance !== 'NEUTRAL' && <IoPerson size={25} />}
-            <h1 className="text-3xl">{speakerText}</h1>
-          </div>
+    <div
+      className={`flex w-min flex-col ${bgColor} items-center rounded-[50px] border-4 border-zinc-50 px-8 py-8 shadow-2xl`}
+    >
+      {/* Title */}
+      <div className="m-2 mb-8 flex flex-col items-center space-y-3">
+        <h1 className="text-6xl font-bold text-zinc-50">{titleText}</h1>
+        <div className="flex flex-row items-center space-x-3 text-zinc-50">
+          {debateInfo.stance !== 'NEUTRAL' && <IoPerson size={25} />}
+          <h1 className="text-3xl">{speakerText}</h1>
         </div>
-
-        {/* Timer */}
-        <TimerDisplay timer={timer} />
-
-        {/* Timer controller that includes buttons that can handle timer */}
-        <TimerController
-          isRunning={isRunning}
-          onReset={resetTimer}
-          onStart={startTimer}
-          onPause={pauseTimer}
-          onOpenModal={onOpenModal}
-        />
       </div>
+
+      {/* Timer */}
+      <TimerDisplay timer={timer} />
+
+      {/* Timer controller that includes buttons that can handle timer */}
+      <TimerController
+        isRunning={isRunning}
+        onReset={resetTimer}
+        onStart={startTimer}
+        onPause={pauseTimer}
+        onOpenModal={onOpenModal}
+      />
     </div>
   );
 }

--- a/src/page/TimerPage/components/Timer/TimerComponent.tsx
+++ b/src/page/TimerPage/components/Timer/TimerComponent.tsx
@@ -8,6 +8,7 @@ import TimerController from './TimerController';
 import { IoPerson } from 'react-icons/io5';
 
 interface TimerComponentProps {
+  isRunning: boolean;
   debateInfo: DebateInfo;
   timer: number;
   startTimer: () => void;
@@ -18,6 +19,7 @@ interface TimerComponentProps {
 
 // Main timer component that user can control
 export default function TimerComponent({
+  isRunning,
   debateInfo,
   timer,
   startTimer,
@@ -63,6 +65,7 @@ export default function TimerComponent({
 
         {/* Timer controller that includes buttons that can handle timer */}
         <TimerController
+          isRunning={isRunning}
           onReset={resetTimer}
           onStart={startTimer}
           onPause={pauseTimer}

--- a/src/page/TimerPage/components/Timer/TimerController.tsx
+++ b/src/page/TimerPage/components/Timer/TimerController.tsx
@@ -1,7 +1,9 @@
+import { LuRefreshCcw } from 'react-icons/lu';
 import TimerIconButton from '../common/TimerIconButton';
-import { IoPauseOutline, IoPlayOutline, IoTimerOutline } from 'react-icons/io5';
+import { IoPauseOutline, IoPlayOutline } from 'react-icons/io5';
 
 interface TimerControllerProps {
+  isRunning: boolean;
   onPause: () => void;
   onStart: () => void;
   onReset: () => void;
@@ -11,6 +13,7 @@ interface TimerControllerProps {
 const iconSize = 40;
 
 export default function TimerController({
+  isRunning,
   onPause,
   onStart,
   onReset,
@@ -19,34 +22,38 @@ export default function TimerController({
   return (
     <div className="flex flex-row items-center space-x-8">
       {/* Timer start button */}
-      <TimerIconButton
-        icon={<IoPlayOutline size={iconSize} />}
-        style={{
-          bgColor: 'bg-emerald-500',
-          hoverColor: 'hover:bg-emerald-600',
-          contentColor: 'text-zinc-50',
-        }}
-        onClick={() => {
-          onStart();
-        }}
-      />
+      {isRunning && (
+        <TimerIconButton
+          icon={<IoPauseOutline size={iconSize} />}
+          style={{
+            bgColor: 'bg-amber-500',
+            hoverColor: 'hover:bg-amber-600',
+            contentColor: 'text-zinc-50',
+          }}
+          onClick={() => {
+            onPause();
+          }}
+        />
+      )}
 
       {/* Timer pause button */}
-      <TimerIconButton
-        icon={<IoPauseOutline size={iconSize} />}
-        style={{
-          bgColor: 'bg-amber-500',
-          hoverColor: 'hover:bg-amber-600',
-          contentColor: 'text-zinc-50',
-        }}
-        onClick={() => {
-          onPause();
-        }}
-      />
+      {!isRunning && (
+        <TimerIconButton
+          icon={<IoPlayOutline size={iconSize} />}
+          style={{
+            bgColor: 'bg-emerald-500',
+            hoverColor: 'hover:bg-emerald-600',
+            contentColor: 'text-zinc-50',
+          }}
+          onClick={() => {
+            onStart();
+          }}
+        />
+      )}
 
       {/* Timer reset button */}
       <TimerIconButton
-        icon={<IoTimerOutline size={iconSize} />}
+        icon={<LuRefreshCcw size={iconSize} />}
         style={{
           bgColor: 'bg-red-500',
           hoverColor: 'hover:bg-red-600',
@@ -65,7 +72,7 @@ export default function TimerController({
           onOpenModal();
         }}
       >
-        <h1 className="text-2xl font-bold">추가 작전 시간</h1>
+        <h1 className="text-2xl font-bold">작전 시간 사용</h1>
       </button>
     </div>
   );

--- a/src/page/TimerPage/components/common/FirstUseToolTip.tsx
+++ b/src/page/TimerPage/components/common/FirstUseToolTip.tsx
@@ -1,0 +1,131 @@
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { IoHourglassOutline } from 'react-icons/io5';
+import { LuKeyboard } from 'react-icons/lu';
+import { MdOutlineTimer } from 'react-icons/md';
+
+interface FirstUseToolTipProps {
+  onClose: () => void;
+}
+
+interface FirstUseToolTipContentProps {
+  onClose: () => void;
+  setHeight: (height: number) => void;
+}
+
+interface FirstUseToolTipBackgroundProps {
+  height: string | number;
+}
+
+export default function FirstUseToolTip({ onClose }: FirstUseToolTipProps) {
+  const [height, setHeight] = useState<string | number>('auto');
+
+  return (
+    <div className="relative">
+      <FirstUseToolTipBackground height={height} />
+      <FirstUseToolTipContent
+        setHeight={(value) => setHeight(value)}
+        onClose={() => onClose()}
+      />
+    </div>
+  );
+}
+
+function FirstUseToolTipBackground({ height }: FirstUseToolTipBackgroundProps) {
+  return (
+    <div
+      className="absolute inset-0 z-10 rounded-2xl bg-slate-900 opacity-80"
+      style={{ height }}
+    ></div>
+  );
+}
+
+function FirstUseToolTipContent({
+  setHeight,
+  onClose,
+}: FirstUseToolTipContentProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      setHeight(ref.current.offsetHeight);
+    }
+  }, [ref, setHeight]);
+
+  return (
+    <div className="relative z-20 flex flex-col space-y-6 p-6">
+      <div className="flex flex-col text-slate-50">
+        <div className="mb-2 flex flex-row items-center space-x-4">
+          <MdOutlineTimer size={18} />
+          <h1 className="text-xl font-bold">타이머 조작</h1>
+        </div>
+
+        <div className="text-m flex flex-col space-y-1 md:text-lg">
+          <ListItem>초록색 시작 버튼을 눌러 타이머를 시작</ListItem>
+          <ListItem>
+            타이머가 동작 중일 때, 주황색 일시정지 버튼을 눌러 타이머를 일시정지
+          </ListItem>
+          <ListItem>
+            붉은색 초기화 버튼을 눌러 타이머를 원래 시간으로 초기화
+          </ListItem>
+          <ListItem>
+            작전 시간 사용 버튼을 눌러 별도의 작전 시간 타이머 사용 가능
+          </ListItem>
+        </div>
+      </div>
+
+      <div className="flex flex-col space-y-1 text-slate-50">
+        <div className="mb-2 flex flex-row items-center space-x-4">
+          <LuKeyboard size={18} />
+          <h1 className="text-xl font-bold">키보드 조작</h1>
+        </div>
+
+        <div className="text-m flex flex-col space-y-1 md:text-lg">
+          <ListItem>스페이스 바로 타이머를 시작 및 일시정지</ListItem>
+          <ListItem>R 키로 타이머 초기화</ListItem>
+          <ListItem>좌우 방향키로 이전/다음 차례로 이동</ListItem>
+        </div>
+      </div>
+
+      <div className="flex flex-col space-y-1 text-slate-50">
+        <div className="mb-2 flex flex-row items-center space-x-4">
+          <IoHourglassOutline size={18} />
+          <h1 className="text-xl font-bold">작전 시간 총량이 정해진 경우</h1>
+        </div>
+
+        <div className="text-m flex flex-col space-y-1 md:text-lg">
+          <ListItem>
+            타이머의 초기화 버튼 왼쪽의 &#39;작전 시간 사용&#39; 버튼을 눌러,
+            별도의 작전 시간 타이머를 열 수 있음
+          </ListItem>
+          <ListItem>
+            찬성 또는 반대 측에서 작전 시간을 요청할 경우 사용
+          </ListItem>
+          <ListItem>
+            각 팀에서 요청한 작전 시간 만큼 타이머를 설정할 수 있음 (±30초,
+            ±10초 단위)
+          </ListItem>
+        </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          className="w-fit justify-end rounded-2xl bg-slate-50 px-6 py-2 font-bold text-slate-900 hover:bg-slate-300"
+          onClick={() => onClose()}
+        >
+          닫기
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function ListItem(props: PropsWithChildren) {
+  const { children } = props;
+
+  return (
+    <div className="flex flex-row items-start space-x-2">
+      <p>&#8226;</p>
+      <div className="flex flex-wrap">{children}</div>
+    </div>
+  );
+}

--- a/src/page/TimerPage/hooks/useTimer.ts
+++ b/src/page/TimerPage/hooks/useTimer.ts
@@ -1,0 +1,58 @@
+import { useCallback, useRef, useState } from 'react';
+
+export function useTimer() {
+  const [timer, setTimer] = useState(0);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const [defaultTimer, setDefaultTimer] = useState(0);
+
+  const [isRunning, setIsRunning] = useState(false);
+
+  const startTimer = useCallback(() => {
+    if (intervalRef.current === null) {
+      intervalRef.current = setInterval(() => {
+        setTimer((prev) => prev - 1);
+      }, 1000);
+      setIsRunning(true);
+    }
+  }, []);
+
+  const pauseTimer = useCallback(() => {
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setIsRunning(false);
+  }, []);
+
+  const resetTimer = useCallback(
+    (value?: number) => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      setTimer(value !== undefined ? value : defaultTimer);
+      setIsRunning(false);
+    },
+    [defaultTimer],
+  );
+
+  const actOnTime = useCallback(
+    (time: number, act: () => void) => {
+      if (timer === time) {
+        act();
+      }
+    },
+    [timer],
+  );
+
+  return {
+    timer,
+    isRunning,
+    setTimer,
+    startTimer,
+    pauseTimer,
+    resetTimer,
+    actOnTime,
+    setDefaultValue: setDefaultTimer,
+  };
+}

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -6,7 +6,7 @@ import { getMemberIdToken } from '../util/memberIdToken';
 export default function ProtectedRoute(props: PropsWithChildren) {
   const { children } = props;
 
-  const isAuthenticated = getMemberIdToken() || false;
+  const isAuthenticated = getMemberIdToken() || true;
   const location = useLocation();
 
   return isAuthenticated ? (

--- a/src/routes/ProtectedRoute.tsx
+++ b/src/routes/ProtectedRoute.tsx
@@ -6,7 +6,7 @@ import { getMemberIdToken } from '../util/memberIdToken';
 export default function ProtectedRoute(props: PropsWithChildren) {
   const { children } = props;
 
-  const isAuthenticated = getMemberIdToken() || true;
+  const isAuthenticated = getMemberIdToken() || false;
   const location = useLocation();
 
   return isAuthenticated ? (


### PR DESCRIPTION
## 🚩 연관 이슈
closed #101 

## 📝 작업 내용
### 개요
**UT 피드백 반영**
- (1순위) 타이머 리셋 버튼을 새로고침 아이콘으로 변경
- (1순위) 작전 시간 타이머 버튼의 '추가 작전 시간' 텍스트를 '작전 시간 사용'으로 변경
- (2순위) 최초 사용 시 타이머 사용법이 적힌 툴팁 제공

**그 외 변경 사항**
- 시인성 향상을 위해, 타이머의 시작/일시정지 버튼을 작전 시간 타이머처럼 단일 버튼으로 변경
- 타이머 관련 함수 및 변수를 `useTimer` 훅으로 통합
- 모바일 환경 여부를 판단할 수 있는 `useMobile` 훅 추가
- `useMobile` 훅을 사용하여, 모바일 환경일 때 타이머 화면 홈 버튼에 아이콘만 표시되도록 개선

### 툴팁 소개
- `localStorage` 사용
- 툴팁은 `localStorage`의 `isFirst` 값이 `false`일 경우, 출력되지 않음

### 툴팁 사용자 시나리오
- 타이머를 최초로 사용할 시에는, 아무 값이 할당되어 있지 않으므로 툴팁이 정상적으로 출력됨
- 사용자가 툴팁의 '닫기' 버튼을 누르면, `isFirst`가 `false`로 지정되어 로컬 환경에 저장
- 타이머를 재사용할 시, `isFirst`가 `false`이므로 툴팁이 출력되지 않음

## 🏞️ 스크린샷 (선택)
### 툴팁 및 통합된 재생/일시정지 버튼
![스크린샷_3-2-2025_16521_localhost](https://github.com/user-attachments/assets/3c783408-e7d2-436a-bcf4-d9194bf686b6)


## 🗣️ 리뷰 요구사항 (선택)
- 별도 없음