### PR TITLE
[FIX] `useTimer` 훅 매개변수 오류 수정

### DIFF
--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
@@ -21,9 +21,7 @@ export default function AdditionalTimerComponent({
   const dingTwiceRef = useRef<HTMLAudioElement>(null);
 
   const { timer, isRunning, startTimer, pauseTimer, setTimer, actOnTime } =
-    useTimer({
-      initialTimer: 0,
-    });
+    useTimer();
 
   // Let timer play sounds when only 30 seconds left or timeout
   useEffect(() => {


### PR DESCRIPTION
## 🚩 연관 이슈
closed #108 

## 📝 작업 내용
`useTimer` 훅 사용 시 불필요한 매개변수가 포함되어 빌드가 진행되지 않는 오류를 수정했습니다.

## 🏞️ 스크린샷 (선택)
없음

## 🗣️ 리뷰 요구사항 (선택)
없음