### PR TITLE
[CHORE] 충돌 방지를 위한 main 배포 스크립트 수정

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -68,11 +68,11 @@ jobs:
       - name: Fetch all branches
         run: git fetch --all
 
-      - name: Checkout dev branch
-        run: git checkout dev
+      - name: Checkout develop branch
+        run: git checkout develop
 
-      - name: Rebase dev onto main
+      - name: Rebase develop onto main
         run: git rebase origin/main
 
-      - name: Force Push updated dev branch
-        run: git push origin dev --force-with-lease
+      - name: Force Push updated develop branch
+        run: git push origin develop --force-with-lease

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -47,3 +47,32 @@ jobs:
         run: |
           aws cloudfront create-invalidation \
           --distribution-id ${{secrets.AWS_PROD_CLOUDFRONT_ID}} --paths "/*"
+
+  rebase:
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    permissions: 
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Ensure full commit history
+
+      - name: Configure Git User
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Fetch all branches
+        run: git fetch --all
+
+      - name: Checkout dev branch
+        run: git checkout dev
+
+      - name: Rebase dev onto main
+        run: git rebase origin/main
+
+      - name: Force Push updated dev branch
+        run: git push origin dev --force-with-lease


### PR DESCRIPTION
## 🚩 연관 이슈
closed #113 

## 📝 작업 내용
### 개요
production 환경에서 배포 시, develop 브랜치와 main 브랜치 간 충돌을 방지하기 위해 리베이스하는 스크립트 추가

### 스크립트 설명
```yaml
rebase:
    runs-on: ubuntu-latest
    needs: build-and-deploy
    permissions: 
      contents: write
```
- 리베이스 작업을 정의하는 부분
- `build-and-deploy` 작업이 선행되어야 진행될 수 있음을 `needs`로 명시함
- 저장소에 쓰는 작업이 포함되기 때문에, `permission`을 통해 쓰기 작업을 명시

```yaml
    steps:
      - name: Checkout repository
        uses: actions/checkout@v4
        with:
          fetch-depth: 0  # Ensure full commit history

      - name: Configure Git User
        run: |
          git config --global user.name "github-actions[bot]"
          git config --global user.email "github-actions[bot]@users.noreply.github.com"

      - name: Fetch all branches
        run: git fetch --all

      - name: Checkout develop branch
        run: git checkout develop 
```
- 리베이스를 위한 기초 작업 실행
- 저장소를 읽어들이고 develop 브랜치에서 체크아웃 진행

```yaml
      - name: Rebase develop onto main
        run: git rebase origin/main

      - name: Force Push updated develop branch
        run: git push origin develop --force-with-lease
```
- 리베이스 진행
- `git rebase origin/main` 명령어로 main 브랜치의 원격 저장소를 기준으로 하여 리베이스 진행
- `--force-with-lease` 명령어로 원격 브랜치가 로컬 브랜치와 동일한 상태일 때에만 푸시를 허용함으로써 안전하게 푸시 진행

## 🏞️ 스크린샷 (선택)
없음

## 🗣️ 리뷰 요구사항 (선택)
### 반드시 읽어주세요
이 PR에 대해서는 조금 신중한 접근이 필요할 것 같습니다. 다음 이유 때문입니다:
- GitHub Actions 워크플로우 특성상 사전 테스트는 불가능하고, 병합하고 저장소가 스크립트를 인식해야 실행이 가능합니다.
- 위 이유 때문에 이 스크립트의 정상 실행을 보장하지 못하는 상태로 병합을 진행해야 합니다.
- `--force` 만큼은 아니지만, 강제 푸시를 실행하는 `--force-with-lease` 옵션을 사용합니다.
- 이번에 충돌 해결에 애를 먹은 만큼, 섣부른 자동화가 추후 문제를 일으킬 가능성도 배제할 수 없습니다.

따라서 이 PR 같은 경우는 두 분의 확실한 확신이 동반되어야 병합할 생각입니다. 달리 말하면, 두 분 중 한 분이라도 병합을 원치 않으신다면 그냥 닫아버리려고 해요. 저희가 귀찮더라도 직접 main > dev PR 올려서 진행하는 게 어떤 면에서는 가장 확실하고 나을 수 있으니까요. 그러므로, 부디 신중한 검토 후에 의견 남겨주시면 감사하겠습니다. 추가로, 아래에 GitHub Copilot에게 받은 답변을 같이 첨부하니, PR 검토하실 때 참고해주시면 감사하겠습니다.

### GitHub Copilot과의 대화
**질문**
I wrote this script to merge from main to dev to prevent possible conflicts that might happen after merging from dev to main. Will this script work?

**대답**
네, 이 스크립트는 main 브랜치에서 dev 브랜치로 리베이스를 수행하여 충돌을 방지하려는 의도로 작성되었습니다. 스크립트는 다음과 같은 작업을 수행합니다:

1. main 브랜치에서 코드 빌드 및 배포
2. dev 브랜치로 체크아웃
3. main 브랜치의 변경 사항을 dev 브랜치에 리베이스
4. dev 브랜치를 원격 저장소에 강제 푸시

이 스크립트는 정상적으로 작동할 것으로 보입니다. 다만, 몇 가지 주의사항이 있습니다:

- 리베이스: 리베이스는 커밋 히스토리를 재작성하므로, 협업 중인 다른 개발자들이 dev 브랜치에서 작업 중이라면 혼란을 초래할 수 있습니다. 이 경우, 리베이스 대신 병합을 고려해볼 수 있습니다.
- 강제 푸시: --force-with-lease 옵션을 사용하여 강제 푸시를 수행하고 있습니다. 이 옵션은 원격 브랜치가 로컬 브랜치와 동일한 상태일 때만 푸시를 허용하므로, 안전하게 강제 푸시를 수행할 수 있습니다.

스크립트가 정상적으로 작동할 것으로 예상되지만, 실제 환경에서 테스트를 통해 확인하는 것이 좋습니다.
