### PR TITLE
[FEAT] 토론 테이블 생성, 수정 개선

### DIFF
--- a/src/apis/apis.ts
+++ b/src/apis/apis.ts
@@ -7,7 +7,7 @@ import {
   PostUserResponseType,
   PutDebateTableResponseType,
 } from './responseTypes';
-import { TimeBoxInfo } from '../type/type';
+import { DetailDebateInfo, TimeBoxInfo } from '../type/type';
 import { setAccessToken } from '../util/accessToken';
 
 // String type identifier for TanStack Query's 'useQuery' function
@@ -68,10 +68,7 @@ export async function getParliamentaryTableData(
 
 // POST /api/table/parliamentary
 export async function postParliamentaryDebateTable(
-  tableName: string,
-  tableAgenda: string,
-  warningBell: boolean,
-  finishBell: boolean,
+  info: DetailDebateInfo,
   tables: TimeBoxInfo[],
 ): Promise<PostDebateTableResponseType> {
   const requestUrl: string = ApiUrl.parliamentary;
@@ -80,10 +77,10 @@ export async function postParliamentaryDebateTable(
     requestUrl,
     {
       info: {
-        name: tableName === '' ? '테이블 1' : tableName,
-        agenda: tableAgenda,
-        warningBell: warningBell,
-        finishBell: finishBell,
+        name: info.name === '' ? '테이블 1' : info.name,
+        agenda: info.agenda,
+        warningBell: info.warningBell,
+        finishBell: info.finishBell,
       },
       table: tables,
     },
@@ -96,10 +93,7 @@ export async function postParliamentaryDebateTable(
 // PUT /api/table/parliamentary/{tableId}
 export async function putParliamentaryDebateTable(
   tableId: number,
-  tableName: string,
-  tableAgenda: string,
-  warningBell: boolean,
-  finishBell: boolean,
+  info: DetailDebateInfo,
   tables: TimeBoxInfo[],
 ): Promise<PutDebateTableResponseType> {
   const requestUrl: string = ApiUrl.parliamentary;
@@ -108,10 +102,10 @@ export async function putParliamentaryDebateTable(
     requestUrl + `/${tableId}`,
     {
       info: {
-        name: tableName,
-        agenda: tableAgenda,
-        warningBell: warningBell,
-        finishBell: finishBell,
+        name: info.name,
+        agenda: info.agenda,
+        warningBell: info.warningBell,
+        finishBell: info.finishBell,
       },
       table: tables,
     },

--- a/src/apis/apis.ts
+++ b/src/apis/apis.ts
@@ -7,7 +7,7 @@ import {
   PostUserResponseType,
   PutDebateTableResponseType,
 } from './responseTypes';
-import { DebateInfo } from '../type/type';
+import { TimeBoxInfo } from '../type/type';
 import { setAccessToken } from '../util/accessToken';
 
 // String type identifier for TanStack Query's 'useQuery' function
@@ -72,7 +72,7 @@ export async function postParliamentaryDebateTable(
   tableAgenda: string,
   warningBell: boolean,
   finishBell: boolean,
-  tables: DebateInfo[],
+  tables: TimeBoxInfo[],
 ): Promise<PostDebateTableResponseType> {
   const requestUrl: string = ApiUrl.parliamentary;
   const response = await request<PostDebateTableResponseType>(
@@ -100,7 +100,7 @@ export async function putParliamentaryDebateTable(
   tableAgenda: string,
   warningBell: boolean,
   finishBell: boolean,
-  tables: DebateInfo[],
+  tables: TimeBoxInfo[],
 ): Promise<PutDebateTableResponseType> {
   const requestUrl: string = ApiUrl.parliamentary;
   const response = await request<PutDebateTableResponseType>(

--- a/src/apis/responseTypes.ts
+++ b/src/apis/responseTypes.ts
@@ -1,4 +1,4 @@
-import { DebateInfo, DebateTable } from '../type/type';
+import { TimeBoxInfo, DebateTable } from '../type/type';
 
 // POST "/api/member"
 export interface PostUserResponseType {
@@ -20,7 +20,7 @@ export interface GetTableDataResponseType {
     warningBell: boolean;
     finishBell: boolean;
   };
-  table: DebateInfo[];
+  table: TimeBoxInfo[];
 }
 
 // POST /api/table/parliamentary
@@ -32,7 +32,7 @@ export interface PostDebateTableResponseType {
     warningBell: boolean;
     finishBell: boolean;
   };
-  table: DebateInfo[];
+  table: TimeBoxInfo[];
 }
 
 // PUT /api/table/parliamentary/{tableId}
@@ -44,7 +44,7 @@ export interface PutDebateTableResponseType {
     warningBell: boolean;
     finishBell: boolean;
   };
-  table: DebateInfo[];
+  table: TimeBoxInfo[];
 }
 
 // DELETE /api/table/parliamentary/{tableId}

--- a/src/apis/responseTypes.ts
+++ b/src/apis/responseTypes.ts
@@ -1,4 +1,4 @@
-import { TimeBoxInfo, DebateTable } from '../type/type';
+import { TimeBoxInfo, DebateTable, DetailDebateInfo } from '../type/type';
 
 // POST "/api/member"
 export interface PostUserResponseType {
@@ -14,36 +14,21 @@ export interface GetDebateTableListResponseType {
 // GET /api/table/parliamentary/{tableId}
 export interface GetTableDataResponseType {
   id: number;
-  info: {
-    name: string;
-    agenda: string;
-    warningBell: boolean;
-    finishBell: boolean;
-  };
+  info: DetailDebateInfo;
   table: TimeBoxInfo[];
 }
 
 // POST /api/table/parliamentary
 export interface PostDebateTableResponseType {
   id: number;
-  info: {
-    name: string;
-    agenda: string;
-    warningBell: boolean;
-    finishBell: boolean;
-  };
+  info: DetailDebateInfo;
   table: TimeBoxInfo[];
 }
 
 // PUT /api/table/parliamentary/{tableId}
 export interface PutDebateTableResponseType {
   id: number;
-  info: {
-    name: string;
-    agenda: string;
-    warningBell: boolean;
-    finishBell: boolean;
-  };
+  info: DetailDebateInfo;
   table: TimeBoxInfo[];
 }
 

--- a/src/constants/languageMapping.ts
+++ b/src/constants/languageMapping.ts
@@ -2,5 +2,4 @@ import { Type } from '../type/type';
 
 export const typeMapping: Record<Type, string> = {
   PARLIAMENTARY: '의회식 토론',
-  TIMEBASED: '시간 총량제 토론',
 };

--- a/src/hooks/mutations/useAddTable.ts
+++ b/src/hooks/mutations/useAddTable.ts
@@ -12,10 +12,12 @@ export default function useAddTable(onSuccess: (id: number) => void) {
   return useMutation({
     mutationFn: async (params: UseAddTableParams) => {
       const response = await postParliamentaryDebateTable(
-        params.tableName,
-        params.tableAgenda,
-        params.warningBell,
-        params.finishBell,
+        {
+          name: params.info.name,
+          agenda: params.info.agenda,
+          warningBell: params.info.warningBell,
+          finishBell: params.info.finishBell,
+        },
         params.table,
       );
       return response;

--- a/src/hooks/mutations/useAddTable.ts
+++ b/src/hooks/mutations/useAddTable.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { postParliamentaryDebateTable } from '../../apis/apis';
-import { DebateInfo } from '../../type/type';
+import { TimeBoxInfo } from '../../type/type';
 import { PostDebateTableResponseType } from '../../apis/responseTypes';
 
 interface UseAddTableParams {
@@ -8,7 +8,7 @@ interface UseAddTableParams {
   tableAgenda: string;
   warningBell: boolean;
   finishBell: boolean;
-  table: DebateInfo[];
+  table: TimeBoxInfo[];
 }
 
 export default function useAddTable(onSuccess: (id: number) => void) {

--- a/src/hooks/mutations/useAddTable.ts
+++ b/src/hooks/mutations/useAddTable.ts
@@ -1,13 +1,10 @@
 import { useMutation } from '@tanstack/react-query';
 import { postParliamentaryDebateTable } from '../../apis/apis';
-import { TimeBoxInfo } from '../../type/type';
+import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
 import { PostDebateTableResponseType } from '../../apis/responseTypes';
 
 interface UseAddTableParams {
-  tableName: string;
-  tableAgenda: string;
-  warningBell: boolean;
-  finishBell: boolean;
+  info: DetailDebateInfo;
   table: TimeBoxInfo[];
 }
 

--- a/src/hooks/mutations/usePutParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/usePutParliamentaryDebateTable.ts
@@ -1,14 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { putParliamentaryDebateTable } from '../../apis/apis';
 import { PutDebateTableResponseType } from '../../apis/responseTypes';
-import { TimeBoxInfo } from '../../type/type';
+import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
 
 interface PutParliamentaryTableParams {
   tableId: number;
-  tableName: string;
-  tableAgenda: string;
-  warningBell: boolean;
-  finishBell: boolean;
+  info: DetailDebateInfo;
   table: TimeBoxInfo[];
 }
 
@@ -20,22 +17,8 @@ export function usePutParliamentaryDebateTable(
     Error,
     PutParliamentaryTableParams
   >({
-    mutationFn: ({
-      tableId,
-      tableName,
-      tableAgenda,
-      table,
-      warningBell,
-      finishBell,
-    }) =>
-      putParliamentaryDebateTable(
-        tableId,
-        tableName,
-        tableAgenda,
-        warningBell,
-        finishBell,
-        table,
-      ),
+    mutationFn: ({ tableId, info, table }) =>
+      putParliamentaryDebateTable(tableId, info, table),
     onSuccess: (response: PutDebateTableResponseType) => {
       onSuccess(response.id);
     },

--- a/src/hooks/mutations/usePutParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/usePutParliamentaryDebateTable.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { putParliamentaryDebateTable } from '../../apis/apis';
 import { PutDebateTableResponseType } from '../../apis/responseTypes';
-import { DebateInfo } from '../../type/type';
+import { TimeBoxInfo } from '../../type/type';
 
 interface PutParliamentaryTableParams {
   tableId: number;
@@ -9,7 +9,7 @@ interface PutParliamentaryTableParams {
   tableAgenda: string;
   warningBell: boolean;
   finishBell: boolean;
-  table: DebateInfo[];
+  table: TimeBoxInfo[];
 }
 
 export function usePutParliamentaryDebateTable(

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -33,6 +33,8 @@ export default function TableComposition() {
           name: fetchedTableData.info.name,
           agenda: fetchedTableData.info.agenda,
           type: type,
+          warningBell: fetchedTableData.info.warningBell,
+          finishBell: fetchedTableData.info.finishBell,
         },
         table: fetchedTableData.table,
       };
@@ -49,16 +51,16 @@ export default function TableComposition() {
         tableId: tableId, // etc
         tableName: formData.info.name ?? '테이블 1',
         tableAgenda: formData.info.agenda,
-        warningBell: true,
-        finishBell: true,
+        warningBell: formData.info.warningBell,
+        finishBell: formData.info.finishBell,
         table: formData.table,
       });
     } else {
       AddTable({
         tableName: formData.info.name ?? '테이블 1',
         tableAgenda: formData.info.agenda,
-        warningBell: true,
-        finishBell: true,
+        warningBell: formData.info.warningBell,
+        finishBell: formData.info.finishBell,
         table: formData.table,
       });
     }
@@ -72,7 +74,7 @@ export default function TableComposition() {
             <TableNameAndType
               info={formData.info}
               isEdit={mode === 'edit'}
-              onNameAndTypeChange={updateInfo}
+              onInfoChange={updateInfo}
               onButtonClick={() => goNextStep('TimeBox')}
             />
           ),

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -49,18 +49,22 @@ export default function TableComposition() {
     if (mode === 'edit') {
       EditTable({
         tableId: tableId, // etc
-        tableName: formData.info.name ?? '테이블 1',
-        tableAgenda: formData.info.agenda,
-        warningBell: formData.info.warningBell,
-        finishBell: formData.info.finishBell,
+        info: {
+          name: formData.info.name ?? '테이블 1',
+          agenda: formData.info.agenda,
+          warningBell: formData.info.warningBell,
+          finishBell: formData.info.finishBell,
+        },
         table: formData.table,
       });
     } else {
       AddTable({
-        tableName: formData.info.name ?? '테이블 1',
-        tableAgenda: formData.info.agenda,
-        warningBell: formData.info.warningBell,
-        finishBell: formData.info.finishBell,
+        info: {
+          name: formData.info.name ?? '테이블 1',
+          agenda: formData.info.agenda,
+          warningBell: formData.info.warningBell,
+          finishBell: formData.info.finishBell,
+        },
         table: formData.table,
       });
     }

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -80,7 +80,6 @@ export default function TableComposition() {
             <TimeBoxStep
               initData={formData}
               isEdit={mode === 'edit'}
-              onAgendaChange={updateInfo}
               onTimeBoxChange={updateTable}
               onButtonClick={handleButtonClick}
             />

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -1,11 +1,11 @@
 import { HTMLAttributes } from 'react';
 import EditDeleteButtons from '../EditDeleteButtons/EditDeleteButtons';
-import { DebateInfo, DebateTypeToString } from '../../../../type/type';
+import { TimeBoxInfo, DebateTypeToString } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 import { LuArrowUpDown } from 'react-icons/lu';
 interface DebatePanelProps extends HTMLAttributes<HTMLDivElement> {
-  info: DebateInfo;
-  onSubmitEdit?: (updatedInfo: DebateInfo) => void;
+  info: TimeBoxInfo;
+  onSubmitEdit?: (updatedInfo: TimeBoxInfo) => void;
   onSubmitDelete?: () => void;
 }
 

--- a/src/page/TableComposition/components/DropdownForDebateType/DropdownForDebateType.tsx
+++ b/src/page/TableComposition/components/DropdownForDebateType/DropdownForDebateType.tsx
@@ -31,7 +31,7 @@ export default function DropdownForDebateType(
   );
 
   return (
-    <div className="relative w-8/12">
+    <div className="relative w-full">
       <button
         onClick={() => setIsToggleOpen(!isToggleOpen)}
         className="w-full rounded-md bg-neutral-300 p-6 text-center font-semibold text-white lg:text-3xl"

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.stories.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import EditDeleteButtons from './EditDeleteButtons';
-import { DebateInfo } from '../../../../type/type';
+import { TimeBoxInfo } from '../../../../type/type';
 
 const meta: Meta<typeof EditDeleteButtons> = {
   title: 'page/TableSetup/components/EditDeleteButtons',
@@ -12,7 +12,7 @@ export default meta;
 
 type Story = StoryObj<typeof EditDeleteButtons>;
 
-const mockInfo: DebateInfo = {
+const mockInfo: TimeBoxInfo = {
   stance: 'PROS',
   type: 'OPENING',
   time: 150,

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -1,12 +1,12 @@
 import { AiOutlineDelete, AiOutlineEdit } from 'react-icons/ai';
 import DeleteConfirmContent from '../DeleteConfirmContent/DeleteConfirmContent';
-import { DebateInfo } from '../../../../type/type';
+import { TimeBoxInfo } from '../../../../type/type';
 import { useModal } from '../../../../hooks/useModal';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 
 interface EditDeleteButtonsPros {
-  info: DebateInfo;
-  onSubmitEdit: (updatedInfo: DebateInfo) => void;
+  info: TimeBoxInfo;
+  onSubmitEdit: (updatedInfo: TimeBoxInfo) => void;
   onSubmitDelete: () => void;
 }
 

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -1,6 +1,9 @@
+import { IoMdHome } from 'react-icons/io';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import { Type } from '../../../../type/type';
 import DropdownForDebateType from '../DropdownForDebateType/DropdownForDebateType';
+import useLogout from '../../../../hooks/mutations/useLogout';
+import { useNavigate } from 'react-router-dom';
 
 interface TableNameAndTypeProps {
   info: {
@@ -22,6 +25,8 @@ interface TableNameAndTypeProps {
 }
 
 export default function TableNameAndType(props: TableNameAndTypeProps) {
+  const { mutate: logoutMutate } = useLogout(() => navigate('/login'));
+  const navigate = useNavigate();
   const { info, isEdit = false, onInfoChange, onButtonClick } = props;
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -70,7 +75,27 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
             </h1>
           </div>
         </DefaultLayout.Header.Center>
-        <DefaultLayout.Header.Right></DefaultLayout.Header.Right>
+        <DefaultLayout.Header.Right>
+          <button
+            onClick={() => {
+              navigate('/');
+            }}
+            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
+          >
+            <div className="flex flex-row items-center space-x-4">
+              <IoMdHome size={24} />
+              <h1>홈 화면</h1>
+            </div>
+          </button>
+          <button
+            onClick={() => logoutMutate()}
+            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
+          >
+            <div className="flex flex-row items-center space-x-4">
+              <h2>로그아웃</h2>
+            </div>
+          </button>
+        </DefaultLayout.Header.Right>
       </DefaultLayout.Header>
       <DefaultLayout.ContentContanier>
         <section className="grid w-full grid-cols-[1fr_2fr] gap-10 p-8">

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -27,6 +27,13 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
     });
   };
 
+  const handleAgenda = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onNameAndTypeChange({
+      ...info,
+      agenda: e.target.value,
+    });
+  };
+
   const handleTypeChange = (type: Type) => {
     onNameAndTypeChange({
       ...info,
@@ -56,6 +63,16 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
               className="w-8/12 rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
               value={info.name}
               onChange={handleNameChange}
+            />
+          </div>
+
+          <div className="flex w-full items-center justify-between">
+            <h3 className="text-md font-bold lg:text-5xl">토론 주제</h3>
+            <input
+              placeholder="토론 주제를 입력해주세요"
+              className="w-8/12 rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
+              value={info.agenda}
+              onChange={handleAgenda}
             />
           </div>
 

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -73,7 +73,15 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
 
       <DefaultLayout.StickyFooterWrapper>
         <button
-          onClick={onButtonClick}
+          onClick={() => {
+            if (info.name === '') {
+              onNameAndTypeChange({
+                ...info,
+                name: '테이블 1',
+              });
+            }
+            onButtonClick();
+          }}
           className="h-20 w-full bg-amber-500 text-2xl font-semibold transition duration-300 hover:bg-amber-600"
         >
           {isEdit ? '타임박스 수정하기' : '타임박스 만들기'}

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -7,37 +7,55 @@ interface TableNameAndTypeProps {
     name: string;
     agenda: string;
     type: Type;
+    warningBell: boolean;
+    finishBell: boolean;
   };
   isEdit?: boolean;
-  onNameAndTypeChange: (newInfo: {
+  onInfoChange: (newInfo: {
     name: string;
     agenda: string;
     type: Type;
+    warningBell: boolean;
+    finishBell: boolean;
   }) => void;
   onButtonClick: () => void;
 }
 
 export default function TableNameAndType(props: TableNameAndTypeProps) {
-  const { info, isEdit = false, onNameAndTypeChange, onButtonClick } = props;
+  const { info, isEdit = false, onInfoChange, onButtonClick } = props;
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onNameAndTypeChange({
+    onInfoChange({
       ...info,
       name: e.target.value,
     });
   };
 
   const handleAgenda = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onNameAndTypeChange({
+    onInfoChange({
       ...info,
       agenda: e.target.value,
     });
   };
 
   const handleTypeChange = (type: Type) => {
-    onNameAndTypeChange({
+    onInfoChange({
       ...info,
       type,
+    });
+  };
+
+  const handleWarningBell = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onInfoChange({
+      ...info,
+      warningBell: e.target.checked,
+    });
+  };
+
+  const handleFinishBell = (e: React.ChangeEvent<HTMLInputElement>) => {
+    onInfoChange({
+      ...info,
+      finishBell: e.target.checked,
     });
   };
 
@@ -55,36 +73,54 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
         <DefaultLayout.Header.Right></DefaultLayout.Header.Right>
       </DefaultLayout.Header>
       <DefaultLayout.ContentContanier>
-        <section className="flex w-full flex-col justify-center gap-14 p-8 lg:items-center">
-          <div className="flex w-full items-center justify-between">
-            <h3 className="text-md font-bold lg:text-5xl">토론 시간표 이름</h3>
-            <input
-              placeholder="테이블 1(디폴트 값)"
-              className="w-8/12 rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
-              value={info.name}
-              onChange={handleNameChange}
-            />
-          </div>
+        <section className="grid w-full grid-cols-[1fr_2fr] gap-10 p-8">
+          <h3 className="text-md font-bold lg:text-5xl">토론 템플릿 이름</h3>
+          <input
+            placeholder="테이블 1(디폴트 값)"
+            className="w-full rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
+            value={info.name}
+            onChange={handleNameChange}
+          />
 
-          <div className="flex w-full items-center justify-between">
-            <h3 className="text-md font-bold lg:text-5xl">토론 주제</h3>
-            <input
-              placeholder="토론 주제를 입력해주세요"
-              className="w-8/12 rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
-              value={info.agenda}
-              onChange={handleAgenda}
-            />
-          </div>
+          <h3 className="text-md font-bold lg:text-5xl">토론 주제</h3>
+          <input
+            placeholder="토론 주제를 입력해주세요"
+            className="w-full rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
+            value={info.agenda}
+            onChange={handleAgenda}
+          />
 
           {!isEdit && (
-            <div className="flex w-full items-center justify-between">
+            <>
               <h3 className="text-md font-bold lg:text-5xl">토론 유형</h3>
               <DropdownForDebateType
                 type={info.type}
                 onChange={handleTypeChange}
               />
-            </div>
+            </>
           )}
+
+          <h3 className="text-md font-bold lg:text-5xl">종소리 설정</h3>
+          <div className="flex flex-col gap-5">
+            <label className="flex items-center gap-4 text-lg">
+              <input
+                type="checkbox"
+                checked={info.warningBell}
+                onChange={handleWarningBell}
+                className="h-5 w-5"
+              />
+              발언종료 30초 전 알림
+            </label>
+            <label className="flex items-center gap-4 text-lg">
+              <input
+                type="checkbox"
+                checked={info.finishBell}
+                onChange={handleFinishBell}
+                className="h-5 w-5"
+              />
+              발언종료 알림
+            </label>
+          </div>
         </section>
       </DefaultLayout.ContentContanier>
 
@@ -92,7 +128,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
         <button
           onClick={() => {
             if (info.name === '') {
-              onNameAndTypeChange({
+              onInfoChange({
                 ...info,
                 name: '테이블 1',
               });

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -2,30 +2,26 @@ import DebatePanel from '../DebatePanel/DebatePanel';
 import TimerCreationButton from '../TimerCreationButton/TimerCreationButton';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 import { useModal } from '../../../../hooks/useModal';
-import { DebateInfo, Type } from '../../../../type/type';
+import { DebateInfo } from '../../../../type/type';
 import { useDragAndDrop } from '../../../../hooks/useDragAndDrop';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import PropsAndConsTitle from '../../../../components/ProsAndConsTitle/PropsAndConsTitle';
 import { TableFormData } from '../../hook/useTableFrom';
+import { IoMdHome } from 'react-icons/io';
+import useLogout from '../../../../hooks/mutations/useLogout';
+import { useNavigate } from 'react-router-dom';
 
 interface TimeBoxStepProps {
   initData: TableFormData;
   onTimeBoxChange: React.Dispatch<React.SetStateAction<DebateInfo[]>>;
   onButtonClick: () => void;
-  onAgendaChange: React.Dispatch<
-    React.SetStateAction<{ name: string; agenda: string; type: Type }>
-  >;
   isEdit?: boolean;
 }
 export default function TimeBoxStep(props: TimeBoxStepProps) {
-  const {
-    initData,
-    onTimeBoxChange,
-    onButtonClick,
-    onAgendaChange,
-    isEdit = false,
-  } = props;
-  const initAgenda = initData.info.agenda;
+  const { initData, onTimeBoxChange, onButtonClick, isEdit = false } = props;
+  const { mutate: logoutMutate } = useLogout(() => navigate('/login'));
+
+  const navigate = useNavigate();
   const initTimeBox = initData.table;
   const {
     openModal: ProsOpenModal,
@@ -65,30 +61,46 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
     <DefaultLayout>
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
-          <div className="flex flex-wrap items-center px-2 text-2xl font-bold md:text-3xl">
-            <h1 className="mr-2">{initData.info.name}</h1>
+          <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
+            <h1 className="mr-2">
+              {initData === undefined || initData!.info.name.trim() === ''
+                ? '테이블 이름 없음'
+                : initData!.info.name}
+            </h1>
             <div className="mx-3 h-6 w-[2px] bg-black"></div>
             <span className="text-lg font-normal md:text-xl">의회식</span>
           </div>
         </DefaultLayout.Header.Left>
-        <DefaultLayout.Header.Right>
-          <div className="flex flex-wrap items-center justify-end gap-2 p-2 md:gap-3">
-            <span className="flex basis-full items-start whitespace-nowrap text-sm md:basis-auto md:text-base">
-              토론 주제
-            </span>
-            <input
-              type="text"
-              value={initAgenda}
-              className="w-full rounded-md bg-slate-100 p-2 text-base md:flex-1 md:text-2xl"
-              placeholder="주제를 입력해주세요"
-              onChange={(e) =>
-                onAgendaChange((prev) => ({
-                  ...prev,
-                  agenda: e.target.value,
-                }))
-              }
-            />
+        <DefaultLayout.Header.Center>
+          <div className="flex flex-col items-center">
+            <h1 className="text-m md:text-lg">토론 주제</h1>
+            <h1 className="max-w-md truncate text-xl font-bold md:text-2xl">
+              {initData === undefined || initData.info.agenda.trim() === ''
+                ? '주제 없음'
+                : initData.info.agenda}
+            </h1>
           </div>
+        </DefaultLayout.Header.Center>
+        <DefaultLayout.Header.Right>
+          <button
+            onClick={() => {
+              navigate('/');
+            }}
+            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
+          >
+            <div className="flex flex-row items-center space-x-4">
+              <IoMdHome size={24} />
+              <h1>홈 화면</h1>
+            </div>
+          </button>
+          <button
+            onClick={() => logoutMutate()}
+            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
+          >
+            <div className="flex flex-row items-center space-x-4">
+              <h2>로그아웃</h2>
+            </div>
+          </button>
         </DefaultLayout.Header.Right>
       </DefaultLayout.Header>
 

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -2,7 +2,7 @@ import DebatePanel from '../DebatePanel/DebatePanel';
 import TimerCreationButton from '../TimerCreationButton/TimerCreationButton';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 import { useModal } from '../../../../hooks/useModal';
-import { DebateInfo } from '../../../../type/type';
+import { TimeBoxInfo } from '../../../../type/type';
 import { useDragAndDrop } from '../../../../hooks/useDragAndDrop';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import PropsAndConsTitle from '../../../../components/ProsAndConsTitle/PropsAndConsTitle';
@@ -13,7 +13,7 @@ import { useNavigate } from 'react-router-dom';
 
 interface TimeBoxStepProps {
   initData: TableFormData;
-  onTimeBoxChange: React.Dispatch<React.SetStateAction<DebateInfo[]>>;
+  onTimeBoxChange: React.Dispatch<React.SetStateAction<TimeBoxInfo[]>>;
   onButtonClick: () => void;
   isEdit?: boolean;
 }
@@ -41,7 +41,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       throttleDelay: 50,
     });
 
-  const handleSubmitEdit = (indexToEdit: number, updatedInfo: DebateInfo) => {
+  const handleSubmitEdit = (indexToEdit: number, updatedInfo: TimeBoxInfo) => {
     onTimeBoxChange((prevData) =>
       prevData.map((item, index) =>
         index === indexToEdit ? updatedInfo : item,

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -1,11 +1,11 @@
 import { useState } from 'react';
-import { DebateInfo, DebateType, Stance } from '../../../../type/type';
+import { TimeBoxInfo, DebateType, Stance } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 
 interface TimerCreationContentProps {
   selectedStance: Stance;
-  initDate?: DebateInfo;
-  onSubmit: (data: DebateInfo) => void;
+  initDate?: TimeBoxInfo;
+  onSubmit: (data: TimeBoxInfo) => void;
   onClose: () => void; // 모달 닫기 함수
 }
 

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -17,7 +17,7 @@ export default function TimerCreationContent({
 }: TimerCreationContentProps) {
   const [stance, setStance] = useState<Stance>(selectedStance);
   const [debateType, setDebateType] = useState<DebateType>(
-    initDate?.stance === 'NEUTRAL' ? 'OPENING' : (initDate?.type ?? 'OPENING'),
+    initDate?.type ?? 'OPENING',
   );
   const { minutes: initMinutes, seconds: initSeconds } =
     Formatting.formatSecondsToMinutes(initDate?.time ?? 180);
@@ -89,7 +89,9 @@ export default function TimerCreationContent({
               if (e.target.value === 'TIME_OUT') {
                 setStance('NEUTRAL');
               } else {
-                setStance(selectedStance);
+                setStance(
+                  selectedStance === 'NEUTRAL' ? 'CONS' : selectedStance,
+                );
               }
               setDebateType(e.target.value as DebateType);
             }}

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useNavigate, useNavigationType } from 'react-router-dom';
 import { TableCompositionStep } from '../TableComposition';
 import useBrowserStorage from '../../../hooks/useBrowserStorage';
-import { DebateInfo, Type } from '../../../type/type';
+import { TimeBoxInfo, Type } from '../../../type/type';
 import useAddTable from '../../../hooks/mutations/useAddTable';
 import { usePutParliamentaryDebateTable } from '../../../hooks/mutations/usePutParliamentaryDebateTable';
 
@@ -14,7 +14,7 @@ export interface TableFormData {
     warningBell: boolean;
     finishBell: boolean;
   };
-  table: DebateInfo[];
+  table: TimeBoxInfo[];
 }
 const useTableFrom = (
   currentStep: TableCompositionStep,
@@ -88,13 +88,15 @@ const useTableFrom = (
     });
   };
 
-  const updateTable: React.Dispatch<React.SetStateAction<DebateInfo[]>> = (
+  const updateTable: React.Dispatch<React.SetStateAction<TimeBoxInfo[]>> = (
     action,
   ) => {
     setFormData((prev) => {
-      let newTable: DebateInfo[];
+      let newTable: TimeBoxInfo[];
       if (typeof action === 'function') {
-        newTable = (action as (arg: DebateInfo[]) => DebateInfo[])(prev.table);
+        newTable = (action as (arg: TimeBoxInfo[]) => TimeBoxInfo[])(
+          prev.table,
+        );
       } else {
         newTable = action;
       }

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -11,6 +11,8 @@ export interface TableFormData {
     name: string;
     agenda: string;
     type: Type; // 새로 추가된 속성
+    warningBell: boolean;
+    finishBell: boolean;
   };
   table: DebateInfo[];
 }
@@ -29,6 +31,8 @@ const useTableFrom = (
           name: '',
           agenda: '',
           type: 'PARLIAMENTARY',
+          warningBell: true,
+          finishBell: true,
         },
         table: [],
       },
@@ -57,10 +61,22 @@ const useTableFrom = (
   }, [currentStep, navigationType, navigate]);
 
   const updateInfo: React.Dispatch<
-    React.SetStateAction<{ name: string; agenda: string; type: Type }>
+    React.SetStateAction<{
+      name: string;
+      agenda: string;
+      type: Type;
+      warningBell: boolean;
+      finishBell: boolean;
+    }>
   > = (action) => {
     setFormData((prev) => {
-      let newInfo: { name: string; agenda: string; type: Type };
+      let newInfo: {
+        name: string;
+        agenda: string;
+        type: Type;
+        warningBell: boolean;
+        finishBell: boolean;
+      };
       if (typeof action === 'function') {
         newInfo = (action as (arg: typeof prev.info) => typeof prev.info)(
           prev.info,

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -2,18 +2,12 @@ import { useEffect } from 'react';
 import { useNavigate, useNavigationType } from 'react-router-dom';
 import { TableCompositionStep } from '../TableComposition';
 import useBrowserStorage from '../../../hooks/useBrowserStorage';
-import { TimeBoxInfo, Type } from '../../../type/type';
+import { DetailDebateInfo, TimeBoxInfo, Type } from '../../../type/type';
 import useAddTable from '../../../hooks/mutations/useAddTable';
 import { usePutParliamentaryDebateTable } from '../../../hooks/mutations/usePutParliamentaryDebateTable';
 
 export interface TableFormData {
-  info: {
-    name: string;
-    agenda: string;
-    type: Type; // 새로 추가된 속성
-    warningBell: boolean;
-    finishBell: boolean;
-  };
+  info: DetailDebateInfo & { type: Type };
   table: TimeBoxInfo[];
 }
 const useTableFrom = (

--- a/src/page/TableOverviewPage/TableOverview.stories.tsx
+++ b/src/page/TableOverviewPage/TableOverview.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import TableOverview from './TableOverview';
-import { DebateInfo } from '../../type/type';
+import { TimeBoxInfo } from '../../type/type';
 
 // 1) 메타 설정
 const meta: Meta<typeof TableOverview> = {
@@ -28,6 +28,6 @@ export const Default: Story = {
         time: 180,
         speakerNumber: 2,
       },
-    ] as DebateInfo[],
+    ] as TimeBoxInfo[],
   },
 };

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -31,7 +31,7 @@ export default function TableOverview() {
         <DefaultLayout.Header.Center>
           <div className="flex flex-col items-center">
             <h1 className="text-m md:text-lg">토론 주제</h1>
-            <h1 className="text-xl font-bold md:text-2xl">
+            <h1 className="max-w-md truncate text-xl font-bold md:text-2xl">
               {data === undefined || data!.info.agenda.trim() === ''
                 ? '주제 없음'
                 : data!.info.agenda}

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
@@ -2,13 +2,13 @@ import { useEffect, useRef } from 'react';
 import TimerDisplay from '../common/TimerDisplay';
 import AdditionalTimerController from './AdditionalTimerController';
 import AdditionalTimerSummary from './AdditionalTimerSummary';
-import { DebateInfo } from '../../../../type/type';
+import { TimeBoxInfo } from '../../../../type/type';
 import { useTimer } from '../../hooks/useTimer';
 
 interface AdditionalTimerComponentProps {
-  prevItem?: DebateInfo;
-  currItem: DebateInfo;
-  nextItem?: DebateInfo;
+  prevItem?: TimeBoxInfo;
+  currItem: TimeBoxInfo;
+  nextItem?: TimeBoxInfo;
 }
 
 export default function AdditionalTimerComponent({

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummary.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummary.tsx
@@ -1,4 +1,4 @@
-import { DebateInfo } from '../../../../type/type';
+import { TimeBoxInfo } from '../../../../type/type';
 import AdditionalTimerSummaryItem from './AdditionalTimerSummaryItem';
 
 type SummaryItemType = 'PREV' | 'CURR' | 'NEXT';
@@ -10,9 +10,9 @@ const SummaryItemTypeToString: Record<SummaryItemType, string> = {
 };
 
 interface AdditionalTimerSummaryProps {
-  prevItem?: DebateInfo;
-  currItem: DebateInfo;
-  nextItem?: DebateInfo;
+  prevItem?: TimeBoxInfo;
+  currItem: TimeBoxInfo;
+  nextItem?: TimeBoxInfo;
 }
 
 export default function AdditionalTimerSummary({

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummaryItem.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerSummaryItem.tsx
@@ -1,12 +1,12 @@
 import { IoTimeOutline } from 'react-icons/io5';
 import {
-  DebateInfo,
+  TimeBoxInfo,
   DebateTypeToString,
   StanceToString,
 } from '../../../../type/type';
 
 interface AdditionalTimerSummaryItemProps {
-  item: DebateInfo;
+  item: TimeBoxInfo;
 }
 
 export default function AdditionalTimerSummaryItem({

--- a/src/page/TimerPage/components/DebateInfoSummary.tsx
+++ b/src/page/TimerPage/components/DebateInfoSummary.tsx
@@ -5,14 +5,14 @@ import {
   IoTime,
 } from 'react-icons/io5';
 import {
-  DebateInfo,
+  TimeBoxInfo,
   DebateTypeToString,
   StanceToString,
 } from '../../../type/type';
 import TimerIconButton from './common/TimerIconButton';
 
 interface DebateInfoSummaryProps {
-  debateInfo: DebateInfo;
+  debateInfo: TimeBoxInfo;
   isPrev: boolean;
   moveToOtherItem: (isPrev: boolean) => void;
 }

--- a/src/page/TimerPage/components/Timer/TimeTableItem.tsx
+++ b/src/page/TimerPage/components/Timer/TimeTableItem.tsx
@@ -1,11 +1,11 @@
 import {
-  DebateInfo,
+  TimeBoxInfo,
   DebateTypeToString,
   StanceToString,
 } from '../../../../type/type';
 
 interface TimeTableItemProps {
-  item: DebateInfo;
+  item: TimeBoxInfo;
   isCurrent: boolean;
 }
 

--- a/src/page/TimerPage/components/Timer/TimerComponent.tsx
+++ b/src/page/TimerPage/components/Timer/TimerComponent.tsx
@@ -1,5 +1,5 @@
 import {
-  DebateInfo,
+  TimeBoxInfo,
   DebateTypeToString,
   StanceToString,
 } from '../../../../type/type';
@@ -9,7 +9,7 @@ import { IoPerson } from 'react-icons/io5';
 
 interface TimerComponentProps {
   isRunning: boolean;
-  debateInfo: DebateInfo;
+  debateInfo: TimeBoxInfo;
   timer: number;
   startTimer: () => void;
   pauseTimer: () => void;

--- a/src/page/TimerPage/components/Timer/TimerTimeTable.tsx
+++ b/src/page/TimerPage/components/Timer/TimerTimeTable.tsx
@@ -1,10 +1,10 @@
 import { IoArrowBack, IoArrowForward } from 'react-icons/io5';
-import { DebateInfo } from '../../../../type/type';
+import { TimeBoxInfo } from '../../../../type/type';
 import TimeTableItem from './TimeTableItem';
 
 interface TimerTimeTableProps {
   currIndex: number;
-  tables: DebateInfo[];
+  tables: TimeBoxInfo[];
   moveToOtherItem: (goToPrev: boolean) => void;
 }
 

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -25,7 +25,7 @@ export interface User {
   name: string;
 }
 
-export interface DebateInfo {
+export interface TimeBoxInfo {
   stance: Stance;
   type: DebateType;
   time: number;

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -32,6 +32,13 @@ export interface TimeBoxInfo {
   speakerNumber?: number;
 }
 
+export interface DetailDebateInfo {
+  name: string;
+  agenda: string;
+  warningBell: boolean;
+  finishBell: boolean;
+}
+
 export interface DebateTable {
   id: number;
   name: string;

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -39,4 +39,4 @@ export interface DebateTable {
   duration: number;
 }
 
-export type Type = 'PARLIAMENTARY' | 'TIMEBASED';
+export type Type = 'PARLIAMENTARY';


### PR DESCRIPTION
## 🚩 연관 이슈
closed #122 

## 📝 작업 내용
### Feat
- 지원되지 않는 토론 유형(시간 총량제) 제거
- 30초, 발언종료 종소리 on & off 기능 추가

### FIX
- 헤더 UI를 overview페이지와 타이머 페이지와 동일하게 변경.
- 타임 박스 수정에 작전시간에서 다른 유형으로 변경시 오류가 발생.

## REFACTOR
- DebateInfo 인터페이스 명을 TimeBoxInfo로 변경
- 하드코딩된 타입을 DetailDebateInfo 타입으로 공통화

---

## 지원되지 않는 토론 유형(시간 총량제) 제거
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/08681d61-7e62-4b2e-90d8-d11de48a1ac9" />
아직 지원하지 않은 시간총량제 토론을 제거함으로써 사용자에게 혼란을 주는 일을 없앴습니다.


## 30초, 발언종료 종소리 on & off 기능 추가
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/c318f723-2153-4f03-be01-6f4eec0ed207" />
다음과 같이 알림을 선택할 수 있는 체크박스를 추가했습니다.


## 헤더 UI를 overview페이지와 타이머 페이지와 동일하게 변경.
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/579e73f4-3167-4a0b-8ef4-c11fdc2c28a8" />
<img width="1363" alt="image" src="https://github.com/user-attachments/assets/51dcbeda-e823-47ae-a9da-9615a45b98e6" />
테이블 생성 페이지에서의 헤더 UI를 공통화했습니다.

## 타임 박스 수정에 작전시간에서 다른 유형으로 변경시 오류가 발생.
기존의 수정흐름에서 타임박스가 작전시간인 상태에서 다른 유형으로 변경 후 수정하기 버튼 클릭 시 에러가 발생하는 문제를 수정.


## DebateInfo 인터페이스 명을 TimeBoxInfo로 변경
DebateInfo 인터페이스명을 실제 TimeBox에서 사용되기 때문에 더 정확한 네이밍으로 변경하였습니다.


## 하드코딩된 타입을 DetailDebateInfo 타입으로 공통화
```ts
  name: string;
  agenda: string;
  warningBell: boolean;
  finishBell: boolean;
```
  하드 코딩된 타입을 DetailDebateInfo으로 공통화했습니다.

