### PR TITLE
[FEAT] 타이머 개선 외

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     environment: DEPLOY_DEV
 
     steps:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     environment: DEPLOY_PROD
 
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -563,9 +563,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.0.tgz",
-      "integrity": "sha512-WtKdFM7ls47zkKHFVzMz8opM7LkcsIp9amDUBIAWirg70RM71WRSjdILPsY5Uv1D42ZpUfaPILDlfactHgsRkw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.24.2.tgz",
+      "integrity": "sha512-thpVCb/rhxE/BnMLQ7GReQLLN8q9qbHmI55F4489/ByVg2aQaQ6kbcLb6FHkocZzQhxc4gx0sCk0tJkKBFzDhA==",
       "cpu": [
         "ppc64"
       ],
@@ -580,9 +580,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.0.tgz",
-      "integrity": "sha512-arAtTPo76fJ/ICkXWetLCc9EwEHKaeya4vMrReVlEIUCAUncH7M4bhMQ+M9Vf+FFOZJdTNMXNBrWwW+OXWpSew==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.24.2.tgz",
+      "integrity": "sha512-tmwl4hJkCfNHwFB3nBa8z1Uy3ypZpxqxfTQOcHX+xRByyYgunVbZ9MzUUfb0RxaHIMnbHagwAxuTL+tnNM+1/Q==",
       "cpu": [
         "arm"
       ],
@@ -597,9 +597,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.0.tgz",
-      "integrity": "sha512-Vsm497xFM7tTIPYK9bNTYJyF/lsP590Qc1WxJdlB6ljCbdZKU9SY8i7+Iin4kyhV/KV5J2rOKsBQbB77Ab7L/w==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.24.2.tgz",
+      "integrity": "sha512-cNLgeqCqV8WxfcTIOeL4OAtSmL8JjcN6m09XIgro1Wi7cF4t/THaWEa7eL5CMoMBdjoHOTh/vwTO/o2TRXIyzg==",
       "cpu": [
         "arm64"
       ],
@@ -614,9 +614,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.0.tgz",
-      "integrity": "sha512-t8GrvnFkiIY7pa7mMgJd7p8p8qqYIz1NYiAoKc75Zyv73L3DZW++oYMSHPRarcotTKuSs6m3hTOa5CKHaS02TQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.24.2.tgz",
+      "integrity": "sha512-B6Q0YQDqMx9D7rvIcsXfmJfvUYLoP722bgfBlO5cGvNVb5V/+Y7nhBE3mHV9OpxBf4eAS2S68KZztiPaWq4XYw==",
       "cpu": [
         "x64"
       ],
@@ -631,9 +631,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.0.tgz",
-      "integrity": "sha512-CKyDpRbK1hXwv79soeTJNHb5EiG6ct3efd/FTPdzOWdbZZfGhpbcqIpiD0+vwmpu0wTIL97ZRPZu8vUt46nBSw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.24.2.tgz",
+      "integrity": "sha512-kj3AnYWc+CekmZnS5IPu9D+HWtUI49hbnyqk0FLEJDbzCIQt7hg7ucF1SQAilhtYpIujfaHr6O0UHlzzSPdOeA==",
       "cpu": [
         "arm64"
       ],
@@ -648,9 +648,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.0.tgz",
-      "integrity": "sha512-rgtz6flkVkh58od4PwTRqxbKH9cOjaXCMZgWD905JOzjFKW+7EiUObfd/Kav+A6Gyud6WZk9w+xu6QLytdi2OA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.24.2.tgz",
+      "integrity": "sha512-WeSrmwwHaPkNR5H3yYfowhZcbriGqooyu3zI/3GGpF8AyUdsrrP0X6KumITGA9WOyiJavnGZUwPGvxvwfWPHIA==",
       "cpu": [
         "x64"
       ],
@@ -665,9 +665,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.0.tgz",
-      "integrity": "sha512-6Mtdq5nHggwfDNLAHkPlyLBpE5L6hwsuXZX8XNmHno9JuL2+bg2BX5tRkwjyfn6sKbxZTq68suOjgWqCicvPXA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-UN8HXjtJ0k/Mj6a9+5u6+2eZ2ERD7Edt1Q9IZiB5UZAIdPnVKDoG7mdTVGhHJIeEml60JteamR3qhsr1r8gXvg==",
       "cpu": [
         "arm64"
       ],
@@ -682,9 +682,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.0.tgz",
-      "integrity": "sha512-D3H+xh3/zphoX8ck4S2RxKR6gHlHDXXzOf6f/9dbFt/NRBDIE33+cVa49Kil4WUjxMGW0ZIYBYtaGCa2+OsQwQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.24.2.tgz",
+      "integrity": "sha512-TvW7wE/89PYW+IevEJXZ5sF6gJRDY/14hyIGFXdIucxCsbRmLUcjseQu1SyTko+2idmCw94TgyaEZi9HUSOe3Q==",
       "cpu": [
         "x64"
       ],
@@ -699,9 +699,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.0.tgz",
-      "integrity": "sha512-gJKIi2IjRo5G6Glxb8d3DzYXlxdEj2NlkixPsqePSZMhLudqPhtZ4BUrpIuTjJYXxvF9njql+vRjB2oaC9XpBw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.24.2.tgz",
+      "integrity": "sha512-n0WRM/gWIdU29J57hJyUdIsk0WarGd6To0s+Y+LwvlC55wt+GT/OgkwoXCXvIue1i1sSNWblHEig00GBWiJgfA==",
       "cpu": [
         "arm"
       ],
@@ -716,9 +716,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.0.tgz",
-      "integrity": "sha512-TDijPXTOeE3eaMkRYpcy3LarIg13dS9wWHRdwYRnzlwlA370rNdZqbcp0WTyyV/k2zSxfko52+C7jU5F9Tfj1g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.24.2.tgz",
+      "integrity": "sha512-7HnAD6074BW43YvvUmE/35Id9/NB7BeX5EoNkK9obndmZBUk8xmJJeU7DwmUeN7tkysslb2eSl6CTrYz6oEMQg==",
       "cpu": [
         "arm64"
       ],
@@ -733,9 +733,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.0.tgz",
-      "integrity": "sha512-K40ip1LAcA0byL05TbCQ4yJ4swvnbzHscRmUilrmP9Am7//0UjPreh4lpYzvThT2Quw66MhjG//20mrufm40mA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.24.2.tgz",
+      "integrity": "sha512-sfv0tGPQhcZOgTKO3oBE9xpHuUqguHvSo4jl+wjnKwFpapx+vUDcawbwPNuBIAYdRAvIDBfZVvXprIj3HA+Ugw==",
       "cpu": [
         "ia32"
       ],
@@ -750,9 +750,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.0.tgz",
-      "integrity": "sha512-0mswrYP/9ai+CU0BzBfPMZ8RVm3RGAN/lmOMgW4aFUSOQBjA31UP8Mr6DDhWSuMwj7jaWOT0p0WoZ6jeHhrD7g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.24.2.tgz",
+      "integrity": "sha512-CN9AZr8kEndGooS35ntToZLTQLHEjtVB5n7dl8ZcTZMonJ7CCfStrYhrzF97eAecqVbVJ7APOEe18RPI4KLhwQ==",
       "cpu": [
         "loong64"
       ],
@@ -767,9 +767,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.0.tgz",
-      "integrity": "sha512-hIKvXm0/3w/5+RDtCJeXqMZGkI2s4oMUGj3/jM0QzhgIASWrGO5/RlzAzm5nNh/awHE0A19h/CvHQe6FaBNrRA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.24.2.tgz",
+      "integrity": "sha512-iMkk7qr/wl3exJATwkISxI7kTcmHKE+BlymIAbHO8xanq/TjHaaVThFF6ipWzPHryoFsesNQJPE/3wFJw4+huw==",
       "cpu": [
         "mips64el"
       ],
@@ -784,9 +784,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.0.tgz",
-      "integrity": "sha512-HcZh5BNq0aC52UoocJxaKORfFODWXZxtBaaZNuN3PUX3MoDsChsZqopzi5UupRhPHSEHotoiptqikjN/B77mYQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.24.2.tgz",
+      "integrity": "sha512-shsVrgCZ57Vr2L8mm39kO5PPIb+843FStGt7sGGoqiiWYconSxwTiuswC1VJZLCjNiMLAMh34jg4VSEQb+iEbw==",
       "cpu": [
         "ppc64"
       ],
@@ -801,9 +801,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.0.tgz",
-      "integrity": "sha512-bEh7dMn/h3QxeR2KTy1DUszQjUrIHPZKyO6aN1X4BCnhfYhuQqedHaa5MxSQA/06j3GpiIlFGSsy1c7Gf9padw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.24.2.tgz",
+      "integrity": "sha512-4eSFWnU9Hhd68fW16GD0TINewo1L6dRrB+oLNNbYyMUAeOD2yCK5KXGK1GH4qD/kT+bTEXjsyTCiJGHPZ3eM9Q==",
       "cpu": [
         "riscv64"
       ],
@@ -818,9 +818,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.0.tgz",
-      "integrity": "sha512-ZcQ6+qRkw1UcZGPyrCiHHkmBaj9SiCD8Oqd556HldP+QlpUIe2Wgn3ehQGVoPOvZvtHm8HPx+bH20c9pvbkX3g==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.24.2.tgz",
+      "integrity": "sha512-S0Bh0A53b0YHL2XEXC20bHLuGMOhFDO6GN4b3YjRLK//Ep3ql3erpNcPlEFed93hsQAjAQDNsvcK+hV90FubSw==",
       "cpu": [
         "s390x"
       ],
@@ -835,9 +835,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.0.tgz",
-      "integrity": "sha512-vbutsFqQ+foy3wSSbmjBXXIJ6PL3scghJoM8zCL142cGaZKAdCZHyf+Bpu/MmX9zT9Q0zFBVKb36Ma5Fzfa8xA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.24.2.tgz",
+      "integrity": "sha512-8Qi4nQcCTbLnK9WoMjdC9NiTG6/E38RNICU6sUNqK0QFxCYgoARqVqxdFmWkdonVsvGqWhmm7MO0jyTqLqwj0Q==",
       "cpu": [
         "x64"
       ],
@@ -851,10 +851,27 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-wuLK/VztRRpMt9zyHSazyCVdCXlpHkKm34WUyinD2lzK07FAHTq0KQvZZlXikNWkDGoT6x3TD51jKQ7gMVpopw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.0.tgz",
-      "integrity": "sha512-hjQ0R/ulkO8fCYFsG0FZoH+pWgTTDreqpqY7UnQntnaKv95uP5iW3+dChxnx7C3trQQU40S+OgWhUVwCjVFLvg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-VefFaQUc4FMmJuAxmIHgUmfNiLXY438XrL4GDNV1Y1H/RW3qow68xTwjZKfj/+Plp9NANmzbH5R40Meudu8mmw==",
       "cpu": [
         "x64"
       ],
@@ -869,9 +886,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.0.tgz",
-      "integrity": "sha512-MD9uzzkPQbYehwcN583yx3Tu5M8EIoTD+tUgKF982WYL9Pf5rKy9ltgD0eUgs8pvKnmizxjXZyLt0z6DC3rRXg==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.24.2.tgz",
+      "integrity": "sha512-YQbi46SBct6iKnszhSvdluqDmxCJA+Pu280Av9WICNwQmMxV7nLRHZfjQzwbPs3jeWnuAhE9Jy0NrnJ12Oz+0A==",
       "cpu": [
         "arm64"
       ],
@@ -886,9 +903,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.0.tgz",
-      "integrity": "sha512-4ir0aY1NGUhIC1hdoCzr1+5b43mw99uNwVzhIq1OY3QcEwPDO3B7WNXBzaKY5Nsf1+N11i1eOfFcq+D/gOS15Q==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.24.2.tgz",
+      "integrity": "sha512-+iDS6zpNM6EnJyWv0bMGLWSWeXGN/HTaF/LXHXHwejGsVi+ooqDfMCCTerNFxEkM3wYVcExkeGXNqshc9iMaOA==",
       "cpu": [
         "x64"
       ],
@@ -903,9 +920,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.0.tgz",
-      "integrity": "sha512-jVzdzsbM5xrotH+W5f1s+JtUy1UWgjU0Cf4wMvffTB8m6wP5/kx0KiaLHlbJO+dMgtxKV8RQ/JvtlFcdZ1zCPA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.24.2.tgz",
+      "integrity": "sha512-hTdsW27jcktEvpwNHJU4ZwWFGkz2zRJUz8pvddmXPtXDzVKTTINmlmga3ZzwcuMpUvLw7JkLy9QLKyGpD2Yxig==",
       "cpu": [
         "x64"
       ],
@@ -920,9 +937,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.0.tgz",
-      "integrity": "sha512-iKc8GAslzRpBytO2/aN3d2yb2z8XTVfNV0PjGlCxKo5SgWmNXx82I/Q3aG1tFfS+A2igVCY97TJ8tnYwpUWLCA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.24.2.tgz",
+      "integrity": "sha512-LihEQ2BBKVFLOC9ZItT9iFprsE9tqjDjnbulhHoFxYQtQfai7qfluVODIYxt1PgdoyQkz23+01rzwNwYfutxUQ==",
       "cpu": [
         "arm64"
       ],
@@ -937,9 +954,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.0.tgz",
-      "integrity": "sha512-vQW36KZolfIudCcTnaTpmLQ24Ha1RjygBo39/aLkM2kmjkWmZGEJ5Gn9l5/7tzXA42QGIoWbICfg6KLLkIw6yw==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.24.2.tgz",
+      "integrity": "sha512-q+iGUwfs8tncmFC9pcnD5IvRHAzmbwQ3GPS5/ceCyHdjXubwQWI12MKWSNSMYLJMq23/IUCvJMS76PDqXe1fxA==",
       "cpu": [
         "ia32"
       ],
@@ -954,9 +971,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.0.tgz",
-      "integrity": "sha512-7IAFPrjSQIJrGsK6flwg7NFmwBoSTyF3rl7If0hNUFQU4ilTsEPL6GuMuU9BfIWVVGuRnuIidkSMC+c0Otu8IA==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.24.2.tgz",
+      "integrity": "sha512-7VTgWzgMGvup6aSqDPLiW5zHaxYJGTO4OokMjIlrCtf+VpEL+cXKtCvg723iguPYI5oaUNdS+/V7OU2gvXVWEg==",
       "cpu": [
         "x64"
       ],
@@ -1587,9 +1604,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.28.0.tgz",
-      "integrity": "sha512-wLJuPLT6grGZsy34g4N1yRfYeouklTgPhH1gWXCYspenKYD0s3cR99ZevOGw5BexMNywkbV3UkjADisozBmpPQ==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.6.tgz",
+      "integrity": "sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==",
       "cpu": [
         "arm"
       ],
@@ -1601,9 +1618,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.28.0.tgz",
-      "integrity": "sha512-eiNkznlo0dLmVG/6wf+Ifi/v78G4d4QxRhuUl+s8EWZpDewgk7PX3ZyECUXU0Zq/Ca+8nU8cQpNC4Xgn2gFNDA==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.6.tgz",
+      "integrity": "sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==",
       "cpu": [
         "arm64"
       ],
@@ -1615,9 +1632,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.28.0.tgz",
-      "integrity": "sha512-lmKx9yHsppblnLQZOGxdO66gT77bvdBtr/0P+TPOseowE7D9AJoBw8ZDULRasXRWf1Z86/gcOdpBrV6VDUY36Q==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.6.tgz",
+      "integrity": "sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==",
       "cpu": [
         "arm64"
       ],
@@ -1629,9 +1646,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.28.0.tgz",
-      "integrity": "sha512-8hxgfReVs7k9Js1uAIhS6zq3I+wKQETInnWQtgzt8JfGx51R1N6DRVy3F4o0lQwumbErRz52YqwjfvuwRxGv1w==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.6.tgz",
+      "integrity": "sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==",
       "cpu": [
         "x64"
       ],
@@ -1643,9 +1660,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.28.0.tgz",
-      "integrity": "sha512-lA1zZB3bFx5oxu9fYud4+g1mt+lYXCoch0M0V/xhqLoGatbzVse0wlSQ1UYOWKpuSu3gyN4qEc0Dxf/DII1bhQ==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.6.tgz",
+      "integrity": "sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==",
       "cpu": [
         "arm64"
       ],
@@ -1657,9 +1674,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.28.0.tgz",
-      "integrity": "sha512-aI2plavbUDjCQB/sRbeUZWX9qp12GfYkYSJOrdYTL/C5D53bsE2/nBPuoiJKoWp5SN78v2Vr8ZPnB+/VbQ2pFA==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.6.tgz",
+      "integrity": "sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==",
       "cpu": [
         "x64"
       ],
@@ -1671,9 +1688,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.28.0.tgz",
-      "integrity": "sha512-WXveUPKtfqtaNvpf0iOb0M6xC64GzUX/OowbqfiCSXTdi/jLlOmH0Ba94/OkiY2yTGTwteo4/dsHRfh5bDCZ+w==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.6.tgz",
+      "integrity": "sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==",
       "cpu": [
         "arm"
       ],
@@ -1685,9 +1702,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.28.0.tgz",
-      "integrity": "sha512-yLc3O2NtOQR67lI79zsSc7lk31xjwcaocvdD1twL64PK1yNaIqCeWI9L5B4MFPAVGEVjH5k1oWSGuYX1Wutxpg==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.6.tgz",
+      "integrity": "sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==",
       "cpu": [
         "arm"
       ],
@@ -1699,9 +1716,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.28.0.tgz",
-      "integrity": "sha512-+P9G9hjEpHucHRXqesY+3X9hD2wh0iNnJXX/QhS/J5vTdG6VhNYMxJ2rJkQOxRUd17u5mbMLHM7yWGZdAASfcg==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.6.tgz",
+      "integrity": "sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==",
       "cpu": [
         "arm64"
       ],
@@ -1713,9 +1730,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.28.0.tgz",
-      "integrity": "sha512-1xsm2rCKSTpKzi5/ypT5wfc+4bOGa/9yI/eaOLW0oMs7qpC542APWhl4A37AENGZ6St6GBMWhCCMM6tXgTIplw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.6.tgz",
+      "integrity": "sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==",
       "cpu": [
         "arm64"
       ],
@@ -1726,10 +1743,24 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.6.tgz",
+      "integrity": "sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.28.0.tgz",
-      "integrity": "sha512-zgWxMq8neVQeXL+ouSf6S7DoNeo6EPgi1eeqHXVKQxqPy1B2NvTbaOUWPn/7CfMKL7xvhV0/+fq/Z/J69g1WAQ==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.6.tgz",
+      "integrity": "sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1741,9 +1772,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.28.0.tgz",
-      "integrity": "sha512-VEdVYacLniRxbRJLNtzwGt5vwS0ycYshofI7cWAfj7Vg5asqj+pt+Q6x4n+AONSZW/kVm+5nklde0qs2EUwU2g==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.6.tgz",
+      "integrity": "sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==",
       "cpu": [
         "riscv64"
       ],
@@ -1755,9 +1786,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.28.0.tgz",
-      "integrity": "sha512-LQlP5t2hcDJh8HV8RELD9/xlYtEzJkm/aWGsauvdO2ulfl3QYRjqrKW+mGAIWP5kdNCBheqqqYIGElSRCaXfpw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.6.tgz",
+      "integrity": "sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==",
       "cpu": [
         "s390x"
       ],
@@ -1769,9 +1800,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.28.0.tgz",
-      "integrity": "sha512-Nl4KIzteVEKE9BdAvYoTkW19pa7LR/RBrT6F1dJCV/3pbjwDcaOq+edkP0LXuJ9kflW/xOK414X78r+K84+msw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.6.tgz",
+      "integrity": "sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==",
       "cpu": [
         "x64"
       ],
@@ -1783,9 +1814,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.28.0.tgz",
-      "integrity": "sha512-eKpJr4vBDOi4goT75MvW+0dXcNUqisK4jvibY9vDdlgLx+yekxSm55StsHbxUsRxSTt3JEQvlr3cGDkzcSP8bw==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.6.tgz",
+      "integrity": "sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==",
       "cpu": [
         "x64"
       ],
@@ -1797,9 +1828,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.28.0.tgz",
-      "integrity": "sha512-Vi+WR62xWGsE/Oj+mD0FNAPY2MEox3cfyG0zLpotZdehPFXwz6lypkGs5y38Jd/NVSbOD02aVad6q6QYF7i8Bg==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.6.tgz",
+      "integrity": "sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==",
       "cpu": [
         "arm64"
       ],
@@ -1811,9 +1842,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.28.0.tgz",
-      "integrity": "sha512-kN/Vpip8emMLn/eOza+4JwqDZBL6MPNpkdaEsgUtW1NYN3DZvZqSQrbKzJcTL6hd8YNmFTn7XGWMwccOcJBL0A==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.6.tgz",
+      "integrity": "sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==",
       "cpu": [
         "ia32"
       ],
@@ -1825,9 +1856,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.28.0.tgz",
-      "integrity": "sha512-Bvno2/aZT6usSa7lRDL2+hMjVAGjuqaymF1ApZm31JXzniR/hvr14jpU+/z4X6Gt5BPlzosscyJZGUvguXIqeQ==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.6.tgz",
+      "integrity": "sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==",
       "cpu": [
         "x64"
       ],
@@ -4884,9 +4915,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
-      "integrity": "sha512-FuLPevChGDshgSicjisSooU0cemp/sGXR841D5LHMB7mTVOmsEHcAxaH3irL53+8YDIeVNQEySh4DaYU/iuPqQ==",
+      "version": "0.24.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.2.tgz",
+      "integrity": "sha512-+9egpBW8I3CD5XPe0n6BfT5fxLzxrlDzqydF3aviG+9ni1lDC/OvMHcxqEFV0+LANZG5R1bFMWfUrjVsdwxJvA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4897,30 +4928,31 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.24.0",
-        "@esbuild/android-arm": "0.24.0",
-        "@esbuild/android-arm64": "0.24.0",
-        "@esbuild/android-x64": "0.24.0",
-        "@esbuild/darwin-arm64": "0.24.0",
-        "@esbuild/darwin-x64": "0.24.0",
-        "@esbuild/freebsd-arm64": "0.24.0",
-        "@esbuild/freebsd-x64": "0.24.0",
-        "@esbuild/linux-arm": "0.24.0",
-        "@esbuild/linux-arm64": "0.24.0",
-        "@esbuild/linux-ia32": "0.24.0",
-        "@esbuild/linux-loong64": "0.24.0",
-        "@esbuild/linux-mips64el": "0.24.0",
-        "@esbuild/linux-ppc64": "0.24.0",
-        "@esbuild/linux-riscv64": "0.24.0",
-        "@esbuild/linux-s390x": "0.24.0",
-        "@esbuild/linux-x64": "0.24.0",
-        "@esbuild/netbsd-x64": "0.24.0",
-        "@esbuild/openbsd-arm64": "0.24.0",
-        "@esbuild/openbsd-x64": "0.24.0",
-        "@esbuild/sunos-x64": "0.24.0",
-        "@esbuild/win32-arm64": "0.24.0",
-        "@esbuild/win32-ia32": "0.24.0",
-        "@esbuild/win32-x64": "0.24.0"
+        "@esbuild/aix-ppc64": "0.24.2",
+        "@esbuild/android-arm": "0.24.2",
+        "@esbuild/android-arm64": "0.24.2",
+        "@esbuild/android-x64": "0.24.2",
+        "@esbuild/darwin-arm64": "0.24.2",
+        "@esbuild/darwin-x64": "0.24.2",
+        "@esbuild/freebsd-arm64": "0.24.2",
+        "@esbuild/freebsd-x64": "0.24.2",
+        "@esbuild/linux-arm": "0.24.2",
+        "@esbuild/linux-arm64": "0.24.2",
+        "@esbuild/linux-ia32": "0.24.2",
+        "@esbuild/linux-loong64": "0.24.2",
+        "@esbuild/linux-mips64el": "0.24.2",
+        "@esbuild/linux-ppc64": "0.24.2",
+        "@esbuild/linux-riscv64": "0.24.2",
+        "@esbuild/linux-s390x": "0.24.2",
+        "@esbuild/linux-x64": "0.24.2",
+        "@esbuild/netbsd-arm64": "0.24.2",
+        "@esbuild/netbsd-x64": "0.24.2",
+        "@esbuild/openbsd-arm64": "0.24.2",
+        "@esbuild/openbsd-x64": "0.24.2",
+        "@esbuild/sunos-x64": "0.24.2",
+        "@esbuild/win32-arm64": "0.24.2",
+        "@esbuild/win32-ia32": "0.24.2",
+        "@esbuild/win32-x64": "0.24.2"
       }
     },
     "node_modules/esbuild-register": {
@@ -7945,9 +7977,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.49",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
-      "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
+      "integrity": "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA==",
       "dev": true,
       "funding": [
         {
@@ -7965,7 +7997,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.7",
+        "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8705,9 +8737,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.28.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.28.0.tgz",
-      "integrity": "sha512-G9GOrmgWHBma4YfCcX8PjH0qhXSdH8B4HDE2o4/jaxj93S4DPCIDoLcXz99eWMji4hB29UFCEd7B2gwGJDR9cQ==",
+      "version": "4.34.6",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.6.tgz",
+      "integrity": "sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -8721,24 +8753,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.28.0",
-        "@rollup/rollup-android-arm64": "4.28.0",
-        "@rollup/rollup-darwin-arm64": "4.28.0",
-        "@rollup/rollup-darwin-x64": "4.28.0",
-        "@rollup/rollup-freebsd-arm64": "4.28.0",
-        "@rollup/rollup-freebsd-x64": "4.28.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.28.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.28.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.28.0",
-        "@rollup/rollup-linux-arm64-musl": "4.28.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.28.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.28.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.28.0",
-        "@rollup/rollup-linux-x64-gnu": "4.28.0",
-        "@rollup/rollup-linux-x64-musl": "4.28.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.28.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.28.0",
-        "@rollup/rollup-win32-x64-msvc": "4.28.0",
+        "@rollup/rollup-android-arm-eabi": "4.34.6",
+        "@rollup/rollup-android-arm64": "4.34.6",
+        "@rollup/rollup-darwin-arm64": "4.34.6",
+        "@rollup/rollup-darwin-x64": "4.34.6",
+        "@rollup/rollup-freebsd-arm64": "4.34.6",
+        "@rollup/rollup-freebsd-x64": "4.34.6",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.34.6",
+        "@rollup/rollup-linux-arm-musleabihf": "4.34.6",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.6",
+        "@rollup/rollup-linux-arm64-musl": "4.34.6",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.34.6",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.6",
+        "@rollup/rollup-linux-riscv64-gnu": "4.34.6",
+        "@rollup/rollup-linux-s390x-gnu": "4.34.6",
+        "@rollup/rollup-linux-x64-gnu": "4.34.6",
+        "@rollup/rollup-linux-x64-musl": "4.34.6",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.6",
+        "@rollup/rollup-win32-ia32-msvc": "4.34.6",
+        "@rollup/rollup-win32-x64-msvc": "4.34.6",
         "fsevents": "~2.3.2"
       }
     },
@@ -10389,15 +10422,15 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.3.tgz",
-      "integrity": "sha512-Cmuo5P0ENTN6HxLSo6IHsjCLn/81Vgrp81oaiFFMRa8gGDj5xEjIcEpf2ZymZtZR8oU0P2JX5WuUp/rlXcHkAw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.1.0.tgz",
+      "integrity": "sha512-RjjMipCKVoR4hVfPY6GQTgveinjNuyLw+qruksLDvA5ktI1150VmcMBKmQaEWJhg/j6Uaf6dNCNA0AfdzUb/hQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "esbuild": "^0.24.0",
-        "postcss": "^8.4.49",
-        "rollup": "^4.23.0"
+        "esbuild": "^0.24.2",
+        "postcss": "^8.5.1",
+        "rollup": "^4.30.1"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -10932,9 +10965,9 @@
       }
     },
     "node_modules/vite-node/node_modules/vite": {
-      "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11554,9 +11587,9 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "5.4.11",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.11.tgz",
-      "integrity": "sha512-c7jFQRklXua0mTzneGW9QVyxFjUgwcihC4bXEtujIo2ouWCe1Ajt/amn2PCxYnhYfd5k09JX3SB7OYWFKYqj8Q==",
+      "version": "5.4.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.14.tgz",
+      "integrity": "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -13,11 +13,20 @@ export async function request<T>(
   data: object | null,
   params: object | null,
 ): Promise<AxiosResponse<T>> {
-  // console.log(`# endpoint = ${endpoint}`);
+  const instance =
+    import.meta.env.MODE !== 'production'
+      ? axios.create({
+          timeout: 10000,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          withCredentials: true,
+        })
+      : axiosInstance;
 
   try {
     // Get response
-    const response: AxiosResponse<T> = await axiosInstance({
+    const response: AxiosResponse<T> = await instance({
       method,
       url: endpoint,
       data: data ? JSON.stringify(data) : null,

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -13,16 +13,7 @@ export async function request<T>(
   data: object | null,
   params: object | null,
 ): Promise<AxiosResponse<T>> {
-  const instance =
-    import.meta.env.MODE !== 'production'
-      ? axios.create({
-          timeout: 10000,
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          withCredentials: true,
-        })
-      : axiosInstance;
+  const instance = axiosInstance;
 
   try {
     // Get response

--- a/src/components/GoogleButton.tsx
+++ b/src/components/GoogleButton.tsx
@@ -1,19 +1,46 @@
 import { ButtonHTMLAttributes } from 'react';
 import { FcGoogle } from 'react-icons/fc';
+import { isEmbeddedWebView } from '../util/validateUserAgent';
+import { MdOutlineErrorOutline } from 'react-icons/md';
 export default function GoogleButton(
   props: ButtonHTMLAttributes<HTMLButtonElement>,
 ) {
+  // Check whether user-agent is acceptable and set background color
+  const isDisabled = isEmbeddedWebView();
+  const bgColor = isDisabled ? 'bg-gray-300' : 'bg-slate-100';
+  const hoverBgColor = isDisabled ? '' : 'hover:bg-slate-200';
+  console.log(isDisabled);
+
   return (
-    <button
-      {...props}
-      className="
+    <div className="flex flex-col items-center space-y-2">
+      {/* Google login button */}
+      <button
+        {...props}
+        className={`
         mx-auto my-4 flex scale-150 transform items-center
         justify-center
-        rounded bg-white  px-2 py-3 text-sm shadow hover:bg-gray-100
-      "
-    >
-      <FcGoogle className="mr-5 h-5 w-5" />
-      <span className="text-black-54 font-semibold">구글 계정으로 로그인</span>
-    </button>
+        rounded-full ${bgColor} px-8 py-2 text-sm shadow-lg ${hoverBgColor}
+      `}
+        disabled={isDisabled}
+      >
+        <div className="flex flex-row items-center">
+          <FcGoogle size={24} className="mr-5" />
+          <span className="font-semibold text-slate-900">
+            Google 계정으로 로그인
+          </span>
+        </div>
+      </button>
+
+      {/* Error message */}
+      {isDisabled && (
+        <div className="flex w-max flex-row items-center space-x-2 text-red-500">
+          <MdOutlineErrorOutline size={20} />
+          <p className="text-sm font-normal">
+            이 브라우저에서는 로그인이 불가능해요. 다른 웹 브라우저로
+            접속해주세요.
+          </p>
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/page/LoginPage/LoginPage.test.tsx
+++ b/src/page/LoginPage/LoginPage.test.tsx
@@ -36,6 +36,6 @@ describe('LoginPage', () => {
     expect(screen.getByText('Debate Timer')).toBeInTheDocument();
 
     // 입력 필드와 버튼 확인
-    expect(screen.getByText('구글 계정으로 로그인')).toBeInTheDocument();
+    expect(screen.getByText('Google 계정으로 로그인')).toBeInTheDocument();
   });
 });

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -215,7 +215,7 @@ export default function TimerPage() {
 
               {/* Timer and timetable */}
               <div
-                className={`z-2 absolute inset-0 ${isMobile ? 'top-[50px]' : ''} flex h-full ${isMobile ? 'flex-col' : 'flex-row'} items-center justify-center ${isMobile ? 'space-y-20' : 'space-x-20'}`}
+                className={`absolute inset-0 ${isMobile ? 'top-[50px]' : ''} flex h-full ${isMobile ? 'flex-col' : 'flex-row'} items-center justify-center ${isMobile ? 'space-y-20' : 'space-x-20'}`}
               >
                 <TimerComponent
                   isRunning={isRunning}

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -327,7 +327,7 @@ export default function TimerPage() {
           )}
 
           <div
-            className={`absolute inset-0 top-[80px] z-0 animate-gradient opacity-80 ${bg}`}
+            className={`absolute inset-0 z-0 animate-gradient opacity-80 ${bg}`}
           ></div>
         </DefaultLayout.ContentContanier>
       </DefaultLayout>

--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -38,8 +38,6 @@ export default function TimerPage() {
 
   // Set states
   const [isFirst, setIsFirst] = useState(false);
-  const [direction, setDirection] = useState('flex-row');
-  const [space, setSpace] = useState('space-x-20');
   const [index, setIndex] = useState(0);
   const [bg, setBg] = useState('');
   const [isWarningBellOn, setWarningBell] = useState(false);
@@ -78,17 +76,6 @@ export default function TimerPage() {
       setIsFirst(storedIsFirst.trim() === 'true' ? true : false);
     }
   }, []);
-
-  // Change direction of row
-  useEffect(() => {
-    if (isMobile) {
-      setDirection('flex-col');
-      setSpace('space-y-20');
-    } else {
-      setDirection('flex-row');
-      setSpace('space-x-20');
-    }
-  }, [isMobile]);
 
   // Change background color
   useEffect(() => {
@@ -228,7 +215,7 @@ export default function TimerPage() {
 
               {/* Timer and timetable */}
               <div
-                className={`z-2 absolute inset-0 ${isMobile ? 'top-[50px]' : ''} flex h-full ${direction} items-center justify-center ${space}`}
+                className={`z-2 absolute inset-0 ${isMobile ? 'top-[50px]' : ''} flex h-full ${isMobile ? 'flex-col' : 'flex-row'} items-center justify-center ${isMobile ? 'space-y-20' : 'space-x-20'}`}
               >
                 <TimerComponent
                   isRunning={isRunning}

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerComponent.tsx
@@ -1,21 +1,9 @@
 import { useEffect, useRef } from 'react';
 import TimerDisplay from '../common/TimerDisplay';
 import AdditionalTimerController from './AdditionalTimerController';
-import AdditionalTimerSummary from './AdditionalTimerSummary';
-import { DebateInfo } from '../../../../type/type';
 import { useTimer } from '../../hooks/useTimer';
 
-interface AdditionalTimerComponentProps {
-  prevItem?: DebateInfo;
-  currItem: DebateInfo;
-  nextItem?: DebateInfo;
-}
-
-export default function AdditionalTimerComponent({
-  prevItem,
-  currItem,
-  nextItem,
-}: AdditionalTimerComponentProps) {
+export default function AdditionalTimerComponent() {
   // Load sounds
   const dingOnceRef = useRef<HTMLAudioElement>(null);
   const dingTwiceRef = useRef<HTMLAudioElement>(null);
@@ -32,11 +20,12 @@ export default function AdditionalTimerComponent({
     });
 
     actOnTime(0, () => {
+      pauseTimer();
       if (dingTwiceRef.current && isRunning) {
         dingTwiceRef.current.play();
       }
     });
-  }, [actOnTime, isRunning]);
+  }, [actOnTime, isRunning, pauseTimer]);
 
   return (
     <div className="flex flex-col items-center space-y-12 px-12 pb-8">
@@ -55,11 +44,6 @@ export default function AdditionalTimerComponent({
         onStart={() => {
           if (timer > 0) startTimer();
         }}
-      />
-      <AdditionalTimerSummary
-        prevItem={prevItem}
-        currItem={currItem}
-        nextItem={nextItem}
       />
     </div>
   );

--- a/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerController.tsx
+++ b/src/page/TimerPage/components/AdditionalTimer/AdditionalTimerController.tsx
@@ -24,9 +24,9 @@ export default function AdditionalTimerController({
           <TimerIconButton
             icon={<IoPauseOutline size={iconSize} />}
             style={{
-              bgColor: 'bg-amber-500',
-              hoverColor: 'hover:bg-amber-600',
-              contentColor: 'text-zinc-50',
+              bgColor: 'bg-slate-200',
+              hoverColor: 'hover:bg-slate-400',
+              contentColor: 'text-slate-900',
             }}
             onClick={() => {
               onPause();
@@ -38,9 +38,9 @@ export default function AdditionalTimerController({
           <TimerIconButton
             icon={<IoPlayOutline size={iconSize} />}
             style={{
-              bgColor: 'bg-emerald-500',
-              hoverColor: 'hover:bg-emerald-600',
-              contentColor: 'text-zinc-50',
+              bgColor: 'bg-slate-200',
+              hoverColor: 'hover:bg-slate-400',
+              contentColor: 'text-slate-900',
             }}
             onClick={() => {
               onStart();

--- a/src/page/TimerPage/components/Timer/TimeTableItem.tsx
+++ b/src/page/TimerPage/components/Timer/TimeTableItem.tsx
@@ -1,0 +1,53 @@
+import {
+  DebateInfo,
+  DebateTypeToString,
+  StanceToString,
+} from '../../../../type/type';
+
+interface TimeTableItemProps {
+  item: DebateInfo;
+  isCurrent: boolean;
+}
+
+export default function TimeTableItem({ item, isCurrent }: TimeTableItemProps) {
+  const titleText =
+    item.type !== 'TIME_OUT'
+      ? `${StanceToString[item.stance]} ${DebateTypeToString[item.type]}`
+      : DebateTypeToString[item.type];
+  const speakerText =
+    item.stance === 'NEUTRAL' ? '' : `${item.speakerNumber}번 발언자`;
+  let timeText: string;
+  const bgStyle = isCurrent ? 'animate-color-transition' : 'bg-slate-200';
+  const fontStyle = isCurrent ? 'text-slate-50' : 'text-slate-900';
+  const weightStyle = isCurrent ? 'font-bold' : 'font-base';
+  if (item.time < 60) {
+    timeText = `${item.time % 60}초`;
+  } else {
+    if (item.time % 60 === 0) {
+      timeText = `${Math.floor(item.time / 60)}분`;
+    } else {
+      timeText = `${Math.floor(item.time / 60)}분 ${item.time % 60}초`;
+    }
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-lg items-center justify-center">
+      <div className="relative z-10 flex w-full items-center overflow-hidden rounded-xl bg-slate-50 p-[2.5px]">
+        {isCurrent && (
+          <div className="absolute inset-0 h-full w-full animate-rotate rounded-full bg-[conic-gradient(theme(colors.red.500)_20deg,transparent_120deg)]"></div>
+        )}
+        <div
+          className={`relative z-20 flex w-full ${bgStyle} rounded-[0.60rem] px-8 py-2`}
+        >
+          <div
+            className={`${weightStyle} flex flex-row items-center justify-between text-lg ${fontStyle}`}
+          >
+            <p className="w-32 text-center">{titleText}</p>
+            <p className="w-32 text-center">{speakerText}</p>
+            <p className="w-32 text-center">{timeText}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/page/TimerPage/components/Timer/TimerComponent.tsx
+++ b/src/page/TimerPage/components/Timer/TimerComponent.tsx
@@ -1,3 +1,4 @@
+import useMobile from '../../../../hooks/useMobile';
 import {
   DebateInfo,
   DebateTypeToString,
@@ -15,6 +16,10 @@ interface TimerComponentProps {
   pauseTimer: () => void;
   resetTimer: () => void;
   onOpenModal: () => void;
+  isWarningBellOn: boolean;
+  isFinishBellOn: boolean;
+  onChangeWarningBell: () => void;
+  onChangeFinishBell: () => void;
 }
 
 // Main timer component that user can control
@@ -26,6 +31,10 @@ export default function TimerComponent({
   pauseTimer,
   resetTimer,
   onOpenModal,
+  isWarningBellOn,
+  isFinishBellOn,
+  onChangeWarningBell,
+  onChangeFinishBell,
 }: TimerComponentProps) {
   // Set texts to be displayed
   const titleText =
@@ -45,6 +54,8 @@ export default function TimerComponent({
         ? 'bg-blue-500'
         : 'bg-red-500';
 
+  const isMobile = useMobile();
+
   // Return React component
   return (
     <div
@@ -52,10 +63,14 @@ export default function TimerComponent({
     >
       {/* Title */}
       <div className="m-2 mb-8 flex flex-col items-center space-y-3">
-        <h1 className="text-6xl font-bold text-zinc-50">{titleText}</h1>
+        <h1 className="text-5xl font-bold text-zinc-50 md:text-6xl">
+          {titleText}
+        </h1>
         <div className="flex flex-row items-center space-x-3 text-zinc-50">
-          {debateInfo.stance !== 'NEUTRAL' && <IoPerson size={25} />}
-          <h1 className="text-3xl">{speakerText}</h1>
+          {debateInfo.stance !== 'NEUTRAL' && (
+            <IoPerson size={isMobile ? 15 : 25} />
+          )}
+          <h1 className="text-2xl md:text-3xl">{speakerText}</h1>
         </div>
       </div>
 
@@ -69,6 +84,10 @@ export default function TimerComponent({
         onStart={startTimer}
         onPause={pauseTimer}
         onOpenModal={onOpenModal}
+        isWarningBellOn={isWarningBellOn}
+        isFinishBellOn={isFinishBellOn}
+        onChangeWarningBell={() => onChangeWarningBell()}
+        onChangeFinishBell={() => onChangeFinishBell()}
       />
     </div>
   );

--- a/src/page/TimerPage/components/Timer/TimerController.tsx
+++ b/src/page/TimerPage/components/Timer/TimerController.tsx
@@ -1,6 +1,7 @@
 import { LuRefreshCcw } from 'react-icons/lu';
 import TimerIconButton from '../common/TimerIconButton';
 import { IoPauseOutline, IoPlayOutline } from 'react-icons/io5';
+import useMobile from '../../../../hooks/useMobile';
 
 interface TimerControllerProps {
   isRunning: boolean;
@@ -8,9 +9,11 @@ interface TimerControllerProps {
   onStart: () => void;
   onReset: () => void;
   onOpenModal: () => void;
+  isWarningBellOn: boolean;
+  isFinishBellOn: boolean;
+  onChangeWarningBell: () => void;
+  onChangeFinishBell: () => void;
 }
-
-const iconSize = 40;
 
 export default function TimerController({
   isRunning,
@@ -18,17 +21,23 @@ export default function TimerController({
   onStart,
   onReset,
   onOpenModal,
+  isWarningBellOn,
+  isFinishBellOn,
+  onChangeWarningBell,
+  onChangeFinishBell,
 }: TimerControllerProps) {
+  const isMobile = useMobile();
+
   return (
-    <div className="flex flex-row items-center space-x-8">
+    <div className="flex flex-row items-center space-x-4 md:space-x-8">
       {/* Timer start button */}
       {isRunning && (
         <TimerIconButton
-          icon={<IoPauseOutline size={iconSize} />}
+          icon={<IoPauseOutline size={isMobile ? 20 : 40} />}
           style={{
-            bgColor: 'bg-amber-500',
-            hoverColor: 'hover:bg-amber-600',
-            contentColor: 'text-zinc-50',
+            bgColor: 'bg-slate-50',
+            hoverColor: 'hover:bg-slate-300',
+            contentColor: 'text-slate-900',
           }}
           onClick={() => {
             onPause();
@@ -39,11 +48,11 @@ export default function TimerController({
       {/* Timer pause button */}
       {!isRunning && (
         <TimerIconButton
-          icon={<IoPlayOutline size={iconSize} />}
+          icon={<IoPlayOutline size={isMobile ? 20 : 40} />}
           style={{
-            bgColor: 'bg-emerald-500',
-            hoverColor: 'hover:bg-emerald-600',
-            contentColor: 'text-zinc-50',
+            bgColor: 'bg-slate-50',
+            hoverColor: 'hover:bg-slate-300',
+            contentColor: 'text-slate-900',
           }}
           onClick={() => {
             onStart();
@@ -53,27 +62,47 @@ export default function TimerController({
 
       {/* Timer reset button */}
       <TimerIconButton
-        icon={<LuRefreshCcw size={iconSize} />}
+        icon={<LuRefreshCcw size={isMobile ? 20 : 40} />}
         style={{
-          bgColor: 'bg-red-500',
-          hoverColor: 'hover:bg-red-600',
-          contentColor: 'text-zinc-50',
+          bgColor: 'bg-slate-50',
+          hoverColor: 'hover:bg-slate-300',
+          contentColor: 'text-slate-900',
         }}
         onClick={() => {
           onReset();
         }}
       />
 
-      {/*Additional discussion time button*/}
+      {/* Additional discussion time button */}
       <button
-        className="rounded-full border-2 border-zinc-50 bg-zinc-200 px-8 py-4 hover:bg-zinc-300"
+        className="rounded-full border-2 border-zinc-50 bg-zinc-200 px-8 py-3 hover:bg-zinc-300"
         onClick={() => {
           console.log('# Additional discussion time button clicked');
           onOpenModal();
         }}
       >
-        <h1 className="text-2xl font-bold">작전 시간 사용</h1>
+        <h1 className="w-max text-xl font-bold md:text-2xl">작전 시간 사용</h1>
       </button>
+
+      {/* Sound on/off checkboxes */}
+      <div className="flex flex-col space-y-2">
+        <div className="flex flex-row space-x-2 rounded-full border-2 border-slate-50 bg-slate-200 px-4 py-2">
+          <input
+            type="checkbox"
+            checked={isWarningBellOn}
+            onChange={() => onChangeWarningBell()}
+          />
+          <p className="w-max font-semibold">30초 경고</p>
+        </div>
+        <div className="flex flex-row space-x-2 rounded-full border-2 border-slate-50 bg-slate-200 px-4 py-2">
+          <input
+            type="checkbox"
+            checked={isFinishBellOn}
+            onChange={() => onChangeFinishBell()}
+          />
+          <p className="w-max font-semibold">0초 경고</p>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/page/TimerPage/components/Timer/TimerTimeTable.tsx
+++ b/src/page/TimerPage/components/Timer/TimerTimeTable.tsx
@@ -1,0 +1,43 @@
+import { IoArrowBack, IoArrowForward } from 'react-icons/io5';
+import { DebateInfo } from '../../../../type/type';
+import TimeTableItem from './TimeTableItem';
+
+interface TimerTimeTableProps {
+  currIndex: number;
+  tables: DebateInfo[];
+  moveToOtherItem: (goToPrev: boolean) => void;
+}
+
+export default function TimerTimeTable({
+  currIndex,
+  tables,
+  moveToOtherItem,
+}: TimerTimeTableProps) {
+  return (
+    <div className="flex flex-col items-center space-y-3">
+      {tables.map((value, index) => (
+        <TimeTableItem
+          key={index}
+          isCurrent={currIndex === index}
+          item={value}
+        />
+      ))}
+
+      <div className="flex flex-row space-x-4 pt-5">
+        <button onClick={() => moveToOtherItem(true)}>
+          <div className="flex flex-row items-center space-x-2 rounded-full border-2 border-slate-50 bg-slate-200 px-6 py-3 hover:bg-slate-400">
+            <IoArrowBack size={24} />
+            <h1 className="font-bold">이전 차례</h1>
+          </div>
+        </button>
+
+        <button onClick={() => moveToOtherItem(false)}>
+          <div className="flex flex-row items-center space-x-2 rounded-full border-2 border-slate-50 bg-slate-200 px-6 py-3 hover:bg-slate-400">
+            <h1 className="font-bold">다음 차례</h1>
+            <IoArrowForward size={24} />
+          </div>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/page/TimerPage/components/common/FirstUseToolTip.tsx
+++ b/src/page/TimerPage/components/common/FirstUseToolTip.tsx
@@ -30,7 +30,7 @@ export default function FirstUseToolTip({ onClose }: FirstUseToolTipProps) {
 function FirstUseToolTipBackground({ height }: FirstUseToolTipBackgroundProps) {
   return (
     <div
-      className="absolute inset-0 z-10 rounded-2xl bg-slate-900 opacity-80"
+      className="absolute inset-0 z-30 rounded-2xl bg-slate-900 opacity-80"
       style={{ height }}
     ></div>
   );
@@ -49,7 +49,7 @@ function FirstUseToolTipContent({
   }, [ref, setHeight]);
 
   return (
-    <div className="relative z-20 flex flex-col space-y-6 p-6">
+    <div className="relative z-40 flex flex-col space-y-6 p-6">
       <div className="flex flex-col text-slate-50">
         <div className="mb-2 flex flex-row items-center space-x-4">
           <MdOutlineTimer size={18} />

--- a/src/page/TimerPage/components/common/HeaderButtons.tsx
+++ b/src/page/TimerPage/components/common/HeaderButtons.tsx
@@ -1,0 +1,38 @@
+import { IoMdHome } from 'react-icons/io';
+import { IoHelpCircle, IoLogOut } from 'react-icons/io5';
+
+interface HeaderButtonsProps {
+  onClickHome: () => void;
+  onClickHelp: () => void;
+  onClickLogout: () => void;
+}
+
+export default function HeaderButtons({
+  onClickHome,
+  onClickHelp,
+  onClickLogout,
+}: HeaderButtonsProps) {
+  return (
+    <div className="flex flex-row justify-end space-x-2">
+      <button
+        onClick={() => onClickHome()}
+        className="rounded-full bg-slate-300 px-2 py-2 font-bold text-zinc-900 hover:bg-zinc-400"
+      >
+        <IoMdHome size={24} />
+      </button>
+
+      <button
+        onClick={() => onClickHelp()}
+        className="rounded-full bg-slate-300 px-2 py-2 font-bold text-zinc-900 hover:bg-zinc-400"
+      >
+        <IoHelpCircle size={24} />
+      </button>
+      <button
+        onClick={() => onClickLogout()}
+        className="rounded-full bg-slate-300 px-2 py-2 font-bold text-zinc-900 hover:bg-zinc-400"
+      >
+        <IoLogOut size={24} />
+      </button>
+    </div>
+  );
+}

--- a/src/page/TimerPage/components/common/TimerDisplay.tsx
+++ b/src/page/TimerPage/components/common/TimerDisplay.tsx
@@ -1,3 +1,4 @@
+import useMobile from '../../../../hooks/useMobile';
 import { Formatting } from '../../../../util/formatting';
 
 interface TimerProps {
@@ -6,27 +7,32 @@ interface TimerProps {
 }
 export default function TimerDisplay({ bg, timer }: TimerProps) {
   const bgText = bg === undefined ? 'bg-zinc-100' : bg;
+  const isMobile = useMobile();
 
   return (
     <div
       className={`mb-12 flex flex-row items-center justify-center space-x-4 rounded-[50px] ${bgText} p-8`}
     >
       {/* Prints -(minus) if remaining time is negative */}
-      {timer < 0 && <h1 className="py-2 text-9xl font-bold">-</h1>}
+      {timer < 0 && <h1 className="py-2 text-8xl font-bold">-</h1>}
 
       {/* Minutes */}
-      <div className="flex w-[240px] justify-center rounded-[50px] bg-zinc-200 py-4">
-        <h1 className="text-9xl font-bold">
+      <div
+        className={`flex ${isMobile ? 'w-[144px]' : 'w-[200px]'} justify-center rounded-[50px] bg-slate-200 py-4`}
+      >
+        <h1 className="text-7xl font-bold md:text-9xl">
           {Formatting.formatTwoDigits(Math.floor(Math.abs(timer) / 60))}
         </h1>
       </div>
 
       {/* Colon */}
-      <h1 className="py-2 text-8xl">:</h1>
+      <h1 className="py-2 text-6xl md:text-8xl">:</h1>
 
       {/* Seconds */}
-      <div className="flex w-[240px] justify-center rounded-[50px] bg-zinc-200 py-4">
-        <h1 className="text-9xl font-bold">
+      <div
+        className={`flex ${isMobile ? 'w-[144px]' : 'w-[200px]'} justify-center rounded-[50px] bg-slate-200 py-4`}
+      >
+        <h1 className="text-7xl font-bold md:text-9xl">
           {Formatting.formatTwoDigits(Math.abs(timer % 60))}
         </h1>
       </div>

--- a/src/page/TimerPage/components/common/TimerTextButton.tsx
+++ b/src/page/TimerPage/components/common/TimerTextButton.tsx
@@ -10,7 +10,7 @@ export default function TimerTextButton({
   return (
     <button
       onClick={onClick}
-      className="rounded-full bg-zinc-200 px-6 py-2 text-lg font-bold text-zinc-900 hover:bg-zinc-400"
+      className="rounded-full bg-slate-200 px-6 py-2 text-lg font-bold text-slate-900 hover:bg-zinc-400"
     >
       {name}
     </button>

--- a/src/util/validateUserAgent.ts
+++ b/src/util/validateUserAgent.ts
@@ -1,0 +1,8 @@
+export const isEmbeddedWebView = (): boolean => {
+  const userAgent = navigator.userAgent.toLowerCase();
+  // console.log(userAgent);
+
+  return /fban|fbav|instagram|kakaotalk|line|wechat|snapchat|twitter/i.test(
+    userAgent,
+  );
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,6 +4,10 @@ export default {
   theme: {
     extend: {
       keyframes: {
+        rotate: {
+          '0%': { transform: 'rotate(0deg) scale(10)' },
+          '100%': { transform: 'rotate(-360deg) scale(10)' },
+        },
         gradient: {
           '0%, 100%': {
             'background-size': '300% 300%',
@@ -18,9 +22,19 @@ export default {
             'background-position': 'right center',
           },
         },
+        colorTransition: {
+          '0%, 100%': {
+            backgroundColor: '#ffa2a2',
+          },
+          '50%': {
+            backgroundColor: '#ff6467',
+          },
+        },
       },
       animation: {
+        rotate: 'rotate 5s linear infinite',
         gradient: 'gradient 10s ease infinite',
+        'color-transition': 'colorTransition 5s ease-in-out infinite',
       },
       fontFamily: {
         pretendard: [


### PR DESCRIPTION
# 🚩 연관 이슈
closed #121 

# 📝 작업 내용
## 요약
### 타이머 관련
- 불완전한 반응형 레이아웃 적용
- 임시 토론 시간표 추가 및 이에 따른 이전 차례 요약과 다음 차례 요약 제거
- 30s, 0s 효과음 켜고 끌 수 있는 체크박스 추가

### 그 외
- 사용자의 User Agent 확인하여 일부 웹 뷰 환경에서 로그인 버튼 비활성화
- Google 로그인 버튼 디자인 일부 개선
- PR이 병합되지 않은 채로 닫혀도 배포가 진행되는 문제 수정

## 타이머 관련 변경사항 세부 설명
### 불완전한 반응형 레이아웃 적용
![image](https://github.com/user-attachments/assets/f0d07bf7-0116-459f-a6ec-bbaa5ff976e3)

말 그대로 불완전한 수준의 반응형 레이아웃을 적용했습니다. 이 말은, 여전히 모바일 환경에서는 사용하기 어려울 수 있으나, PC 웹 브라우저 환경에서는 가로 폭을 어느정도 줄여도 대응이 가능하다는 말입니다. 이를 위해 반영한 변경 사항은 간단하게는 아래과 같습니다:
- 모바일 환경에서 텍스트 크기 감소
- 모바일 환경에서 아이콘 크기 감소
- 모바일 환경에서 일부 컴포넌트의 가로 너비 감소
- 모바일 환경에서 타이머와 시간표가 세로로 정렬됨 (웹 환경에서는 가로로 정렬)

### 임시 토론 시간표 추가 및 이에 따른 이전 차례 요약과 다음 차례 요약 제거
![image](https://github.com/user-attachments/assets/02d2aff6-08a1-4430-bb91-3eef25bddd93)

진지하게 논의가 진행되었던 토론 시간표를 화면 우측에 추가했습니다. 원래는 계획에 없었으나, 모킹 기능이 제대로 작동하지 않고 무한 렌더링에 걸려 이 문제를 해결하고자 TimerPage를 싹 갈아 엎다가 그냥 하는 김에 추가했어요. 일단은 간단하게 디자인하였으니, 본격적으로 목업이 나오면 그에 맞추어 다시 수정 진행할게요. 기능 세부 설명은 아래와 같습니다:
- 전체 토론 순서를 시간표에 위부터 순서대로 표시
- 현재 토론 순서는 빨간 색의 움직이는 테두리와 그라데이션 배경으로 강조됨
- 그 외 토론 순서는 회색으로 강조되지 않음
- 토론 시간표 아래의 이전 차례, 다음 차례 버튼으로 토론 순서를 바꿀 수 있음

### 30s, 0s 효과음 켜고 끌 수 있는 체크박스 추가
![image](https://github.com/user-attachments/assets/e1a9a6a1-6fba-4c42-a5ed-8a953b9231a0)

30초 효과음과 0초 효과음을 끌 수 있는 체크박스를 추가했습니다. 기능 세부 설명은 아래와 같습니다:
- 30초 효과음과 0초 효과음을 각각 따로 켜고 끌 수 있는 체크박스 추가
- 이 설정은 서버에서 불러오는 정보이기 때문에, 타이머 사용 중에는 켜고 끈 설정이 유지되나, 사용자가 뒤로 갔다가 다시 돌아오면 서버 설정으로 복원됨
- 따라서 로컬 저장소에 정보를 저장하지 않는 식으로 구현함\

### 그 외 타이머 변경 사항
- 다수 색상이 혼란스럽다는 피드백에 따라 버튼 색상 일괄 무색으로 조정
- 동일한 이유로 추가 작전 시간 타이머의 버튼 색상도 일괄 무색으로 조정
- 추가 작전 시간 타이머의 이전, 현재, 이후 차례 요약을 삭제
- 헤더 왼쪽의 버튼에 아이콘만 표시되도록 모든 텍스트를 제거

## 그 외 변경사항 설명
### 사용자의 User Agent 확인하여 일부 웹 뷰 환경에서 로그인 버튼 비활성화
![image](https://github.com/user-attachments/assets/76530fb7-33cf-4327-8cca-14e522a30e21)

```ts
export const isEmbeddedWebView = (): boolean => {
  const userAgent = navigator.userAgent.toLowerCase();
  // console.log(userAgent);

  return /fban|fbav|instagram|kakaotalk|line|wechat|snapchat|twitter/i.test(
    userAgent,
  );
};
```

Discord에서 공유드렸던 대로, Instagram 등 일부 메이저 웹 브라우저가 아닌 앱 내부 웹 뷰에서의 Google OAuth 로그인이 불가능한 문제가 확인되었습니다. 이에, FE 측에서 선제적으로 User Agent를 확인한 후 문제가 되는 웹 뷰는 사전에 로그인 버튼을 비활성화하여 불쾌한 사용자 경험을 사전에 차단하였습니다.

### Google 로그인 버튼 디자인 일부 개선
![image](https://github.com/user-attachments/assets/998d7ce3-2c0c-4cd1-b8a3-1d27667bf387)

보시는 바와 같습니다.

### PR이 병합되지 않은 채로 닫혀도 배포가 진행되는 문제 수정
저번에 병합 충돌 관련 문제를 해결하다가, PR이 병합되지 않았는데도 닫히기만 하면 배포가 진행되는 문제가 발생하였습니다. 이에, GitHub Actions 스크립트에 병합 여부를 판단하는 조건문을 추가하여 이를 방지하도록 개선했습니다.

## 🗣️ 리뷰 요구사항 (선택)
별도 없음
