### PR TITLE
[REFACTOR] 헤더 UI를 공통화 

### DIFF
--- a/src/components/HeaderTableInfo/HeaderTableInfo.tsx
+++ b/src/components/HeaderTableInfo/HeaderTableInfo.tsx
@@ -1,13 +1,17 @@
+import { typeMapping } from '../../constants/languageMapping';
+import { Type } from '../../type/type';
+
 interface HeaderTitleProps {
   name?: string;
+  type: Type;
 }
 
 export default function HeaderTableInfo(props: HeaderTitleProps) {
-  const { name } = props;
+  const { name, type } = props;
   const displayName = !name?.trim() ? '테이블 이름 없음' : name.trim();
   return (
     <div className="flex flex-col space-y-[4px]">
-      <h1 className="text-sm">의회식</h1>
+      <h1 className="text-sm">{typeMapping[type]}</h1>
       <h1 className="text-2xl font-bold">{displayName}</h1>
     </div>
   );

--- a/src/components/HeaderTableInfo/HeaderTableInfo.tsx
+++ b/src/components/HeaderTableInfo/HeaderTableInfo.tsx
@@ -1,0 +1,15 @@
+interface HeaderTitleProps {
+  name: string | undefined;
+}
+
+export default function HeaderTableInfo(props: HeaderTitleProps) {
+  const { name } = props;
+  const displayName =
+    name === undefined || name.trim() === '' ? '테이블 이름 없음' : name;
+  return (
+    <div className="flex flex-col space-y-[4px]">
+      <h1 className="text-sm">의회식</h1>
+      <h1 className="text-2xl font-bold">{displayName}</h1>
+    </div>
+  );
+}

--- a/src/components/HeaderTableInfo/HeaderTableInfo.tsx
+++ b/src/components/HeaderTableInfo/HeaderTableInfo.tsx
@@ -1,11 +1,10 @@
 interface HeaderTitleProps {
-  name: string | undefined;
+  name?: string;
 }
 
 export default function HeaderTableInfo(props: HeaderTitleProps) {
   const { name } = props;
-  const displayName =
-    name === undefined || name.trim() === '' ? '테이블 이름 없음' : name;
+  const displayName = !name?.trim() ? '테이블 이름 없음' : name.trim();
   return (
     <div className="flex flex-col space-y-[4px]">
       <h1 className="text-sm">의회식</h1>

--- a/src/components/HeaderTitle/HeaderTitle.tsx
+++ b/src/components/HeaderTitle/HeaderTitle.tsx
@@ -1,10 +1,13 @@
 interface HeaderTitleProps {
-  title: string | undefined;
+  title?: string;
 }
 
-export default function HeaderTitle(props: HeaderTitleProps) {
-  const { title } = props;
-  const displayTitle =
-    title === undefined || title.trim() === '' ? '주제 없음' : title;
-  return <h1 className="text-3xl font-bold">{displayTitle}</h1>;
+export default function HeaderTitle({ title }: HeaderTitleProps) {
+  const displayTitle = !title?.trim() ? '주제 없음' : title.trim();
+
+  return (
+    <h1 className="w-full max-w-[50vw] overflow-hidden text-ellipsis whitespace-nowrap text-3xl font-bold">
+      {displayTitle}
+    </h1>
+  );
 }

--- a/src/components/HeaderTitle/HeaderTitle.tsx
+++ b/src/components/HeaderTitle/HeaderTitle.tsx
@@ -1,0 +1,10 @@
+interface HeaderTitleProps {
+  title: string | undefined;
+}
+
+export default function HeaderTitle(props: HeaderTitleProps) {
+  const { title } = props;
+  const displayTitle =
+    title === undefined || title.trim() === '' ? '주제 없음' : title;
+  return <h1 className="text-3xl font-bold">{displayTitle}</h1>;
+}

--- a/src/components/IconButton/IconButton.tsx
+++ b/src/components/IconButton/IconButton.tsx
@@ -1,0 +1,16 @@
+import { ButtonHTMLAttributes, ReactNode } from 'react';
+
+interface IconButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  icon: ReactNode;
+}
+
+export default function IconButton({ icon, ...props }: IconButtonProps) {
+  return (
+    <button
+      className="rounded-full bg-background-default px-2 py-2 font-bold text-neutral-900 hover:bg-neutral-300"
+      {...props}
+    >
+      {icon}
+    </button>
+  );
+}

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -1,10 +1,15 @@
 import { PropsWithChildren } from 'react';
+import { IoMdHome } from 'react-icons/io';
+import { useNavigate } from 'react-router-dom';
+import useLogout from '../../../hooks/mutations/useLogout';
+import { IoLogOut } from 'react-icons/io5';
+import IconButton from '../../../components/IconButton/IconButton';
 
 function StickyTriSectionHeader(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <header className="sticky top-0 min-h-20 bg-slate-200 px-6">
+    <header className="sticky top-0 min-h-20 border-b-[1px] border-neutral-900 bg-background-default px-6">
       <div className="relative flex h-full items-center justify-between">
         {children}
       </div>
@@ -22,11 +27,50 @@ StickyTriSectionHeader.Center = function Center(props: PropsWithChildren) {
   return <div className="flex-1 items-center text-center">{children}</div>;
 };
 
-StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
-  const { children } = props;
+interface RightProps extends PropsWithChildren {
+  defaultIcons?: ('home' | 'logout')[];
+}
+
+StickyTriSectionHeader.Right = function Right({
+  children,
+  defaultIcons,
+}: RightProps) {
+  const navigate = useNavigate();
+  const { mutate: logoutMutate } = useLogout(() => navigate('/login'));
+
   return (
-    <div className="flex flex-1 items-end justify-end gap-1 text-right">
-      {children}
+    <div className="flex flex-1  items-stretch justify-end gap-2 text-right">
+      {children && (
+        <>
+          {children}
+          <div className="w-[1px] self-stretch bg-neutral-500" />
+        </>
+      )}
+
+      {defaultIcons?.map((iconName, index) => {
+        switch (iconName) {
+          case 'home':
+            return (
+              <div key={`${iconName}-${index}`}>
+                <IconButton
+                  icon={<IoMdHome size={24} />}
+                  onClick={() => navigate('/')}
+                />
+              </div>
+            );
+          case 'logout':
+            return (
+              <div key={`${iconName}-${index}`}>
+                <IconButton
+                  icon={<IoLogOut size={24} />}
+                  onClick={() => logoutMutate()}
+                />
+              </div>
+            );
+          default:
+            return null;
+        }
+      })}
     </div>
   );
 };

--- a/src/page/TableComposition/TableComposition.test.tsx
+++ b/src/page/TableComposition/TableComposition.test.tsx
@@ -90,7 +90,7 @@ describe('TableComposition', () => {
 
     // TimeBoxStep 컴포넌트가 표시된다고 가정
     // 예: TimeBoxStep에 data-testid="time-box-step"가 있다면:
-    expect(screen.getByText('토론 주제')).toBeInTheDocument();
+    expect(screen.getByText('주제 없음')).toBeInTheDocument();
   });
 
   it('타임박스 단계에서 "완료" 버튼 클릭 시, overview 페이지로 이동한다 (mode=add)', async () => {
@@ -105,7 +105,7 @@ describe('TableComposition', () => {
     await userEvent.click(nextButton);
 
     // 3. TimeBoxStep 노출 확인
-    expect(screen.getByText('토론 주제')).toBeInTheDocument();
+    expect(screen.getByText('주제 없음')).toBeInTheDocument();
 
     // 4. "완료" (혹은 "제출") 버튼 클릭
     const submitButton = screen.getByText('테이블 추가하기');

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -1,9 +1,6 @@
-import { IoMdHome } from 'react-icons/io';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import { Type } from '../../../../type/type';
 import DropdownForDebateType from '../DropdownForDebateType/DropdownForDebateType';
-import useLogout from '../../../../hooks/mutations/useLogout';
-import { useNavigate } from 'react-router-dom';
 
 interface TableNameAndTypeProps {
   info: {
@@ -25,8 +22,6 @@ interface TableNameAndTypeProps {
 }
 
 export default function TableNameAndType(props: TableNameAndTypeProps) {
-  const { mutate: logoutMutate } = useLogout(() => navigate('/login'));
-  const navigate = useNavigate();
   const { info, isEdit = false, onInfoChange, onButtonClick } = props;
 
   const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -75,27 +70,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
             </h1>
           </div>
         </DefaultLayout.Header.Center>
-        <DefaultLayout.Header.Right>
-          <button
-            onClick={() => {
-              navigate('/');
-            }}
-            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
-          >
-            <div className="flex flex-row items-center space-x-4">
-              <IoMdHome size={24} />
-              <h1>홈 화면</h1>
-            </div>
-          </button>
-          <button
-            onClick={() => logoutMutate()}
-            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
-          >
-            <div className="flex flex-row items-center space-x-4">
-              <h2>로그아웃</h2>
-            </div>
-          </button>
-        </DefaultLayout.Header.Right>
+        <DefaultLayout.Header.Right defaultIcons={['home', 'logout']} />
       </DefaultLayout.Header>
       <DefaultLayout.ContentContanier>
         <section className="grid w-full grid-cols-[1fr_2fr] gap-10 p-8">

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -57,7 +57,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
     <DefaultLayout>
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
-          <HeaderTableInfo name={initData.info.name} />
+          <HeaderTableInfo name={initData.info.name} type={'PARLIAMENTARY'} />
         </DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center>
           <HeaderTitle title={initData.info.agenda} />

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -7,9 +7,8 @@ import { useDragAndDrop } from '../../../../hooks/useDragAndDrop';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import PropsAndConsTitle from '../../../../components/ProsAndConsTitle/PropsAndConsTitle';
 import { TableFormData } from '../../hook/useTableFrom';
-import { IoMdHome } from 'react-icons/io';
-import useLogout from '../../../../hooks/mutations/useLogout';
-import { useNavigate } from 'react-router-dom';
+import HeaderTableInfo from '../../../../components/HeaderTableInfo/HeaderTableInfo';
+import HeaderTitle from '../../../../components/HeaderTitle/HeaderTitle';
 
 interface TimeBoxStepProps {
   initData: TableFormData;
@@ -19,9 +18,6 @@ interface TimeBoxStepProps {
 }
 export default function TimeBoxStep(props: TimeBoxStepProps) {
   const { initData, onTimeBoxChange, onButtonClick, isEdit = false } = props;
-  const { mutate: logoutMutate } = useLogout(() => navigate('/login'));
-
-  const navigate = useNavigate();
   const initTimeBox = initData.table;
   const {
     openModal: ProsOpenModal,
@@ -61,47 +57,12 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
     <DefaultLayout>
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
-          <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
-            <h1 className="mr-2">
-              {initData === undefined || initData!.info.name.trim() === ''
-                ? '테이블 이름 없음'
-                : initData!.info.name}
-            </h1>
-            <div className="mx-3 h-6 w-[2px] bg-black"></div>
-            <span className="text-lg font-normal md:text-xl">의회식</span>
-          </div>
+          <HeaderTableInfo name={initData.info.name} />
         </DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center>
-          <div className="flex flex-col items-center">
-            <h1 className="text-m md:text-lg">토론 주제</h1>
-            <h1 className="max-w-md truncate text-xl font-bold md:text-2xl">
-              {initData === undefined || initData.info.agenda.trim() === ''
-                ? '주제 없음'
-                : initData.info.agenda}
-            </h1>
-          </div>
+          <HeaderTitle title={initData.info.agenda} />
         </DefaultLayout.Header.Center>
-        <DefaultLayout.Header.Right>
-          <button
-            onClick={() => {
-              navigate('/');
-            }}
-            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
-          >
-            <div className="flex flex-row items-center space-x-4">
-              <IoMdHome size={24} />
-              <h1>홈 화면</h1>
-            </div>
-          </button>
-          <button
-            onClick={() => logoutMutate()}
-            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
-          >
-            <div className="flex flex-row items-center space-x-4">
-              <h2>로그아웃</h2>
-            </div>
-          </button>
-        </DefaultLayout.Header.Right>
+        <DefaultLayout.Header.Right defaultIcons={['home', 'logout']} />
       </DefaultLayout.Header>
 
       <DefaultLayout.ContentContanier>

--- a/src/page/TableListPage/TableListPage.tsx
+++ b/src/page/TableListPage/TableListPage.tsx
@@ -4,15 +4,11 @@ import AddTable from './components/Table/AddTable';
 import Table from './components/Table/Table';
 import { useGetDebateTableList } from '../../hooks/query/useGetDebateTableList';
 import { useDeleteParliamentaryDebateTable } from '../../hooks/mutations/useDeleteParliamentaryDebateTable';
-import useLogout from '../../hooks/mutations/useLogout';
-import { useNavigate } from 'react-router-dom';
 
 export default function TableListPage() {
   const { data: tables } = useGetDebateTableList();
 
   const { mutate } = useDeleteParliamentaryDebateTable();
-  const navigate = useNavigate();
-  const { mutate: logoutMutate } = useLogout(() => navigate('/login'));
 
   return (
     <DefaultLayout>
@@ -23,16 +19,7 @@ export default function TableListPage() {
           </div>
         </DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center />
-        <DefaultLayout.Header.Right>
-          <button
-            onClick={() => logoutMutate()}
-            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
-          >
-            <div className="flex flex-row items-center space-x-4">
-              <h2>로그아웃</h2>
-            </div>
-          </button>
-        </DefaultLayout.Header.Right>
+        <DefaultLayout.Header.Right defaultIcons={['home', 'logout']} />
       </DefaultLayout.Header>
       <div className="flex h-screen flex-col px-4 py-6">
         <main className="grid grid-cols-3 justify-items-center gap-6">

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -16,7 +16,7 @@ export default function TableOverview() {
     <DefaultLayout>
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
-          <HeaderTableInfo name={data?.info.name} />
+          <HeaderTableInfo name={data?.info.name} type={'PARLIAMENTARY'} />
         </DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center>
           <HeaderTitle title={data?.info.agenda} />

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -3,14 +3,14 @@ import PropsAndConsTitle from '../../components/ProsAndConsTitle/PropsAndConsTit
 import { useGetParliamentaryTableData } from '../../hooks/query/useGetParliamentaryTableData';
 import { useNavigate, useParams } from 'react-router-dom';
 import DebatePanel from '../TableComposition/components/DebatePanel/DebatePanel';
-import { IoMdHome } from 'react-icons/io';
-import useLogout from '../../hooks/mutations/useLogout';
-
+import HeaderTableInfo from '../../components/HeaderTableInfo/HeaderTableInfo';
+import HeaderTitle from '../../components/HeaderTitle/HeaderTitle';
+import IconButton from '../../components/IconButton/IconButton';
+import { IoHelpCircle } from 'react-icons/io5';
 export default function TableOverview() {
   const pathParams = useParams();
   const tableId = Number(pathParams.id);
   const { data } = useGetParliamentaryTableData(tableId);
-  const { mutate: logoutMutate } = useLogout(() => navigate('/login'));
 
   const navigate = useNavigate();
 
@@ -18,47 +18,12 @@ export default function TableOverview() {
     <DefaultLayout>
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
-          <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
-            <h1 className="mr-2">
-              {data === undefined || data!.info.name.trim() === ''
-                ? '테이블 이름 없음'
-                : data!.info.name}
-            </h1>
-            <div className="mx-3 h-6 w-[2px] bg-black"></div>
-            <span className="text-lg font-normal md:text-xl">의회식</span>
-          </div>
+          <HeaderTableInfo name={data?.info.name} />
         </DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center>
-          <div className="flex flex-col items-center">
-            <h1 className="text-m md:text-lg">토론 주제</h1>
-            <h1 className="max-w-md truncate text-xl font-bold md:text-2xl">
-              {data === undefined || data!.info.agenda.trim() === ''
-                ? '주제 없음'
-                : data!.info.agenda}
-            </h1>
-          </div>
+          <HeaderTitle title={data?.info.agenda} />
         </DefaultLayout.Header.Center>
-        <DefaultLayout.Header.Right>
-          <button
-            onClick={() => {
-              navigate('/');
-            }}
-            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
-          >
-            <div className="flex flex-row items-center space-x-4">
-              <IoMdHome size={24} />
-              <h1>홈 화면</h1>
-            </div>
-          </button>
-          <button
-            onClick={() => logoutMutate()}
-            className="rounded-full bg-slate-300 px-2 py-1 font-bold text-zinc-900 hover:bg-zinc-400"
-          >
-            <div className="flex flex-row items-center space-x-4">
-              <h2>로그아웃</h2>
-            </div>
-          </button>
-        </DefaultLayout.Header.Right>
+        <DefaultLayout.Header.Right defaultIcons={['home', 'logout']} />
       </DefaultLayout.Header>
       <DefaultLayout.ContentContanier>
         <PropsAndConsTitle />

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -5,8 +5,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import DebatePanel from '../TableComposition/components/DebatePanel/DebatePanel';
 import HeaderTableInfo from '../../components/HeaderTableInfo/HeaderTableInfo';
 import HeaderTitle from '../../components/HeaderTitle/HeaderTitle';
-import IconButton from '../../components/IconButton/IconButton';
-import { IoHelpCircle } from 'react-icons/io5';
 export default function TableOverview() {
   const pathParams = useParams();
   const tableId = Number(pathParams.id);


### PR DESCRIPTION
## 🚩 연관 이슈
closed #130

## 📝 작업 내용

## 개요
- StickyTriSectionHeader의 로직을 UI와 다양한 헤더에 대응될 수 있게 개선
- 헤더에 표시되는 정보를 공통 컴포넌트로 분리

## StickyTriSectionHeader 개선
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/88069071-0480-494b-b3fb-68c40cb96b12" />

StickyTriSectionHeader를 더 다양한 헤더 스타일을 대응할 수 있게 개선했습니다.
```tsx
<DefaultLayout.Header.Right defaultIcons={['home', 'logout']}/>
```
오른쪽 헤더영역에서 home과 logout을 선택해서 렌더링할 수 있습니다. 헤더에 표시되는 버튼의 순서도 배열의 순서로 변경 가능합니다. 
후에 자주 재사용되는 헤더가 추가되는 경우, StickyTriSectionHeader.Right의 switch문에 추가하면됩니다.
```tsx
switch (iconName) {
          case 'home':
            return (
              <div key={`${iconName}-${index}`}>
                <IconButton
                  icon={<IoMdHome size={24} />}
                  onClick={() => navigate('/')}
                />
              </div>
            );
          case 'logout':
            return (
              <div key={`${iconName}-${index}`}>
                <IconButton
                  icon={<IoLogOut size={24} />}
                  onClick={() => logoutMutate()}
                />
              </div>
            );
          default:
            return null;
        }
      })}
```

추가로 단기성 아이콘 버튼을 표시할 필요가 있는 경우,
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/71d6639e-26d4-468c-904a-357d06bb7aac" />

```tsx
        <DefaultLayout.Header.Right defaultIcons={['home', 'logout']}>
          <IconButton icon={<IoHelpCircle size={24} />}></IconButton>
        </DefaultLayout.Header.Right>
```
다음과 같이 버튼을 추가할 수 있습니다. IconButton으로 자식 컴포넌트로 넘겨주어야 공통된 UI를 가질 수 있습니다.
IconButton은 공용 컴포넌트로 src/components에 있습니다.

## 헤더에 표시되는 정보를 공통 컴포넌트로 분리
<img width="117" alt="image" src="https://github.com/user-attachments/assets/1c4114ad-aa51-42f3-809a-1276f5ca5eaa" />
src/components/HeaderTableInfo 를 사용하면됩니다.

<img width="1244" alt="image" src="https://github.com/user-attachments/assets/2ec7e238-6d9a-40d8-a961-58bf25cb61d5" />
src/components/HeaderTitle을 사용하면 됩니다.

## 추가 개선사항
TimerPage에서도 해당 헤더로 변경하는 작업이 필요

## 🗣️ 리뷰 요구사항 (선택)
StickyTriSectionHeader의 로직은 이정도로 구현하면 되는지 리뷰 부탁드립니다. 