### PR TITLE
[FEAT] ContentContanier의 padding유무를 props로 전달

### DIFF
--- a/src/layout/components/main/ContentContanier.tsx
+++ b/src/layout/components/main/ContentContanier.tsx
@@ -1,10 +1,19 @@
 import { PropsWithChildren } from 'react';
 
-export default function ContentContanier(props: PropsWithChildren) {
-  const { children } = props;
+interface ContentContainerProps extends PropsWithChildren {
+  noPadding?: boolean;
+}
 
+export default function ContentContanier({
+  children,
+  noPadding = false,
+}: ContentContainerProps) {
   return (
-    <main className="relative flex flex-grow flex-col items-center gap-2 overflow-auto px-8 py-4">
+    <main
+      className={`relative flex flex-grow flex-col items-center gap-2 overflow-auto ${
+        noPadding ? '' : 'px-8 py-4'
+      }`}
+    >
       {children}
     </main>
   );


### PR DESCRIPTION
## 🚩 연관 이슈
closed #138

## 📝 작업 내용
## 개요
- padding유무를 props로 전달

```tsx
import { PropsWithChildren } from 'react';

interface ContentContainerProps extends PropsWithChildren {
  noPadding?: boolean;
}

export default function ContentContanier({
  children,
  noPadding = false,
}: ContentContainerProps) {
  return (
    <main
      className={`relative flex flex-grow flex-col items-center gap-2 overflow-auto ${
        noPadding ? '' : 'px-8 py-4'
      }`}
    >
      {children}
    </main>
  );
}

```
props로 패딩 유무를 전달 받는다. 
default로 패딩이 존재하고
```tsx
<DefaultLayout.ContentContanier noPadding={true}>
```
일 경우 패딩을 제거할 수 있다.

## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
