### PR TITLE
[STYLE] 템플릿 만들기 화면 스타일변경

### DIFF
--- a/src/components/ClearableInput/ClearableInput.stories.tsx
+++ b/src/components/ClearableInput/ClearableInput.stories.tsx
@@ -1,0 +1,21 @@
+// Storybook 코드
+import { Meta, StoryObj } from '@storybook/react';
+import ClearableInput from './ClearableInput';
+
+const meta: Meta<typeof ClearableInput> = {
+  title: 'Components/ClearableInput',
+  component: ClearableInput,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ClearableInput>;
+
+export const Default: Story = {
+  args: {
+    value: 'Hello Storybook',
+    onClear: () => alert('Clear clicked'),
+    placeholder: 'Enter text...',
+  },
+};

--- a/src/components/ClearableInput/ClearableInput.tsx
+++ b/src/components/ClearableInput/ClearableInput.tsx
@@ -1,0 +1,32 @@
+import { InputHTMLAttributes } from 'react';
+import { IoMdCloseCircle } from 'react-icons/io';
+
+interface ClearableInputProps extends InputHTMLAttributes<HTMLInputElement> {
+  value: string;
+  onClear: () => void;
+}
+
+export default function ClearableInput({
+  value,
+  onClear,
+  ...rest
+}: ClearableInputProps) {
+  return (
+    <div className="relative">
+      <input
+        {...rest}
+        value={value}
+        className="w-full rounded-md border border-neutral-300 p-3 pr-10 text-base text-black placeholder-neutral-400 focus:outline-none"
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={onClear}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-xl text-neutral-400 hover:text-neutral-600"
+        >
+          <IoMdCloseCircle />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/LabledCheckBox/LabeledCheckbox.stories.tsx
+++ b/src/components/LabledCheckBox/LabeledCheckbox.stories.tsx
@@ -1,0 +1,39 @@
+// LabeledCheckbox.stories.tsx
+import { Meta, StoryObj } from '@storybook/react';
+import LabeledCheckbox from './LabeledCheckbox';
+
+const meta: Meta<typeof LabeledCheckbox> = {
+  title: 'Components/LabeledCheckbox',
+  component: LabeledCheckbox,
+  tags: ['autodocs'],
+  argTypes: {
+    onChange: { action: 'changed' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LabeledCheckbox>;
+
+// 기본 스토리
+export const Default: Story = {
+  args: {
+    label: '체크박스 라벨 (Default)',
+    checked: false,
+  },
+};
+
+// 체크된 상태
+export const Checked: Story = {
+  args: {
+    label: '체크박스 라벨 (Checked)',
+    checked: true,
+  },
+};
+
+// 체크 해제 상태
+export const Unchecked: Story = {
+  args: {
+    label: '체크박스 라벨 (Unchecked)',
+    checked: false,
+  },
+};

--- a/src/components/LabledCheckBox/LabeledCheckbox.tsx
+++ b/src/components/LabledCheckBox/LabeledCheckbox.tsx
@@ -1,0 +1,23 @@
+import { InputHTMLAttributes } from 'react';
+
+interface LabeledCheckboxProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string;
+  checked: boolean;
+}
+
+export default function LabeledCheckbox({
+  label,
+  checked,
+  ...rest
+}: LabeledCheckboxProps) {
+  const labelColorClass = checked ? '' : 'text-neutral-400';
+
+  return (
+    <label
+      className={`flex items-center gap-2 text-sm md:text-base ${labelColorClass}`}
+    >
+      <input {...rest} type="checkbox" checked={checked} className="h-5 w-5" />
+      {label}
+    </label>
+  );
+}

--- a/src/components/LabledCheckBox/LabeledCheckbox.tsx
+++ b/src/components/LabledCheckBox/LabeledCheckbox.tsx
@@ -10,13 +10,37 @@ export default function LabeledCheckbox({
   checked,
   ...rest
 }: LabeledCheckboxProps) {
+  // 체크 안 된 상태일 때 라벨 색을 회색으로
   const labelColorClass = checked ? '' : 'text-neutral-400';
 
   return (
     <label
       className={`flex items-center gap-2 text-sm md:text-base ${labelColorClass}`}
     >
-      <input {...rest} type="checkbox" checked={checked} className="h-5 w-5" />
+      <input
+        {...rest}
+        type="checkbox"
+        checked={checked}
+        className="
+          relative
+          h-5
+          w-5 appearance-none
+          rounded-sm
+          border border-neutral-300
+          checked:border-transparent
+          checked:bg-blue-500
+          checked:before:absolute
+
+          checked:before:left-1/2
+          checked:before:top-[-4px]
+          checked:before:-translate-x-1/2
+          checked:before:text-xl
+          checked:before:font-bold
+          checked:before:text-background-default
+          checked:before:content-['✓']
+          focus:outline-none
+        "
+      />
       {label}
     </label>
   );

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -50,7 +50,7 @@ export default function TableComposition() {
       EditTable({
         tableId: tableId, // etc
         info: {
-          name: formData.info.name ?? '시간표 1',
+          name: formData.info.name ?? '템플릿 1',
           agenda: formData.info.agenda,
           warningBell: formData.info.warningBell,
           finishBell: formData.info.finishBell,
@@ -60,7 +60,7 @@ export default function TableComposition() {
     } else {
       AddTable({
         info: {
-          name: formData.info.name ?? '시간표 1',
+          name: formData.info.name ?? '템플릿 1',
           agenda: formData.info.agenda,
           warningBell: formData.info.warningBell,
           finishBell: formData.info.finishBell,

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -50,7 +50,7 @@ export default function TableComposition() {
       EditTable({
         tableId: tableId, // etc
         info: {
-          name: formData.info.name ?? '테이블 1',
+          name: formData.info.name ?? '시간표 1',
           agenda: formData.info.agenda,
           warningBell: formData.info.warningBell,
           finishBell: formData.info.finishBell,
@@ -60,7 +60,7 @@ export default function TableComposition() {
     } else {
       AddTable({
         info: {
-          name: formData.info.name ?? '테이블 1',
+          name: formData.info.name ?? '시간표 1',
           agenda: formData.info.agenda,
           warningBell: formData.info.warningBell,
           finishBell: formData.info.finishBell,

--- a/src/page/TableComposition/components/DropdownForDebateType/DropdownForDebateType.tsx
+++ b/src/page/TableComposition/components/DropdownForDebateType/DropdownForDebateType.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Type } from '../../../../type/type';
 import { typeMapping } from '../../../../constants/languageMapping';
+import { IoMdArrowDropdown } from 'react-icons/io';
 
 interface DropdownForDebateTypeProps {
   type: Type;
@@ -34,14 +35,19 @@ export default function DropdownForDebateType(
     <div className="relative w-full">
       <button
         onClick={() => setIsToggleOpen(!isToggleOpen)}
-        className="w-full rounded-md bg-neutral-300 p-6 text-center font-semibold text-white lg:text-3xl"
+        className="flex w-full items-center justify-between rounded-md border border-neutral-300 bg-white p-3 text-sm text-black focus:outline-none md:text-base"
       >
-        ▼ {typeMapping[type]}
+        <span>{typeMapping[type]}</span>
+        <IoMdArrowDropdown
+          className={`ml-2 text-xl transition-transform ${
+            isToggleOpen ? 'rotate-180' : ''
+          }`}
+        />
       </button>
 
-      {isToggleOpen && (
+      {isToggleOpen && getAlternativeOptions.length !== 0 && (
         <ul
-          className="absolute left-0 right-0 mt-2 rounded-md bg-neutral-200 shadow-lg"
+          className="absolute left-0 right-0 mt-1 rounded-md border border-neutral-300 bg-white shadow-md"
           role="listbox"
         >
           {getAlternativeOptions.map((koreanType) => (
@@ -50,7 +56,7 @@ export default function DropdownForDebateType(
               onClick={() => handleTypeSelect(koreanType)}
               role="option"
               tabIndex={0}
-              className="cursor-pointer p-2 text-center font-semibold text-white hover:bg-neutral-400 focus:bg-neutral-400 focus:outline-none"
+              className="cursor-pointer px-3 py-2 text-sm text-black hover:bg-neutral-100 focus:bg-neutral-100 focus:outline-none md:text-base"
             >
               {koreanType}
             </li>

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -1,144 +1,128 @@
+import ClearableInput from '../../../../components/ClearableInput/ClearableInput';
+import HeaderTitle from '../../../../components/HeaderTitle/HeaderTitle';
+import LabeledCheckbox from '../../../../components/LabledCheckBox/LabeledCheckbox';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
-import { Type } from '../../../../type/type';
+import { DetailDebateInfo, Type } from '../../../../type/type';
 import DropdownForDebateType from '../DropdownForDebateType/DropdownForDebateType';
 
+type ExtendedDebateInfo = DetailDebateInfo & {
+  type: Type;
+};
 interface TableNameAndTypeProps {
-  info: {
-    name: string;
-    agenda: string;
-    type: Type;
-    warningBell: boolean;
-    finishBell: boolean;
-  };
+  info: ExtendedDebateInfo;
   isEdit?: boolean;
-  onInfoChange: (newInfo: {
-    name: string;
-    agenda: string;
-    type: Type;
-    warningBell: boolean;
-    finishBell: boolean;
-  }) => void;
+  onInfoChange: (newInfo: ExtendedDebateInfo) => void;
   onButtonClick: () => void;
 }
+
+type ExtendedDebateInfoField = keyof ExtendedDebateInfo;
+type ExtendedDebateInfoValue = ExtendedDebateInfo[ExtendedDebateInfoField];
 
 export default function TableNameAndType(props: TableNameAndTypeProps) {
   const { info, isEdit = false, onInfoChange, onButtonClick } = props;
 
-  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleFieldChange = (
+    field: ExtendedDebateInfoField,
+    value: ExtendedDebateInfoValue,
+  ) => {
     onInfoChange({
       ...info,
-      name: e.target.value,
+      [field]: value,
     });
   };
 
-  const handleAgenda = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const clearField = (field: 'name' | 'agenda') => {
     onInfoChange({
       ...info,
-      agenda: e.target.value,
-    });
-  };
-
-  const handleTypeChange = (type: Type) => {
-    onInfoChange({
-      ...info,
-      type,
-    });
-  };
-
-  const handleWarningBell = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onInfoChange({
-      ...info,
-      warningBell: e.target.checked,
-    });
-  };
-
-  const handleFinishBell = (e: React.ChangeEvent<HTMLInputElement>) => {
-    onInfoChange({
-      ...info,
-      finishBell: e.target.checked,
+      [field]: '',
     });
   };
 
   return (
     <DefaultLayout>
       <DefaultLayout.Header>
-        <DefaultLayout.Header.Left></DefaultLayout.Header.Left>
+        <DefaultLayout.Header.Left />
         <DefaultLayout.Header.Center>
-          <div className="flex flex-wrap items-center justify-center px-2 text-2xl font-bold md:text-3xl">
-            <h1>
-              {isEdit ? '토론 정보를 수정해주세요' : '어떤 토론을 원하시나요?'}
-            </h1>
-          </div>
+          <HeaderTitle
+            title={`토론 정보를 ${isEdit ? '수정' : '설정'}해주세요`}
+          />
         </DefaultLayout.Header.Center>
         <DefaultLayout.Header.Right defaultIcons={['home', 'logout']} />
       </DefaultLayout.Header>
+
       <DefaultLayout.ContentContanier>
-        <section className="grid w-full grid-cols-[1fr_2fr] gap-10 p-8">
-          <h3 className="text-md font-bold lg:text-5xl">토론 템플릿 이름</h3>
-          <input
-            placeholder="테이블 1(디폴트 값)"
-            className="w-full rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
+        <section className="mx-auto grid w-full max-w-4xl grid-cols-[180px_1fr] gap-x-4 gap-y-6 p-6 md:p-8">
+          <label className="flex items-center text-base font-semibold md:text-2xl">
+            토론 시간표 이름
+          </label>
+          <ClearableInput
             value={info.name}
-            onChange={handleNameChange}
+            onChange={(e) => handleFieldChange('name', e.target.value)}
+            onClear={() => clearField('name')}
+            placeholder="테이블 1"
           />
 
-          <h3 className="text-md font-bold lg:text-5xl">토론 주제</h3>
-          <input
-            placeholder="토론 주제를 입력해주세요"
-            className="w-full rounded-md bg-neutral-300 p-6 text-center font-semibold text-white placeholder-white lg:text-3xl"
+          <label className="flex items-center text-base font-semibold md:text-2xl">
+            토론 주제
+          </label>
+          <ClearableInput
             value={info.agenda}
-            onChange={handleAgenda}
+            onChange={(e) => handleFieldChange('agenda', e.target.value)}
+            onClear={() => clearField('agenda')}
+            placeholder="토론 주제를 입력해주세요"
           />
-
           {!isEdit && (
             <>
-              <h3 className="text-md font-bold lg:text-5xl">토론 유형</h3>
+              <label className="flex items-center text-base font-semibold md:text-2xl">
+                토론 유형
+              </label>
               <DropdownForDebateType
                 type={info.type}
-                onChange={handleTypeChange}
+                onChange={(selectedType) =>
+                  handleFieldChange('type', selectedType)
+                }
               />
             </>
           )}
 
-          <h3 className="text-md font-bold lg:text-5xl">종소리 설정</h3>
-          <div className="flex flex-col gap-5">
-            <label className="flex items-center gap-4 text-lg">
-              <input
-                type="checkbox"
-                checked={info.warningBell}
-                onChange={handleWarningBell}
-                className="h-5 w-5"
-              />
-              발언종료 30초 전 알림
-            </label>
-            <label className="flex items-center gap-4 text-lg">
-              <input
-                type="checkbox"
-                checked={info.finishBell}
-                onChange={handleFinishBell}
-                className="h-5 w-5"
-              />
-              발언종료 알림
-            </label>
+          <label className="text-base font-semibold md:text-2xl">
+            종소리 설정
+          </label>
+          <div className="flex flex-col gap-3">
+            <LabeledCheckbox
+              label="발언종료 30초 전 알림"
+              checked={info.warningBell}
+              onChange={(e) =>
+                handleFieldChange('warningBell', e.target.checked)
+              }
+            />
+            <LabeledCheckbox
+              label="발언종료 알림"
+              checked={info.finishBell}
+              onChange={(e) =>
+                handleFieldChange('finishBell', e.target.checked)
+              }
+            />
           </div>
         </section>
       </DefaultLayout.ContentContanier>
-
       <DefaultLayout.StickyFooterWrapper>
-        <button
-          onClick={() => {
-            if (info.name === '') {
-              onInfoChange({
-                ...info,
-                name: '테이블 1',
-              });
-            }
-            onButtonClick();
-          }}
-          className="h-20 w-full bg-amber-500 text-2xl font-semibold transition duration-300 hover:bg-amber-600"
-        >
-          {isEdit ? '타임박스 수정하기' : '타임박스 만들기'}
-        </button>
+        <div className="mx-auto mb-4 w-full max-w-4xl px-6 md:px-8">
+          <button
+            onClick={() => {
+              if (info.name === '') {
+                onInfoChange({
+                  ...info,
+                  name: '시간표 1',
+                });
+              }
+              onButtonClick();
+            }}
+            className="font-semibol h-16 w-full rounded-md bg-brand-main text-lg transition-colors duration-300 hover:bg-amber-500 md:text-xl"
+          >
+            {isEdit ? '시간표 수정하기' : '시간표 추가하기'}
+          </button>
+        </div>
       </DefaultLayout.StickyFooterWrapper>
     </DefaultLayout>
   );

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -113,7 +113,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
               if (info.name === '') {
                 onInfoChange({
                   ...info,
-                  name: '시간표 1',
+                  name: '템플릿 1',
                 });
               }
               onButtonClick();

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -51,7 +51,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
       </DefaultLayout.Header>
 
       <DefaultLayout.ContentContanier>
-        <section className="mx-auto grid w-full max-w-4xl grid-cols-[180px_1fr] gap-x-4 gap-y-6 p-6 md:p-8">
+        <section className="mx-auto grid w-full max-w-4xl grid-cols-[180px_1fr] gap-x-4 gap-y-12 p-6 md:p-8">
           <label className="flex items-center text-base font-semibold md:text-2xl">
             토론 시간표 이름
           </label>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,7 +57,7 @@ export default {
       },
       colors: {
         brand: {
-          main: '#FF9900',   
+          main: '#F8B62D',   
           sub1: '#01204E',
           sub2: '#028391',  
           sub3: '#37474F',   


### PR DESCRIPTION
## 🚩 연관 이슈
closed #141 

## 📝 작업 내용
- 템플릿 만들기 화면 스타일변경
- input, checkbox 공통 컴포넌트로 분리

### 템플릿 만들기 화면 스타일변경
Before
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/d529b3e0-d9dd-40ad-9cdd-3d10a8b79956" />

After
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/464b354c-97f7-4e60-8bf4-c344048127e7" />

피그마 시안
<img width="385" alt="image" src="https://github.com/user-attachments/assets/f81a55ef-1c40-497f-9906-5266188d8e8a" />

### input, checkbox 공통 컴포넌트로 분리
- ClearableInput
<img width="937" alt="image" src="https://github.com/user-attachments/assets/2e49964b-f47f-4aca-a30b-ba361f1c7154" />
input에 입력이 있으면 x버튼이 활성화되어 input의 내용을 전부 비우는 컴포넌트입니다.

- LabeledCheckbox
<img width="937" alt="image" src="https://github.com/user-attachments/assets/19ae0734-fc30-4e1a-9124-362d8fb1a405" />
checkbox의 선택 여부에 따라 label text의 색상이 변경되는 컴포넌트입니다. 추가적으로 checkbox가 브라우저에서 일관적으로 나타나지 않으므로 이를 일관성 있게 변경하였습니다. 
다음은 이를 위한 css입니다.

```ts
    <label
      className={`flex items-center gap-2 text-sm md:text-base ${labelColorClass}`}
    >
      <input
        {...rest}
        type="checkbox"
        checked={checked}
        className="
          relative
          h-5
          w-5 appearance-none
          rounded-sm
          border border-neutral-300
          checked:border-transparent
          checked:bg-blue-500
          checked:before:absolute

          checked:before:left-1/2
          checked:before:top-[-4px]
          checked:before:-translate-x-1/2
          checked:before:text-xl
          checked:before:font-bold
          checked:before:text-background-default
          checked:before:content-['✓']
          focus:outline-none
        "
      />
      {label}
    </label>
```
