### PR TITLE
[STYLE] 타임박스 설정 페이지, 시간표 상세페이지 UI 변경 

### DIFF
--- a/src/components/ProsAndConsTitle/PropsAndConsTitle.tsx
+++ b/src/components/ProsAndConsTitle/PropsAndConsTitle.tsx
@@ -1,8 +1,14 @@
 export default function PropsAndConsTitle() {
   return (
-    <div className="mb-8 flex w-full items-center justify-around border-b border-black pb-1">
-      <span className="text-3xl font-bold text-blue-500">찬성</span>
-      <span className="text-3xl font-bold text-red-500">반대</span>
+    <div className="mx-auto flex w-full items-center justify-between py-4">
+      <div className="flex w-1/2 flex-col items-center px-4">
+        <span className="text-2xl font-bold text-camp-blue">찬성</span>
+        <div className="mt-1 h-1 w-full bg-camp-blue" />
+      </div>
+      <div className="flex w-1/2 flex-col items-center px-4">
+        <span className="text-2xl font-bold text-camp-red">반대</span>
+        <div className="mt-1 h-1 w-full bg-camp-red" />
+      </div>
     </div>
   );
 }

--- a/src/hooks/useModal.test.tsx
+++ b/src/hooks/useModal.test.tsx
@@ -98,8 +98,7 @@ describe('useModal Hook 테스트', () => {
     expect(screen.getByTestId('modal-content')).toBeInTheDocument();
 
     // 'X' 버튼(모달 내부 right-4 top-4) 클릭
-    const closeButton = screen.getByRole('button', { name: /x/i });
-    await user.click(closeButton);
+    await user.click(screen.getByTestId('close-btn'));
 
     expect(screen.queryByTestId('modal-content')).not.toBeInTheDocument();
   });

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -58,6 +58,7 @@ export function useModal(options: UseModalOptions = {}) {
               type="button"
               onClick={closeModal}
               className="absolute right-4 top-4 text-3xl text-neutral-0 hover:text-gray-300"
+              aria-label="모달 닫기"
             >
               <IoMdClose />
             </button>

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,5 +1,6 @@
 import { ReactNode, useState, useCallback, useEffect } from 'react';
 import { GlobalPortal } from '../util/GlobalPortal';
+import { IoMdClose } from 'react-icons/io';
 
 interface UseModalOptions {
   closeOnOverlayClick?: boolean;
@@ -51,14 +52,14 @@ export function useModal(options: UseModalOptions = {}) {
           className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
           onClick={handleOverlayClick}
         >
-          <div className="relative rounded-lg bg-white shadow-lg">
+          <div className="relative overflow-hidden rounded-lg bg-white shadow-lg">
             {children}
             <button
               type="button"
               onClick={closeModal}
-              className="absolute right-4 top-8 text-3xl text-gray-500 hover:text-gray-700"
+              className="absolute right-4 top-4 text-3xl text-neutral-0 hover:text-gray-300"
             >
-              X
+              <IoMdClose />
             </button>
           </div>
         </div>

--- a/src/page/TableComposition/TableComposition.test.tsx
+++ b/src/page/TableComposition/TableComposition.test.tsx
@@ -108,7 +108,7 @@ describe('TableComposition', () => {
     expect(screen.getByText('주제 없음')).toBeInTheDocument();
 
     // 4. "완료" (혹은 "제출") 버튼 클릭
-    const submitButton = screen.getByText('테이블 추가하기');
+    const submitButton = screen.getByText('시간표 추가완료하기');
     expect(submitButton).toBeDisabled();
 
     const leftAddButton = screen.getAllByText('+')[0]; // 첫 번째 "+" 버튼 (왼쪽 버튼)

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -29,36 +29,49 @@ export default function DebatePanel(props: DebatePanelProps) {
 
   const renderDragHandle = () => (
     <div
-      className="left-0x absolute top-4 flex h-2/3 w-4 flex-1 cursor-grab items-center 
-                justify-center rounded-md bg-slate-100 "
+      className={`${isPros ? 'right-2' : 'left-2'} absolute top-4 flex h-2/3 w-4 flex-1 cursor-grab items-center 
+                justify-center rounded-md bg-neutral-0 hover:bg-neutral-300`}
       onMouseDown={onMouseDown}
       title="위아래로 드래그"
     >
-      {/* 세로줄 아이콘을 중앙에 표시해줍니다 */}
-      <LuArrowUpDown className="text-gray-600" />
+      <LuArrowUpDown className="text-neutral-900" />
     </div>
   );
   const renderProsConsPanel = () => (
     <div
-      className={`relative flex w-1/2 flex-col items-center rounded-md ${
-        isPros ? 'bg-blue-500' : 'bg-red-500'
-      } h-24 select-none p-2 font-bold text-white`}
+      className={`relative flex w-1/2 flex-col items-center justify-center rounded-md ${
+        isPros ? 'bg-camp-blue' : 'bg-camp-red'
+      } h-24 select-none p-2 font-bold text-neutral-0`}
     >
       {onSubmitEdit && onSubmitDelete && (
-        <div className="flex h-4 w-full items-center gap-2">
-          <div className="flex-1" />
-          {renderDragHandle()}
-          <div className="flex-1">
-            <EditDeleteButtons
-              info={props.info}
-              onSubmitEdit={onSubmitEdit}
-              onSubmitDelete={onSubmitDelete}
-            />
-          </div>
-        </div>
+        <>
+          {isPros ? (
+            <>
+              <div className="absolute left-2 top-2">
+                <EditDeleteButtons
+                  info={props.info}
+                  onSubmitEdit={onSubmitEdit}
+                  onSubmitDelete={onSubmitDelete}
+                />
+              </div>
+              {renderDragHandle()}
+            </>
+          ) : (
+            <>
+              {renderDragHandle()}
+              <div className="absolute right-2 top-2">
+                <EditDeleteButtons
+                  info={props.info}
+                  onSubmitEdit={onSubmitEdit}
+                  onSubmitDelete={onSubmitDelete}
+                />
+              </div>
+            </>
+          )}
+        </>
       )}
       <div>
-        {debateTypeLabel} / {speakerNumber}번 토론자
+        {debateTypeLabel} | {speakerNumber}번 토론자
       </div>
       <div className="text-2xl">{timeStr}</div>
     </div>
@@ -66,21 +79,21 @@ export default function DebatePanel(props: DebatePanelProps) {
 
   const renderNeutralTimeoutPanel = () => (
     <div className="relative flex h-24 w-full select-none items-center text-center">
-      <div className="flex h-4/5 w-full flex-col items-center justify-start rounded-md bg-gray-200 p-2 font-medium text-gray-600">
+      <div className="relative flex h-4/5 w-full flex-col items-center justify-center rounded-md bg-neutral-500 p-2 font-medium ">
         {onSubmitEdit && onSubmitDelete && (
-          <div className="flex h-4 w-full items-center gap-2">
-            <div className="flex-1" />
+          <>
             {renderDragHandle()}
-            <div className="flex-1">
+            <div className="absolute right-2 top-2">
               <EditDeleteButtons
                 info={props.info}
                 onSubmitEdit={onSubmitEdit}
                 onSubmitDelete={onSubmitDelete}
               />
             </div>
-          </div>
+          </>
         )}
-        {debateTypeLabel} | {timeStr}
+        <span className="text-sm">{debateTypeLabel}</span>
+        <span className="text-xl">{timeStr}</span>
       </div>
     </div>
   );

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -1,4 +1,4 @@
-import { AiOutlineDelete, AiOutlineEdit } from 'react-icons/ai';
+import { RiEditFill, RiDeleteBinFill } from 'react-icons/ri';
 import DeleteConfirmContent from '../DeleteConfirmContent/DeleteConfirmContent';
 import { TimeBoxInfo } from '../../../../type/type';
 import { useModal } from '../../../../hooks/useModal';
@@ -26,11 +26,19 @@ export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
   return (
     <>
       <div className="flex justify-end gap-2">
-        <button onClick={openEditModal} aria-label="수정하기">
-          <AiOutlineEdit />
+        <button
+          onClick={openEditModal}
+          className="rounded-sm bg-neutral-0"
+          aria-label="수정하기"
+        >
+          <RiEditFill className="text-neutral-900" />
         </button>
-        <button onClick={deleteOpenModal} aria-label="삭제하기">
-          <AiOutlineDelete />
+        <button
+          onClick={deleteOpenModal}
+          className="rounded-sm bg-neutral-0"
+          aria-label="삭제하기"
+        >
+          <RiDeleteBinFill className="text-neutral-900" />
         </button>
       </div>
       <EditModalWrapper>

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -19,16 +19,7 @@ interface TimeBoxStepProps {
 export default function TimeBoxStep(props: TimeBoxStepProps) {
   const { initData, onTimeBoxChange, onButtonClick, isEdit = false } = props;
   const initTimeBox = initData.table;
-  const {
-    openModal: ProsOpenModal,
-    closeModal: ProsCloseModal,
-    ModalWrapper: ProsModalWrapper,
-  } = useModal();
-  const {
-    openModal: ConsOpenModal,
-    closeModal: ConsCloseModal,
-    ModalWrapper: ConsModalWrapper,
-  } = useModal();
+  const { openModal, closeModal, ModalWrapper } = useModal();
 
   const { handleMouseDown, getDraggingStyles, DragAndDropWrapper } =
     useDragAndDrop({
@@ -66,65 +57,60 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       </DefaultLayout.Header>
 
       <DefaultLayout.ContentContanier>
-        <PropsAndConsTitle />
-        <DragAndDropWrapper>
-          {initTimeBox.map((info, index) => (
-            <div key={index + info.stance} style={getDraggingStyles(index)}>
-              <DebatePanel
-                key={index + info.stance}
-                info={info}
-                onSubmitEdit={(updatedInfo) =>
-                  handleSubmitEdit(index, updatedInfo)
-                }
-                onSubmitDelete={() => handleSubmitDelete(index)}
-                onMouseDown={() => handleMouseDown(index)}
-              />
-            </div>
-          ))}
-        </DragAndDropWrapper>
+        <section className="mx-auto flex w-full max-w-4xl flex-col">
+          <PropsAndConsTitle />
+          <DragAndDropWrapper>
+            {initTimeBox.map((info, index) => (
+              <div key={index + info.stance} style={getDraggingStyles(index)}>
+                <DebatePanel
+                  key={index + info.stance}
+                  info={info}
+                  onSubmitEdit={(updatedInfo) =>
+                    handleSubmitEdit(index, updatedInfo)
+                  }
+                  onSubmitDelete={() => handleSubmitDelete(index)}
+                  onMouseDown={() => handleMouseDown(index)}
+                />
+              </div>
+            ))}
+          </DragAndDropWrapper>
 
-        <TimerCreationButton
-          leftOnClick={ProsOpenModal}
-          rightOnClick={ConsOpenModal}
-        />
+          <TimerCreationButton onClick={openModal} />
+        </section>
       </DefaultLayout.ContentContanier>
 
       <DefaultLayout.StickyFooterWrapper>
-        <button
-          className={`h-20 w-screen text-2xl font-semibold transition duration-300 ${
-            isAbledSummitButton
-              ? 'bg-amber-500 hover:bg-amber-600'
-              : 'cursor-not-allowed bg-gray-400'
-          }`}
-          onClick={onButtonClick}
-          disabled={!isAbledSummitButton}
-        >
-          {isEdit ? '테이블 수정하기' : '테이블 추가하기'}
-        </button>
+        <div className="mx-auto mb-4 w-full max-w-4xl px-6 md:px-8">
+          <button
+            onClick={onButtonClick}
+            className={`font-semibol h-16 w-full rounded-md  text-lg transition-colors duration-300 md:text-xl ${
+              isAbledSummitButton
+                ? 'bg-brand-main hover:bg-amber-500'
+                : 'cursor-not-allowed bg-neutral-500'
+            }`}
+            disabled={!isAbledSummitButton}
+          >
+            {isEdit ? '시간표 수정완료하기' : '시간표 추가완료하기'}
+          </button>
+        </div>
       </DefaultLayout.StickyFooterWrapper>
 
-      <ProsModalWrapper>
+      <ModalWrapper>
         <TimerCreationContent
-          selectedStance={'PROS'}
+          selectedStance={
+            initTimeBox.length === 0
+              ? 'PROS'
+              : initTimeBox[initTimeBox.length - 1].stance === 'PROS'
+                ? 'CONS'
+                : 'PROS'
+          }
           initDate={initTimeBox[initTimeBox.length - 1]}
           onSubmit={(data) => {
             onTimeBoxChange((prev) => [...prev, data]);
           }}
-          onClose={ProsCloseModal}
+          onClose={closeModal}
         />
-        ,
-      </ProsModalWrapper>
-      <ConsModalWrapper>
-        <TimerCreationContent
-          selectedStance={'CONS'}
-          initDate={initTimeBox[initTimeBox.length - 1]}
-          onSubmit={(data) => {
-            onTimeBoxChange((prev) => [...prev, data]);
-          }}
-          onClose={ConsCloseModal}
-        />
-        ,
-      </ConsModalWrapper>
+      </ModalWrapper>
     </DefaultLayout>
   );
 }

--- a/src/page/TableComposition/components/TimerCreationButton/TimerCreationButton.stories.tsx
+++ b/src/page/TableComposition/components/TimerCreationButton/TimerCreationButton.stories.tsx
@@ -13,7 +13,6 @@ type Story = StoryObj<typeof TimerCreationButton>;
 
 export const Default: Story = {
   args: {
-    leftOnClick: () => alert('Left button clicked!'),
-    rightOnClick: () => alert('Right button clicked!'),
+    onClick: () => alert('Left button clicked!'),
   },
 };

--- a/src/page/TableComposition/components/TimerCreationButton/TimerCreationButton.tsx
+++ b/src/page/TableComposition/components/TimerCreationButton/TimerCreationButton.tsx
@@ -1,21 +1,13 @@
-interface TimerCreationButtonProps {
-  leftOnClick: () => void;
-  rightOnClick: () => void;
-}
-export default function TimerCreationButton(props: TimerCreationButtonProps) {
-  const { leftOnClick, rightOnClick } = props;
-  return (
-    <div className="flex w-full items-center justify-around">
-      <button
-        className="flex h-10 w-5/12 items-center justify-center rounded-md bg-gray-200 font-bold text-black"
-        onClick={leftOnClick}
-      >
-        +
-      </button>
+import { ButtonHTMLAttributes } from 'react';
 
+export default function TimerCreationButton(
+  props: ButtonHTMLAttributes<HTMLButtonElement>,
+) {
+  return (
+    <div className="m-2 flex w-full items-center justify-center">
       <button
-        className="flex h-10 w-5/12 items-center justify-center rounded-md bg-gray-200 font-bold text-black"
-        onClick={rightOnClick}
+        className="flex h-10 w-4/5 items-center justify-center rounded-md bg-neutral-300 font-bold hover:bg-neutral-500"
+        {...props}
       >
         +
       </button>

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -42,22 +42,24 @@ export default function TimerCreationContent({
   const getStanceColor = () => {
     switch (stance) {
       case 'PROS':
-        return 'text-blue-500';
+        return 'bg-camp-blue';
       case 'CONS':
-        return 'text-red-500';
+        return 'bg-camp-red';
       case 'NEUTRAL':
-        return 'text-gray-400';
+        return 'bg-neutral-500';
       default:
-        return 'text-gray-400';
+        return 'bg-neutral-500';
     }
   };
 
   return (
-    <div className="p-10">
-      <h2 className={`mb-4 text-xl font-bold ${getStanceColor()}`}>
+    <>
+      <h2
+        className={`mb-4 px-4 py-4 text-xl font-bold text-neutral-0 ${getStanceColor()}`}
+      >
         타임박스 설정
       </h2>
-      <div className="flex flex-col space-y-6">
+      <div className="flex flex-col gap-4 p-4">
         <div className="flex items-center space-x-2">
           <label htmlFor="stance-select" className="w-16 flex-shrink-0">
             입장
@@ -154,7 +156,7 @@ export default function TimerCreationContent({
             <option value="2">2번 토론자</option>
             <option value="3">3번 토론자</option>
             <option value="4">4번 토론자</option>
-            <option value="4">5번 토론자</option>
+            <option value="5">5번 토론자</option>
           </select>
         </div>
 
@@ -165,6 +167,6 @@ export default function TimerCreationContent({
           타임박스 설정하기
         </button>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -5,6 +5,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import DebatePanel from '../TableComposition/components/DebatePanel/DebatePanel';
 import HeaderTableInfo from '../../components/HeaderTableInfo/HeaderTableInfo';
 import HeaderTitle from '../../components/HeaderTitle/HeaderTitle';
+import { RiEditFill, RiSpeakFill } from 'react-icons/ri';
 export default function TableOverview() {
   const pathParams = useParams();
   const tableId = Number(pathParams.id);
@@ -24,29 +25,35 @@ export default function TableOverview() {
         <DefaultLayout.Header.Right defaultIcons={['home', 'logout']} />
       </DefaultLayout.Header>
       <DefaultLayout.ContentContanier>
-        <PropsAndConsTitle />
-        {data &&
-          data.table.map((info, index) => (
-            <DebatePanel key={index} info={info} />
-          ))}
+        <section className="mx-auto flex w-full max-w-4xl flex-col">
+          <PropsAndConsTitle />
+          {data &&
+            data.table.map((info, index) => (
+              <DebatePanel key={index} info={info} />
+            ))}
+        </section>
       </DefaultLayout.ContentContanier>
       <DefaultLayout.StickyFooterWrapper>
-        <button
-          className="h-20 w-screen rounded-md bg-blue-300 text-2xl"
-          onClick={() =>
-            navigate(
-              `/composition?mode=edit&tableId=${tableId}&type=PARLIAMENTARY`,
-            )
-          }
-        >
-          테이블 수정하기
-        </button>
-        <button
-          className="h-20 w-screen rounded-md bg-red-300 text-2xl"
-          onClick={() => navigate(`/table/parliamentary/${tableId}`)}
-        >
-          토론하기
-        </button>
+        <div className="mx-auto mb-4 flex w-full max-w-4xl gap-1 px-6 md:px-8">
+          <button
+            className="flex h-16 w-screen items-center justify-center gap-2 rounded-md  bg-neutral-300 text-2xl"
+            onClick={() =>
+              navigate(
+                `/composition?mode=edit&tableId=${tableId}&type=PARLIAMENTARY`,
+              )
+            }
+          >
+            <RiEditFill />
+            수정하기
+          </button>
+          <button
+            className="flex h-16 w-screen items-center justify-center gap-2 rounded-md bg-brand-main text-2xl"
+            onClick={() => navigate(`/table/parliamentary/${tableId}`)}
+          >
+            <RiSpeakFill />
+            토론하기
+          </button>
+        </div>
       </DefaultLayout.StickyFooterWrapper>
     </DefaultLayout>
   );


### PR DESCRIPTION
## 🚩 연관 이슈
closed #145

## 📝 작업 내용
- 타임박스 설정 페이지 UI 변경
- 생성, 수정 모달 UI 변경
- 시간표 상세페이지 UI 변경 
- modal 닫기 버튼 아이콘 변경
- 문구 변경에 따른 테스트 수정

### 타임박스 설정 페이지 UI 변경
before
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/feed9551-ec68-4b51-9cc0-19bc24308232" />

after
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/74a8b61a-7901-4ae9-a0c8-48273b3aa59e" />

### 생성, 수정 모달 UI 변경
before
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/9e61d210-b6c5-40db-b0b0-da601c5ed88f" />

after
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/3388b97f-be44-46fe-b6d8-764771225a57" />

### 시간표 상세페이지 UI 변경 
before
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/b64ee992-3099-4017-b342-fa5c62bd3abd" />


after
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/bec90681-bde8-40dc-b3d2-1cd451de32d8" />


## 🏞️ 스크린샷 (선택)

## 🗣️ 리뷰 요구사항 (선택)
