### PR TITLE
[DESIGN] 시간표 설정 화면, 타임 박스 모달 피드백 사항 반영

### DIFF
--- a/src/components/ErrorBoundary/ErrorPage.tsx
+++ b/src/components/ErrorBoundary/ErrorPage.tsx
@@ -42,7 +42,7 @@ export default function ErrorPage({ message, stack }: ErrorPageProps) {
           >
             <div className="flex flex-row items-center justify-center space-x-4">
               <IoHome size={30} />
-              <h1 className="mt-0.5 text-2xl font-bold">홈으로 돌아가기</h1>
+              <h1 className="mt-0.5 text-2xl font-semibold">홈으로 돌아가기</h1>
             </div>
           </button>
         </div>

--- a/src/components/ErrorBoundary/NotFoundPage.tsx
+++ b/src/components/ErrorBoundary/NotFoundPage.tsx
@@ -42,7 +42,7 @@ export default function NotFoundPage() {
           >
             <div className="flex flex-row items-center justify-center space-x-4">
               <IoHome size={30} />
-              <h1 className="mt-0.5 text-2xl font-bold">홈으로 돌아가기</h1>
+              <h1 className="mt-0.5 text-2xl font-semibold">홈으로 돌아가기</h1>
             </div>
           </button>
         </div>

--- a/src/components/ProsAndConsTitle/PropsAndConsTitle.tsx
+++ b/src/components/ProsAndConsTitle/PropsAndConsTitle.tsx
@@ -1,11 +1,11 @@
 export default function PropsAndConsTitle() {
   return (
-    <div className="mx-auto flex w-full items-center justify-between py-4">
-      <div className="flex w-1/2 flex-col items-center px-4">
+    <div className="mx-auto flex w-full items-center justify-between gap-2 py-4">
+      <div className="flex w-1/2 flex-col items-center">
         <span className="text-2xl font-bold text-camp-blue">찬성</span>
         <div className="mt-1 h-1 w-full bg-camp-blue" />
       </div>
-      <div className="flex w-1/2 flex-col items-center px-4">
+      <div className="flex w-1/2 flex-col items-center">
         <span className="text-2xl font-bold text-camp-red">반대</span>
         <div className="mt-1 h-1 w-full bg-camp-red" />
       </div>

--- a/src/layout/components/footer/StickyFooterWrapper.tsx
+++ b/src/layout/components/footer/StickyFooterWrapper.tsx
@@ -4,7 +4,7 @@ export default function StickyFooterWrapper(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <footer className="sticky bottom-0 flex w-full content-center items-center gap-1">
+    <footer className="sticky bottom-0 flex w-full content-center items-center gap-1 px-8">
       {children}
     </footer>
   );

--- a/src/page/LoginPage/components/LinkButton/LinkButton.tsx
+++ b/src/page/LoginPage/components/LinkButton/LinkButton.tsx
@@ -15,7 +15,7 @@ export default function LinkButton({ url, title }: LinkButtonProps) {
   return (
     <button
       onClick={handleClick}
-      className="rounded-lg bg-amber-300 p-5 transition-transform duration-200 hover:scale-105"
+      className="rounded-lg bg-amber-300 p-5 font-semibold transition-transform duration-200 hover:scale-105"
     >
       {title}
     </button>

--- a/src/page/TableComposition/TableComposition.test.tsx
+++ b/src/page/TableComposition/TableComposition.test.tsx
@@ -56,9 +56,7 @@ describe('TableComposition', () => {
       }),
     );
     expect(screen.getByText('토론 유형')).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: '시간표 추가' }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '다음' })).toBeInTheDocument();
   });
 
   it('mode=edit일 때 서버에서 가져온 초기값이 반영된다 (tableId=1)', async () => {
@@ -85,7 +83,7 @@ describe('TableComposition', () => {
       </TestWrapper>,
     );
 
-    const nextButton = screen.getByText('시간표 추가');
+    const nextButton = screen.getByText('다음');
     await userEvent.click(nextButton);
 
     // TimeBoxStep 컴포넌트가 표시된다고 가정
@@ -101,7 +99,7 @@ describe('TableComposition', () => {
       </TestWrapper>,
     );
 
-    const nextButton = screen.getByText('시간표 추가');
+    const nextButton = screen.getByText('다음');
     await userEvent.click(nextButton);
 
     // 3. TimeBoxStep 노출 확인
@@ -111,11 +109,11 @@ describe('TableComposition', () => {
     const submitButton = screen.getByText('시간표 추가 완료');
     expect(submitButton).toBeDisabled();
 
-    const leftAddButton = screen.getAllByText('+')[0]; // 첫 번째 "+" 버튼 (왼쪽 버튼)
-    await userEvent.click(leftAddButton);
-
-    const addButton = screen.getByText('시간표 설정');
+    const addButton = screen.getAllByText('+')[0]; // 첫 번째 "+" 버튼 (왼쪽 버튼)
     await userEvent.click(addButton);
+
+    const confirmButton = screen.getByRole('button', { name: '시간표 설정' });
+    await userEvent.click(confirmButton);
 
     await userEvent.click(submitButton);
 

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -41,7 +41,7 @@ export default function DebatePanel(props: DebatePanelProps) {
     <div
       className={`relative flex w-1/2 flex-col items-center justify-center rounded-md ${
         isPros ? 'bg-camp-blue' : 'bg-camp-red'
-      } h-24 select-none p-2 font-bold text-neutral-0`}
+      } h-20 select-none p-2 font-bold text-neutral-0`}
     >
       {onSubmitEdit && onSubmitDelete && (
         <>
@@ -70,31 +70,29 @@ export default function DebatePanel(props: DebatePanelProps) {
           )}
         </>
       )}
-      <div>
-        {debateTypeLabel} | {speakerNumber}번 토론자
+      <div className="font-semibold">
+        {debateTypeLabel} {speakerNumber && `| ${speakerNumber}번 토론자`}
       </div>
-      <div className="text-2xl">{timeStr}</div>
+      <div className="text-2xl font-semibold">{timeStr}</div>
     </div>
   );
 
   const renderNeutralTimeoutPanel = () => (
-    <div className="relative flex h-24 w-full select-none items-center text-center">
-      <div className="relative flex h-4/5 w-full flex-col items-center justify-center rounded-md bg-neutral-500 p-2 font-medium ">
-        {onSubmitEdit && onSubmitDelete && (
-          <>
-            {renderDragHandle()}
-            <div className="absolute right-2 top-2">
-              <EditDeleteButtons
-                info={props.info}
-                onSubmitEdit={onSubmitEdit}
-                onSubmitDelete={onSubmitDelete}
-              />
-            </div>
-          </>
-        )}
-        <span className="text-sm">{debateTypeLabel}</span>
-        <span className="text-xl">{timeStr}</span>
-      </div>
+    <div className="relative flex h-20 w-full flex-col items-center justify-center rounded-md bg-neutral-500 p-2 font-medium ">
+      {onSubmitEdit && onSubmitDelete && (
+        <>
+          {renderDragHandle()}
+          <div className="absolute right-2 top-2">
+            <EditDeleteButtons
+              info={props.info}
+              onSubmitEdit={onSubmitEdit}
+              onSubmitDelete={onSubmitDelete}
+            />
+          </div>
+        </>
+      )}
+      <span className="font-semibold">{debateTypeLabel}</span>
+      <span className="text-2xl font-semibold">{timeStr}</span>
     </div>
   );
 

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -28,14 +28,14 @@ export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
       <div className="flex justify-end gap-2">
         <button
           onClick={openEditModal}
-          className="rounded-sm bg-neutral-0"
+          className="rounded-sm bg-neutral-0 p-[2px]"
           aria-label="수정하기"
         >
           <RiEditFill className="text-neutral-900" />
         </button>
         <button
           onClick={deleteOpenModal}
-          className="rounded-sm bg-neutral-0"
+          className="rounded-sm bg-neutral-0 p-[2px]"
           aria-label="삭제하기"
         >
           <RiDeleteBinFill className="text-neutral-900" />

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -106,9 +106,9 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
           </div>
         </section>
       </DefaultLayout.ContentContainer>
-      
+
       <DefaultLayout.StickyFooterWrapper>
-        <div className="mx-auto mb-4 w-full max-w-4xl px-6 md:px-8">
+        <div className="mx-auto mb-4 w-full max-w-4xl">
           <button
             onClick={() => {
               if (info.name === '') {
@@ -119,9 +119,9 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
               }
               onButtonClick();
             }}
-            className="font-semibol h-16 w-full rounded-md bg-brand-main text-lg transition-colors duration-300 hover:bg-amber-500 md:text-xl"
+            className="h-16 w-full rounded-md bg-brand-main text-lg font-semibold transition-colors duration-300 hover:bg-amber-500 md:text-xl"
           >
-            {isEdit ? '시간표 수정' : '시간표 추가'}
+            다음
           </button>
         </div>
       </DefaultLayout.StickyFooterWrapper>

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -83,7 +83,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
         <div className="mx-auto mb-4 w-full max-w-4xl px-6 md:px-8">
           <button
             onClick={onButtonClick}
-            className={`font-semibol h-16 w-full rounded-md text-lg transition-colors duration-300 md:text-xl ${
+            className={`font-semibol h-16 w-full rounded-md text-lg font-semibold transition-colors duration-300 md:text-xl ${
               isAbledSummitButton
                 ? 'bg-brand-main hover:bg-amber-600'
                 : 'cursor-not-allowed bg-neutral-500'

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -57,7 +57,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       </DefaultLayout.Header>
 
       <DefaultLayout.ContentContainer>
-        <section className="mx-auto flex w-full max-w-4xl flex-col">
+        <section className="mx-auto flex w-full max-w-4xl flex-col justify-center">
           <PropsAndConsTitle />
           <DragAndDropWrapper>
             {initTimeBox.map((info, index) => (
@@ -80,7 +80,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       </DefaultLayout.ContentContainer>
 
       <DefaultLayout.StickyFooterWrapper>
-        <div className="mx-auto mb-4 w-full max-w-4xl px-6 md:px-8">
+        <div className="mx-auto mb-4 w-full max-w-4xl">
           <button
             onClick={onButtonClick}
             className={`font-semibol h-16 w-full rounded-md text-lg font-semibold transition-colors duration-300 md:text-xl ${

--- a/src/page/TableComposition/components/TimerCreationButton/TimerCreationButton.tsx
+++ b/src/page/TableComposition/components/TimerCreationButton/TimerCreationButton.tsx
@@ -4,7 +4,7 @@ export default function TimerCreationButton(
   props: ButtonHTMLAttributes<HTMLButtonElement>,
 ) {
   return (
-    <div className="m-2 flex w-full items-center justify-center">
+    <div className="m-4 flex w-full items-center justify-center">
       <button
         className="flex h-10 w-4/5 items-center justify-center rounded-md bg-neutral-300 font-bold hover:bg-neutral-500"
         {...props}

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -53,15 +53,18 @@ export default function TimerCreationContent({
   };
 
   return (
-    <>
+    <div className="relative aspect-[6/5]">
       <h2
         className={`mb-4 px-4 py-4 text-xl font-bold text-neutral-0 ${getStanceColor()}`}
       >
-        타임박스 설정
+        시간표 설정
       </h2>
-      <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-col gap-6 p-4">
         <div className="flex items-center space-x-2">
-          <label htmlFor="debate-type-select" className="w-16 flex-shrink-0">
+          <label
+            htmlFor="debate-type-select"
+            className="w-16 flex-shrink-0 font-semibold"
+          >
             유형
           </label>
           <select
@@ -88,7 +91,10 @@ export default function TimerCreationContent({
         </div>
 
         <div className="flex items-center space-x-2">
-          <label htmlFor="stance-select" className="w-16 flex-shrink-0">
+          <label
+            htmlFor="stance-select"
+            className="w-16 flex-shrink-0 font-semibold"
+          >
             입장
           </label>
           <select
@@ -107,27 +113,30 @@ export default function TimerCreationContent({
         </div>
 
         <div className="flex w-full items-center space-x-2">
-          <label htmlFor="minutes-input" className="w-16 flex-shrink-0">
+          <label
+            htmlFor="minutes-input"
+            className="w-16 flex-shrink-0 font-semibold"
+          >
             시간
           </label>
           <div className="flex w-full min-w-1 flex-wrap space-x-2">
-            <div className="flex min-w-12 flex-1 items-center">
+            <div className="flex min-w-10 flex-1 items-center">
               <input
                 id="minutes-input"
                 type="number"
                 min={0}
-                className="min-w-10 flex-grow rounded border p-1 text-center"
+                className="min-w-8 flex-grow rounded border p-1"
                 value={minutes.toString()}
                 onChange={(e) => setMinutes(Number(e.target.value))}
               />
               <span className="ml-1 flex-shrink-0">분</span>
             </div>
-            <div className="flex min-w-12 flex-1 items-center">
+            <div className="flex min-w-10 flex-1 items-center">
               <input
                 id="seconds-input"
                 type="number"
                 min={0}
-                className="min-w-10 flex-grow rounded border p-1 text-center"
+                className="min-w-8 flex-grow rounded border p-1"
                 value={seconds.toString()}
                 onChange={(e) => setSeconds(Number(e.target.value))}
               />
@@ -137,7 +146,10 @@ export default function TimerCreationContent({
         </div>
 
         <div className="flex min-w-0 items-center space-x-2">
-          <label htmlFor="speaker-number-input" className="w-16 flex-shrink-0">
+          <label
+            htmlFor="speaker-number-input"
+            className="w-16 flex-shrink-0 font-semibold"
+          >
             발언자
           </label>
           <select
@@ -161,12 +173,12 @@ export default function TimerCreationContent({
         </div>
 
         <button
-          className="mt-4 w-full rounded bg-amber-300 p-2 font-semibold hover:bg-amber-500"
+          className="absolute bottom-4 left-4 right-4 mt-4 rounded bg-amber-300 p-2 font-semibold hover:bg-amber-500"
           onClick={handleSubmit}
         >
           시간표 설정
         </button>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -52,6 +52,12 @@ export default function TimerCreationContent({
     }
   };
 
+  const validateTime = (value: string) => {
+    if (value === '') return 0; // 빈 값 허용
+    const num = Math.max(0, Math.min(59, Number(value))); // 0~59 범위 유지
+    return num;
+  };
+
   return (
     <div className="relative aspect-square min-w-[400px]">
       <h2
@@ -128,7 +134,7 @@ export default function TimerCreationContent({
                 max={59}
                 className="min-w-8 flex-grow rounded border p-1"
                 value={minutes.toString()}
-                onChange={(e) => setMinutes(Number(e.target.value))}
+                onChange={(e) => setMinutes(validateTime(e.target.value))}
               />
               <span className="ml-1 flex-shrink-0">분</span>
             </div>
@@ -140,7 +146,7 @@ export default function TimerCreationContent({
                 max={59}
                 className="min-w-8 flex-grow rounded border p-1"
                 value={seconds.toString()}
-                onChange={(e) => setSeconds(Number(e.target.value))}
+                onChange={(e) => setSeconds(validateTime(e.target.value))}
               />
               <span className="ml-1 flex-shrink-0">초</span>
             </div>

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -53,7 +53,7 @@ export default function TimerCreationContent({
   };
 
   return (
-    <div className="relative aspect-[6/5]">
+    <div className="relative aspect-square min-w-[400px]">
       <h2
         className={`mb-4 px-4 py-4 text-xl font-bold text-neutral-0 ${getStanceColor()}`}
       >

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -6,7 +6,7 @@ interface TimerCreationContentProps {
   selectedStance: Stance;
   initDate?: TimeBoxInfo;
   onSubmit: (data: TimeBoxInfo) => void;
-  onClose: () => void; // 모달 닫기 함수
+  onClose: () => void;
 }
 
 export default function TimerCreationContent({
@@ -125,6 +125,7 @@ export default function TimerCreationContent({
                 id="minutes-input"
                 type="number"
                 min={0}
+                max={59}
                 className="min-w-8 flex-grow rounded border p-1"
                 value={minutes.toString()}
                 onChange={(e) => setMinutes(Number(e.target.value))}
@@ -136,6 +137,7 @@ export default function TimerCreationContent({
                 id="seconds-input"
                 type="number"
                 min={0}
+                max={59}
                 className="min-w-8 flex-grow rounded border p-1"
                 value={seconds.toString()}
                 onChange={(e) => setSeconds(Number(e.target.value))}

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -161,7 +161,7 @@ export default function TimerCreationContent({
         </div>
 
         <button
-          className="mt-4 w-full rounded bg-amber-300 p-2 hover:bg-amber-500"
+          className="mt-4 w-full rounded bg-amber-300 p-2 font-semibold hover:bg-amber-500"
           onClick={handleSubmit}
         >
           시간표 설정

--- a/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
@@ -34,7 +34,7 @@ export default function DeleteModalButton({
           <h1 className="text-xl font-bold">삭제하시겠습니까?</h1>
           <h2 className="text-lg font-semibold">테이블명: {name}</h2>
           <button
-            className="mt-8 rounded-lg bg-red-500 px-8 py-2 text-white"
+            className="mt-8 rounded-lg bg-red-500 px-8 py-2 font-semibold text-white"
             onClick={handleDelete}
           >
             삭제

--- a/src/page/TableListPage/components/Table/AddTable.tsx
+++ b/src/page/TableListPage/components/Table/AddTable.tsx
@@ -5,7 +5,7 @@ export default function AddTable() {
   return (
     <button
       onClick={() => navigate(`/composition?mode=add`)}
-      className="m-5 h-[243px] w-[500px] rounded-md bg-neutral-300 px-[40px] duration-200 hover:scale-105"
+      className="m-5 h-[243px] w-[500px] rounded-md bg-neutral-300 px-[40px] font-semibold duration-200 hover:scale-105"
     >
       <h1 className="text-[50px] font-bold">+</h1>
     </button>

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -26,7 +26,7 @@ export default function TableOverview() {
       </DefaultLayout.Header>
 
       <DefaultLayout.ContentContainer>
-        <section className="mx-auto flex w-full max-w-4xl flex-col">
+        <section className="mx-auto flex w-full max-w-4xl flex-col justify-center">
           <PropsAndConsTitle />
           <div className="flex w-full flex-col gap-2">
             {data &&
@@ -38,7 +38,7 @@ export default function TableOverview() {
       </DefaultLayout.ContentContainer>
 
       <DefaultLayout.StickyFooterWrapper>
-        <div className="mx-auto mb-4 flex w-full max-w-4xl gap-1 px-6 md:px-8">
+        <div className="mx-auto mb-4 flex w-full max-w-4xl items-center justify-between gap-2">
           <button
             className="flex h-16 w-full items-center justify-center gap-2 rounded-md bg-neutral-300 text-2xl font-semibold  transition-colors duration-300 hover:bg-neutral-500"
             onClick={() =>

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -28,17 +28,19 @@ export default function TableOverview() {
       <DefaultLayout.ContentContainer>
         <section className="mx-auto flex w-full max-w-4xl flex-col">
           <PropsAndConsTitle />
-          {data &&
-            data.table.map((info, index) => (
-              <DebatePanel key={index} info={info} />
-            ))}
+          <div className="flex w-full flex-col gap-2">
+            {data &&
+              data.table.map((info, index) => (
+                <DebatePanel key={index} info={info} />
+              ))}
+          </div>
         </section>
       </DefaultLayout.ContentContainer>
 
       <DefaultLayout.StickyFooterWrapper>
         <div className="mx-auto mb-4 flex w-full max-w-4xl gap-1 px-6 md:px-8">
           <button
-            className="flex h-16 w-full items-center justify-center gap-2 rounded-md bg-neutral-300 text-2xl  transition-colors duration-300 hover:bg-neutral-500"
+            className="flex h-16 w-full items-center justify-center gap-2 rounded-md bg-neutral-300 text-2xl font-semibold  transition-colors duration-300 hover:bg-neutral-500"
             onClick={() =>
               navigate(
                 `/composition?mode=edit&tableId=${tableId}&type=PARLIAMENTARY`,
@@ -49,7 +51,7 @@ export default function TableOverview() {
             수정하기
           </button>
           <button
-            className="flex h-16 w-full items-center justify-center gap-2 rounded-md bg-brand-main text-2xl transition-colors duration-300 hover:bg-amber-600"
+            className="flex h-16 w-full items-center justify-center gap-2 rounded-md bg-brand-main text-2xl font-semibold transition-colors duration-300 hover:bg-amber-600"
             onClick={() => navigate(`/table/parliamentary/${tableId}`)}
           >
             <RiSpeakFill />


### PR DESCRIPTION
# 🚩 연관 이슈

closed #151

# 📝 작업 내용
- 시간표 조회 화면에 찬성, 반대 박스 간 margin 설정 ✅
- 타임박스 삭제/수정 아이콘 padding 추가 ✅
- 찬/반 타임박스 높이 맞추기 (중립 타임박스가 더 낮음) ✅
- 시간표 수정 화면에서 상단의 찬/반 사이 너비와 아래의 수정하기/토론하기 버튼 사이 너비를 일치 ✅
(수정하기/토론하기 버튼 사이 너비를 상단에 맞추기)
- 시간표 수정/조회 화면에서 하단 버튼 텍스트 굵게 ✅
- 시간표 수정/조회 화면에서 모든 요소 완전히 중앙 정렬 ✅
- 타임박스 모달 관련
    - 유형, 입장, 시간, 발언자 세미볼드 ✅
    - 시간표 설정 버튼 세미볼드 ✅
    - 전반적으로 너비를 줄이자 ✅
    - 수평 패딩 추가 ✅
    - 텍스트 필드 정렬은 왼쪽으로 ✅
    - ‘타임박스’ → ‘시간표’ 문자열 수정 ✅

# 🏞️ 스크린샷 (선택)
시간표 상세페이지
- before
<img width="1822" alt="image" src="https://github.com/user-attachments/assets/62425f2f-ab31-4cc5-8fcb-cc751f943be3" />

- after
<img width="1822" alt="image" src="https://github.com/user-attachments/assets/9b6aec8b-8e89-4c29-93ac-080006ba3185" />

시간표 수정 생성 페이지
- before
<img width="1822" alt="image" src="https://github.com/user-attachments/assets/dc0ef49a-6b26-4993-9772-cac406931be9" />

-after
<img width="1822" alt="image" src="https://github.com/user-attachments/assets/01da23ca-463d-4c85-ae99-e27cc32dffbd" />

시간표 수정 삭제 모달
- before
<img width="1822" alt="image" src="https://github.com/user-attachments/assets/abc2588a-e3b9-422f-9728-1ed50956d44f" />

- after
<img width="1822" alt="image" src="https://github.com/user-attachments/assets/5b2f0248-74ce-484b-a6ee-cbf82745c0f8" />

