### PR TITLE
[FIX] 작전시간 이후 다음 시간표 박스에도 작전시간이 들어가는 문제 수정

### DIFF
--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -43,8 +43,7 @@ export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
       </div>
       <EditModalWrapper>
         <TimerCreationContent
-          selectedStance={info.stance}
-          initDate={info}
+          initData={info}
           onSubmit={(newInfo) => {
             onSubmitEdit(newInfo);
           }}

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -106,7 +106,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
           </div>
         </section>
       </DefaultLayout.ContentContainer>
-      
+
       <DefaultLayout.StickyFooterWrapper>
         <div className="mx-auto mb-4 w-full max-w-4xl px-6 md:px-8">
           <button

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -97,14 +97,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
 
       <ModalWrapper>
         <TimerCreationContent
-          selectedStance={
-            initTimeBox.length === 0
-              ? 'PROS'
-              : initTimeBox[initTimeBox.length - 1].stance === 'PROS'
-                ? 'CONS'
-                : 'PROS'
-          }
-          initDate={initTimeBox[initTimeBox.length - 1]}
+          beforeData={initTimeBox[initTimeBox.length - 1]}
           onSubmit={(data) => {
             onTimeBoxChange((prev) => [...prev, data]);
           }}

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -3,29 +3,33 @@ import { TimeBoxInfo, DebateType, Stance } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 
 interface TimerCreationContentProps {
-  selectedStance: Stance;
-  initDate?: TimeBoxInfo;
+  beforeData?: TimeBoxInfo;
+  initData?: TimeBoxInfo;
   onSubmit: (data: TimeBoxInfo) => void;
   onClose: () => void; // 모달 닫기 함수
 }
 
 export default function TimerCreationContent({
-  selectedStance,
-  initDate,
+  beforeData,
+  initData,
   onSubmit,
   onClose,
 }: TimerCreationContentProps) {
-  const [stance, setStance] = useState<Stance>(selectedStance);
+  const [stance, setStance] = useState<Stance>(
+    beforeData?.stance === 'NEUTRAL'
+      ? 'PROS'
+      : (beforeData?.stance ?? initData?.stance ?? 'PROS'),
+  );
   const [debateType, setDebateType] = useState<DebateType>(
-    initDate?.type ?? 'OPENING',
+    initData?.type ?? 'OPENING',
   );
   const { minutes: initMinutes, seconds: initSeconds } =
-    Formatting.formatSecondsToMinutes(initDate?.time ?? 180);
+    Formatting.formatSecondsToMinutes(initData?.time ?? 180);
 
   const [minutes, setMinutes] = useState(initMinutes);
   const [seconds, setSeconds] = useState(initSeconds);
   const [speakerNumber, setSpeakerNumber] = useState<number | null>(
-    initDate?.stance === 'NEUTRAL' ? 1 : (initDate?.speakerNumber ?? 1),
+    initData?.stance === 'NEUTRAL' ? 1 : (initData?.speakerNumber ?? 1),
   );
 
   const handleSubmit = () => {
@@ -71,10 +75,11 @@ export default function TimerCreationContent({
             onChange={(e) => {
               if (e.target.value === 'TIME_OUT') {
                 setStance('NEUTRAL');
-              } else {
-                setStance(
-                  selectedStance === 'NEUTRAL' ? 'CONS' : selectedStance,
-                );
+              } else if (
+                stance === 'NEUTRAL' &&
+                e.target.value !== 'TIME_OUT'
+              ) {
+                setStance('PROS');
               }
               setDebateType(e.target.value as DebateType);
             }}
@@ -100,7 +105,7 @@ export default function TimerCreationContent({
             onChange={(e) => setStance(e.target.value as Stance)}
             disabled={stance === 'NEUTRAL'}
           >
-            {stance === 'NEUTRAL' && <option value="NEUTRAL"></option>}
+            {stance === 'NEUTRAL' && <option value="NEUTRAL" />}
             <option value="PROS">찬성</option>
             <option value="CONS">반대</option>
           </select>


### PR DESCRIPTION
# 🚩 연관 이슈

closed #153

# 📝 작업 내용
- 시간표 설정시, 작전시간 이후 다음 시간표 박스에도 작전시간이 들어가는 문제 수정

이전에는 타임 박스를 새로 생성할 때, 이전 타임 박스 설정 정보를 바탕으로 상태를 초기화하기 위해 indata를 props로 넘겼고 타임 박스를 수정할해당 타임박스 정보를 initdata로 같은 props로 넘김으로써 충돌이 발생했습니다. 이를 beforeData, initData로 분리하였습니다.

# 🏞️ 스크린샷 (선택)
- before

https://github.com/user-attachments/assets/610b394d-b9aa-47cf-843a-78e5218d055c

- after

https://github.com/user-attachments/assets/e862c150-4ce4-41fa-b803-4d5930d71407

