### PR TITLE
[DESIGN] 테마 색상 변경

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,6 +5,7 @@
 @layer base {
   body {
     @apply font-pretendard;
+    @apply bg-background-default;
   }
 }
 

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -9,7 +9,7 @@ function StickyTriSectionHeader(props: PropsWithChildren) {
   const { children } = props;
 
   return (
-    <header className="sticky top-0 min-h-20 border-b-[1px] border-neutral-900 bg-background-default px-6">
+    <header className="sticky top-0 min-h-20 border-b-[1px] border-neutral-900 px-6">
       <div className="relative flex h-full items-center justify-between">
         {children}
       </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -77,7 +77,7 @@ export default {
           blue: '#007AFF',
         },
         background: {
-          default: '#FFFFFF',
+          default: '#F6F5F4',
           secondary: '#FFF3DD',
         },
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -57,7 +57,7 @@ export default {
       },
       colors: {
         brand: {
-          main: '#F8B62D',   
+          main: '#FECD4C',
           sub1: '#01204E',
           sub2: '#028391',
           sub3: '#37474F',
@@ -65,10 +65,6 @@ export default {
         },
         neutral: {
           1000: '#000000',
-          900: '#121212',
-          700: '#3C3C3C',
-          500: '#B9B9B9',
-          300: '#E5E5E5',
           0: '#FFFFFF',
         },
         system: {


### PR DESCRIPTION
# 🚩 연관 이슈

closed #156 

# 📝 작업 내용
- 주 색상을 `#FECD4C`으로 변경
- 배경 색상(헤더 + 컨테이너)을 `#F6F5F4`로 변경
- neutral 색상 테이블에 300~900 삭제 (기본값 쓰기로 함)

# 🏞️ 스크린샷 (선택)
뭔가 배경이 둘 다 새하얀 편이라 구분이 어렵지만... 옆에 바로 두고 비교하면 다르게 보이기는 합니다.

## Before
![image](https://github.com/user-attachments/assets/3501cf9c-446b-4663-af23-085abd73d1af)

## After
![image](https://github.com/user-attachments/assets/3ac143cc-9f84-46f9-a6d0-c7e395644438)

# 🗣️ 리뷰 요구사항 (선택)
없음