### PR TITLE
[FIX] 이전 시간표에 따라 시간표 생성 모달 기본 입장이 변경되지 않는 문제 수정

### DIFF
--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -16,20 +16,29 @@ export default function TimerCreationContent({
   onClose,
 }: TimerCreationContentProps) {
   const [stance, setStance] = useState<Stance>(
-    beforeData?.stance === 'NEUTRAL'
-      ? 'PROS'
-      : (beforeData?.stance ?? initData?.stance ?? 'PROS'),
+    beforeData?.stance
+      ? beforeData?.stance === 'NEUTRAL'
+        ? 'PROS'
+        : beforeData?.stance === 'CONS'
+          ? 'PROS'
+          : 'CONS'
+      : (initData?.stance ?? 'PROS'),
   );
+
   const [debateType, setDebateType] = useState<DebateType>(
-    initData?.type ?? 'OPENING',
+    beforeData?.type ?? initData?.type ?? 'OPENING',
   );
   const { minutes: initMinutes, seconds: initSeconds } =
-    Formatting.formatSecondsToMinutes(initData?.time ?? 180);
+    Formatting.formatSecondsToMinutes(
+      beforeData?.time ?? initData?.time ?? 180,
+    );
 
   const [minutes, setMinutes] = useState(initMinutes);
   const [seconds, setSeconds] = useState(initSeconds);
   const [speakerNumber, setSpeakerNumber] = useState<number | null>(
-    initData?.stance === 'NEUTRAL' ? 1 : (initData?.speakerNumber ?? 1),
+    (beforeData?.speakerNumber ?? initData?.stance === 'NEUTRAL')
+      ? null
+      : (initData?.speakerNumber ?? 1),
   );
 
   const handleSubmit = () => {


### PR DESCRIPTION
# 🚩 연관 이슈

closed #166

# 📝 작업 내용
이전 시간표에 따라 시간표 생성 모달 기본 입장이 변경되지 않는 문제 수정
- before

https://github.com/user-attachments/assets/aa2a4d06-499f-492f-9048-1d8959d7d16d


- after

https://github.com/user-attachments/assets/1ada211b-59ea-4088-9521-864a04ff2e21



# 🏞️ 스크린샷 (선택)

# 🗣️ 리뷰 요구사항 (선택)
