### PR TITLE
[DESIGN] 토론 테이블에 주제 표시, 주제 긴 경우 툴팁 추가

### DIFF
--- a/src/page/TableListPage/TableListPage.tsx
+++ b/src/page/TableListPage/TableListPage.tsx
@@ -30,7 +30,7 @@ export default function TableListPage() {
                 id={table.id}
                 name={table.name}
                 type={table.type}
-                duration={table.duration}
+                agenda={table.agenda}
                 onDelete={() => mutate({ tableId: table.id })}
               />
             ))}

--- a/src/page/TableListPage/components/Table/Table.stories.tsx
+++ b/src/page/TableListPage/components/Table/Table.stories.tsx
@@ -35,6 +35,6 @@ export const Default: Story = {
   args: {
     name: '테이블 1',
     type: 'PARLIAMENTARY',
-    duration: 30,
+    agenda: '테이블 1의 주제',
   },
 };

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -35,7 +35,7 @@ export default function Table({
         <div className="flex max-w-full flex-col items-start justify-center text-[36px] font-bold">
           <span>유형 | {typeMapping[type]}</span>
           <span
-            className="w-full truncate hover:delay-0"
+            className="w-full truncate"
             title={agenda && agenda?.length > 15 ? agenda : undefined}
           >
             주제 | {agenda || '주제 없음'}

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -3,7 +3,6 @@ import { DebateTable } from '../../../../type/type';
 import EditButton from '../Modal/EditButton';
 import DeleteModalButton from '../Modal/DeleteModalButton';
 import { typeMapping } from '../../../../constants/languageMapping';
-import { Formatting } from '../../../../util/formatting';
 
 interface DebateTableWithDelete extends DebateTable {
   onDelete: (name: string) => void;
@@ -13,7 +12,7 @@ export default function Table({
   id,
   name,
   type,
-  duration,
+  agenda,
   onDelete,
 }: DebateTableWithDelete) {
   const navigate = useNavigate();
@@ -21,15 +20,10 @@ export default function Table({
     navigate(`/overview/${id}`);
   };
 
-  const { minutes, seconds } = Formatting.formatSecondsToMinutes(duration);
-  const [durationMinutes, durationSeconds] = [minutes, seconds].map(
-    Formatting.formatTwoDigits,
-  );
-
   return (
     <button
       onClick={handleClick}
-      className="relative m-5 h-[243px] w-[500px] rounded-md bg-[#FECD4C] px-[40px] duration-200 hover:scale-105"
+      className="relative m-5 h-[243px] w-[500px] rounded-md bg-[#FECD4C] px-[40px] text-left duration-200 hover:scale-105"
     >
       <div className="absolute right-[40px] top-[40px] flex flex-row space-x-2">
         <EditButton tableId={id} type={type} />
@@ -38,10 +32,13 @@ export default function Table({
 
       <div className="flex h-full flex-col items-start justify-center">
         <h1 className="mb-[30px] text-[40px] font-bold">{name}</h1>
-        <div className="flex flex-col items-start justify-center text-[36px] font-bold">
+        <div className="flex max-w-full flex-col items-start justify-center text-[36px] font-bold">
           <span>유형 | {typeMapping[type]}</span>
-          <span>
-            시간 | {durationMinutes}분 {durationSeconds}초
+          <span
+            className="w-full truncate hover:delay-0"
+            title={agenda && agenda?.length > 15 ? agenda : undefined}
+          >
+            주제 | {agenda || '주제 없음'}
           </span>
         </div>
       </div>

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -43,7 +43,7 @@ export interface DebateTable {
   id: number;
   name: string;
   type: Type;
-  duration: number;
+  agenda: string;
 }
 
 export type Type = 'PARLIAMENTARY';


### PR DESCRIPTION
# 🚩 연관 이슈

closed #170 

# 📝 작업 내용

- 토론 테이블에 시간 대신 주제 표시함
- 주제가 없는 경우 '주제 없음'으로 표시
- 주제가 긴 경우 말줄임표 사용, 호버 시 툴팁으로 전체 텍스트 확인 가능

# 🏞️ 스크린샷 (선택)
<img width="544" alt="스크린샷 2025-03-13 오후 1 23 29" src="https://github.com/user-attachments/assets/c88ba5e2-d12c-45f4-8e0f-f319d374bc58" />

# 🗣️ 리뷰 요구사항 (선택)
합류 후 첫 코드 수정이라 놓친 부분이 있을까 걱정되네요. 코드 리뷰 부탁드립니다-!