### PR TITLE
[FIX] Discord 스크립트 오류 수정

### DIFF
--- a/.github/workflows/Issue_Noti.yml
+++ b/.github/workflows/Issue_Noti.yml
@@ -14,7 +14,7 @@ jobs:
           TITLE: ${{ github.event.issue.title }}
         run: |
           echo "AVATAR_URL=${{ secrets.DISCORD_AVATAR_URL }}" >> $GITHUB_ENV
-          echo "COMMENT_BODY=${{ github.event.issue.body }}" >> $GITHUB_ENV
+          echo "COMMENT_BODY=$(echo "${{ github.event.issue.body }}" | base64)" >> $GITHUB_ENV
           echo "USERNAME=망곰" >> $GITHUB_ENV
           echo "WEB_HOOK=${{ secrets.DISCORD_WEB_HOOK }}" >> $GITHUB_ENV
 
@@ -30,8 +30,9 @@ jobs:
           WEB_HOOK: ${{ env.WEB_HOOK }}
         run: |
           if [ -n "$WEB_HOOK" ]; then
+            DECODED_COMMENT_BODY=$(echo "$COMMENT_BODY" | base64 --decode)
             JSON_PAYLOAD=$(jq -n \
-              --arg comment_body "$COMMENT_BODY" \
+              --arg comment_body "$(echo "$DECODED_COMMENT_BODY" | jq -R @json)" \
               --arg username "$USERNAME" \
               --arg avatar_url "$AVATAR_URL" \
               --arg issue_title "$ISSUE_TITLE" \

--- a/.github/workflows/PR_Comment_Noti.yml
+++ b/.github/workflows/PR_Comment_Noti.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set Environment Variables
         run: |
           echo "AVATAR_URL=${{ secrets.DISCORD_AVATAR_URL }}" >> $GITHUB_ENV
-          echo "COMMENT_BODY=$(echo '${{ github.event.comment.body }}' | jq -Rs .)" >> $GITHUB_ENV
+          echo "COMMENT_BODY=$(echo '${{ github.event.comment.body }}' | base64)" >> $GITHUB_ENV
           echo "USERNAME=망곰" >> $GITHUB_ENV
           echo "WEB_HOOK=${{ secrets.DISCORD_WEB_HOOK }}" >> $GITHUB_ENV
 
@@ -29,8 +29,9 @@ jobs:
           WEB_HOOK: ${{ env.WEB_HOOK }}
         run: |
           if [ -n "$WEB_HOOK" ]; then
+            DECODED_COMMENT_BODY=$(echo "$COMMENT_BODY" | base64 --decode)
             JSON_PAYLOAD=$(jq -n \
-              --arg comment_body "$COMMENT_BODY" \
+              --arg comment_body "$(echo "$DECODED_COMMENT_BODY" | jq -R @json)" \
               --arg username "$USERNAME" \
               --arg avatar_url "$AVATAR_URL" \
               --arg pr_title "$PR_TITLE" \


### PR DESCRIPTION
# 🚩 연관 이슈

closed #172 

# 📝 작업 내용
## 개요
- PR 댓글 알림 스크립트의 제어 문자(`\n` 등)가 제대로 동작하지 않는 오류 해결
- 이슈 생성 알림 스크립트의 제어 문자가 제대로 동작하지 않는 오류 해결
- 이슈 생성 알림 스크립트가 실행되지 않는 오류 해결

## 설명
### 이슈 생성 알림 스크립트 오류 원인 분석
GitHub Copilot의 답변을 첨부합니다:
> 이 오류는 COMMENT_BODY 변수에 포함된 내용이 환경 변수로 설정될 때 문제가 발생하는 것입니다. 특히, COMMENT_BODY에 포함된 줄바꿈이나 특수 문자가 문제를 일으킬 수 있습니다. 이를 해결하기 위해 COMMENT_BODY를 환경 변수로 설정하기 전에 인코딩할 수 있습니다.

조언에 따라, base64로 인코딩하여 환경 변수로 설정 후, jq로 전송하기 직전 디코딩하여 복구하는 식으로 수정했습니다.

### 특수문자 표시
jq에 페이로드를 싣을 때, `jq -R @json` 명령어를 사용하여 제어 문자가 잘 이스케이프되도록 수정했습니다.

> -R (--raw-input): Reads input as a raw string instead of treating it as JSON.
@json: Converts the raw string into a valid JSON string by escaping special characters.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음