### PR TITLE
[DESIGN] 시간표 아이템 개수 5개로 고정되도록 변경

### DIFF
--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -100,12 +100,6 @@ export const handlers = [
           speakerNumber: 1,
         },
         {
-          stance: 'NEUTRAL',
-          type: 'TIME_OUT',
-          time: 40,
-          speakerNumber: 1,
-        },
-        {
           stance: 'CONS',
           type: 'CLOSING',
           time: 35,

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -100,6 +100,12 @@ export const handlers = [
           speakerNumber: 1,
         },
         {
+          stance: 'NEUTRAL',
+          type: 'TIME_OUT',
+          time: 40,
+          speakerNumber: 1,
+        },
+        {
           stance: 'CONS',
           type: 'CLOSING',
           time: 35,

--- a/src/page/TimerPage/components/TimeTable.tsx
+++ b/src/page/TimerPage/components/TimeTable.tsx
@@ -37,13 +37,49 @@ export default function TimeTable({
 
         {/** Print time table items(timeboxes) */}
         <div className="flex w-full flex-col space-y-[15px] px-[20px]">
-          {items.map((item, index) => (
-            <TimeTableItem
-              key={index}
-              isCurrent={currIndex === index}
-              item={item}
-            />
-          ))}
+          {items.length > 0 && (
+            <div className="flex w-full flex-col space-y-2">
+              <div className="h-[70px] w-full">
+                {currIndex - 2 >= 0 && (
+                  <TimeTableItem
+                    isCurrent={false}
+                    item={items[currIndex - 2]}
+                  />
+                )}
+              </div>
+
+              <div className="h-[70px] w-full">
+                {currIndex - 1 >= 0 && (
+                  <TimeTableItem
+                    isCurrent={false}
+                    item={items[currIndex - 1]}
+                  />
+                )}
+              </div>
+
+              <div className="h-[70px] w-full">
+                <TimeTableItem isCurrent={true} item={items[currIndex]} />
+              </div>
+
+              <div className="h-[70px] w-full">
+                {currIndex + 1 <= items.length - 1 && (
+                  <TimeTableItem
+                    isCurrent={false}
+                    item={items[currIndex + 1]}
+                  />
+                )}
+              </div>
+
+              <div className="h-[70px] w-full">
+                {currIndex + 2 <= items.length - 1 && (
+                  <TimeTableItem
+                    isCurrent={false}
+                    item={items[currIndex + 2]}
+                  />
+                )}
+              </div>
+            </div>
+          )}
         </div>
       </div>
 

--- a/src/page/TimerPage/components/TimeTable.tsx
+++ b/src/page/TimerPage/components/TimeTable.tsx
@@ -38,7 +38,7 @@ export default function TimeTable({
         {/** Print time table items(timeboxes) */}
         <div className="flex w-full flex-col space-y-[15px] px-[20px]">
           {items.length > 0 && (
-            <div className="flex w-full flex-col space-y-2">
+            <div className="flex w-full flex-col space-y-[15px]">
               <div className="h-[70px] w-full">
                 {currIndex - 2 >= 0 && (
                   <TimeTableItem

--- a/src/page/TimerPage/components/TimeTableItem.tsx
+++ b/src/page/TimerPage/components/TimeTableItem.tsx
@@ -20,9 +20,9 @@ export default function TimeTableItem({ isCurrent, item }: TimeTableItem) {
   const pos =
     item.stance !== 'NEUTRAL'
       ? item.stance === 'PROS'
-        ? 'self-start'
-        : 'self-end'
-      : 'self-center';
+        ? 'justify-self-start'
+        : 'justify-self-end'
+      : 'justify-self-center';
   const width = item.stance !== 'NEUTRAL' ? 'w-1/2' : 'w-full';
   const minute = Math.floor(Math.abs(item.time) / 60);
   const second = Math.abs(item.time % 60);
@@ -31,7 +31,7 @@ export default function TimeTableItem({ isCurrent, item }: TimeTableItem) {
   return (
     <div
       data-testid="time-table-item"
-      className={`flex h-[69px] ${width} flex-row items-center justify-center space-x-2 ${pos} ${bgColorClass} ${roundedClass} p-[16px] text-[28px] font-bold ${textColorClass}`}
+      className={`flex h-max ${width} flex-row items-center justify-center space-x-2 ${pos} ${bgColorClass} ${roundedClass} p-[16px] text-[28px] font-bold ${textColorClass}`}
     >
       {/* Print what type is this sequence (e.g., opening, time-out, etc.) */}
       <h1>{DebateTypeToString[item.type]}</h1>

--- a/src/page/TimerPage/stories/TimeTable.stories.tsx
+++ b/src/page/TimerPage/stories/TimeTable.stories.tsx
@@ -33,6 +33,24 @@ export const Default: Story = {
         time: 60,
       },
       {
+        stance: 'PROS',
+        type: 'REBUTTAL',
+        time: 175,
+        speakerNumber: 1,
+      },
+      {
+        stance: 'CONS',
+        type: 'REBUTTAL',
+        time: 175,
+        speakerNumber: 1,
+      },
+      {
+        stance: 'NEUTRAL',
+        type: 'TIME_OUT',
+        time: 180,
+        speakerNumber: 0,
+      },
+      {
         stance: 'CONS',
         type: 'CLOSING',
         time: 60,


### PR DESCRIPTION
# 🚩 연관 이슈

closed #169 

# 📝 작업 내용
- 시간표 아이템 개수 5개로 고정되도록 변경
- 현재 순서가 무조건 중앙(3번째)에 고정되도록 변경

# 🏞️ 스크린샷 (선택)
## 인덱스 == 0일 때
![image](https://github.com/user-attachments/assets/894234ca-ce41-4ce6-a006-a7c4d0fd199c)

## 인덱스 == 배열 길이 - 1일 때
![image](https://github.com/user-attachments/assets/2c28c1c0-86c1-4cac-be3a-7550c50908d2)

# 🗣️ 리뷰 요구사항 (선택)
없음