### PR TITLE
[REFACTOR] 대화 상자형 모달 별도 컴포넌트로 분리

### DIFF
--- a/src/components/DialogModal/DialogModal.stories.tsx
+++ b/src/components/DialogModal/DialogModal.stories.tsx
@@ -19,11 +19,14 @@ export const Default: Story = {
         <h1>알림 끄기 → 알림 켜기</h1>
       </div>
     ),
-    leftText: '취소',
-    rightText: '적용',
-    onLeftClick: () => {},
-    onRightClick: () => {},
-    isLeftBold: false,
-    isRightBold: true,
+    left: {
+      text: '취소',
+      onClick: () => {},
+    },
+    right: {
+      text: '적용',
+      onClick: () => {},
+      isBold: true,
+    },
   },
 };

--- a/src/components/DialogModal/DialogModal.stories.tsx
+++ b/src/components/DialogModal/DialogModal.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/react';
+import DialogModal from './DialogModal';
+
+const meta: Meta<typeof DialogModal> = {
+  title: 'components/DialogModal',
+  component: DialogModal,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DialogModal>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <div className="flex flex-col items-center space-y-2 px-10 py-6">
+        <h1 className="text-xl font-bold">변경 사항을 적용하시겠습니까?</h1>
+        <h1>알림 끄기 → 알림 켜기</h1>
+      </div>
+    ),
+    leftText: '취소',
+    rightText: '적용',
+    onLeftClick: () => {},
+    onRightClick: () => {},
+    isLeftBold: false,
+    isRightBold: true,
+  },
+};

--- a/src/components/DialogModal/DialogModal.test.tsx
+++ b/src/components/DialogModal/DialogModal.test.tsx
@@ -1,0 +1,56 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { GlobalPortal } from '../../util/GlobalPortal';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+import DialogModal from './DialogModal';
+import { expect } from 'vitest';
+
+function TestWrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient();
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GlobalPortal.Provider>
+        <MemoryRouter>{children}</MemoryRouter>
+      </GlobalPortal.Provider>
+    </QueryClientProvider>
+  );
+}
+
+describe('DialogModal', () => {
+  const renderDialogModal = () => {
+    return render(
+      <TestWrapper>
+        <DialogModal
+          leftText="왼쪽"
+          rightText="오른쪽"
+          onLeftClick={() => {}}
+          onRightClick={() => {}}
+          isRightBold={true}
+        >
+          <h1 data-testid="container-text">컨테이너 텍스트</h1>
+        </DialogModal>
+      </TestWrapper>,
+    );
+  };
+
+  it('컨테이너 및 컨테이너 컨텐츠 렌더링 검증', () => {
+    renderDialogModal();
+
+    const ancestor = screen.getByTestId('container');
+    const descendant = screen.getByTestId('container-text');
+
+    expect(ancestor).toBeInTheDocument();
+    expect(ancestor).toContainElement(descendant);
+    expect(descendant).toHaveTextContent('컨테이너 텍스트');
+  });
+
+  it('버튼 렌더링 검증', () => {
+    renderDialogModal();
+
+    const leftButton = screen.getByTestId('button-left');
+    const rightButton = screen.getByTestId('button-right');
+
+    expect(leftButton).toBeInTheDocument();
+    expect(rightButton).toBeInTheDocument();
+  });
+});

--- a/src/components/DialogModal/DialogModal.test.tsx
+++ b/src/components/DialogModal/DialogModal.test.tsx
@@ -52,5 +52,8 @@ describe('DialogModal', () => {
 
     expect(leftButton).toBeInTheDocument();
     expect(rightButton).toBeInTheDocument();
+
+    // Checks whether right button text's font weight is bold
+    expect(screen.getByText('오른쪽')).toHaveClass('font-bold');
   });
 });

--- a/src/components/DialogModal/DialogModal.test.tsx
+++ b/src/components/DialogModal/DialogModal.test.tsx
@@ -21,11 +21,8 @@ describe('DialogModal', () => {
     return render(
       <TestWrapper>
         <DialogModal
-          leftText="왼쪽"
-          rightText="오른쪽"
-          onLeftClick={() => {}}
-          onRightClick={() => {}}
-          isRightBold={true}
+          left={{ text: '왼쪽', onClick: () => {} }}
+          right={{ text: '오른쪽', onClick: () => {}, isBold: true }}
         >
           <h1 data-testid="container-text">컨테이너 텍스트</h1>
         </DialogModal>

--- a/src/components/DialogModal/DialogModal.tsx
+++ b/src/components/DialogModal/DialogModal.tsx
@@ -27,18 +27,23 @@ export default function DialogModal({
       {children}
 
       {/** Buttons */}
-      <div
-        data-testid="container"
-        className="w-full border-t border-neutral-300"
-      />
+      <div className="w-full border-t border-neutral-300" />
       <div className="flex w-full flex-row items-center justify-center py-4">
         {/** Left button */}
-        <button className="w-1/2" onClick={() => onLeftClick()}>
+        <button
+          data-testid="button-left"
+          className="w-1/2"
+          onClick={() => onLeftClick()}
+        >
           <p className={`w-full ${isLeftBold} text-brand-sub2`}>{leftText}</p>
         </button>
 
         {/** Right button */}
-        <button className="w-1/2" onClick={() => onRightClick()}>
+        <button
+          data-testid="button-right"
+          className="w-1/2"
+          onClick={() => onRightClick()}
+        >
           <p className={`w-full ${isRightBold} text-brand-sub2`}>{rightText}</p>
         </button>
       </div>

--- a/src/components/DialogModal/DialogModal.tsx
+++ b/src/components/DialogModal/DialogModal.tsx
@@ -35,7 +35,11 @@ export default function DialogModal({
           className="w-1/2"
           onClick={() => onLeftClick()}
         >
-          <p className={`w-full ${isLeftBold} text-brand-sub2`}>{leftText}</p>
+          <p
+            className={`w-full ${isLeftBold ? 'font-bold' : ''} text-brand-sub2`}
+          >
+            {leftText}
+          </p>
         </button>
 
         {/** Right button */}
@@ -44,7 +48,11 @@ export default function DialogModal({
           className="w-1/2"
           onClick={() => onRightClick()}
         >
-          <p className={`w-full ${isRightBold} text-brand-sub2`}>{rightText}</p>
+          <p
+            className={`w-full ${isRightBold ? 'font-bold' : ''} text-brand-sub2`}
+          >
+            {rightText}
+          </p>
         </button>
       </div>
     </div>

--- a/src/components/DialogModal/DialogModal.tsx
+++ b/src/components/DialogModal/DialogModal.tsx
@@ -1,0 +1,47 @@
+import { PropsWithChildren } from 'react';
+
+interface DialogModalProps extends PropsWithChildren {
+  leftText: string;
+  rightText: string;
+  onLeftClick: () => void;
+  onRightClick: () => void;
+  isLeftBold?: boolean;
+  isRightBold?: boolean;
+}
+
+export default function DialogModal({
+  children,
+  leftText,
+  rightText,
+  onLeftClick,
+  onRightClick,
+  isLeftBold = false,
+  isRightBold = false,
+}: DialogModalProps) {
+  return (
+    <div
+      data-testid="container"
+      className="flex max-w-[500px] flex-col items-center"
+    >
+      {/** Children is displayed here */}
+      {children}
+
+      {/** Buttons */}
+      <div
+        data-testid="container"
+        className="w-full border-t border-neutral-300"
+      />
+      <div className="flex w-full flex-row items-center justify-center py-4">
+        {/** Left button */}
+        <button className="w-1/2" onClick={() => onLeftClick()}>
+          <p className={`w-full ${isLeftBold} text-brand-sub2`}>{leftText}</p>
+        </button>
+
+        {/** Right button */}
+        <button className="w-1/2" onClick={() => onRightClick()}>
+          <p className={`w-full ${isRightBold} text-brand-sub2`}>{rightText}</p>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/DialogModal/DialogModal.tsx
+++ b/src/components/DialogModal/DialogModal.tsx
@@ -1,23 +1,30 @@
 import { PropsWithChildren } from 'react';
 
 interface DialogModalProps extends PropsWithChildren {
-  leftText: string;
-  rightText: string;
-  onLeftClick: () => void;
-  onRightClick: () => void;
-  isLeftBold?: boolean;
-  isRightBold?: boolean;
+  left: {
+    text: string;
+    onClick: () => void;
+    isBold?: boolean;
+  };
+  right: {
+    text: string;
+    onClick: () => void;
+    isBold?: boolean;
+  };
 }
 
 export default function DialogModal({
   children,
-  leftText,
-  rightText,
-  onLeftClick,
-  onRightClick,
-  isLeftBold = false,
-  isRightBold = false,
+  left,
+  right,
 }: DialogModalProps) {
+  if (left.isBold === undefined || null) {
+    left.isBold = false;
+  }
+  if (right.isBold === undefined || null) {
+    right.isBold = false;
+  }
+
   return (
     <div
       data-testid="container"
@@ -33,12 +40,12 @@ export default function DialogModal({
         <button
           data-testid="button-left"
           className="w-1/2"
-          onClick={() => onLeftClick()}
+          onClick={() => left.onClick()}
         >
           <p
-            className={`w-full ${isLeftBold ? 'font-bold' : ''} text-brand-sub2`}
+            className={`w-full ${left.isBold ? 'font-bold' : ''} text-brand-sub2`}
           >
-            {leftText}
+            {left.text}
           </p>
         </button>
 
@@ -46,12 +53,12 @@ export default function DialogModal({
         <button
           data-testid="button-right"
           className="w-1/2"
-          onClick={() => onRightClick()}
+          onClick={() => right.onClick()}
         >
           <p
-            className={`w-full ${isRightBold ? 'font-bold' : ''} text-brand-sub2`}
+            className={`w-full ${right.isBold ? 'font-bold' : ''} text-brand-sub2`}
           >
-            {rightText}
+            {right.text}
           </p>
         </button>
       </div>

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -2,6 +2,7 @@ import { RiEditFill, RiDeleteBinFill } from 'react-icons/ri';
 import { TimeBoxInfo } from '../../../../type/type';
 import { useModal } from '../../../../hooks/useModal';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
+import DialogModal from '../../../../components/DialogModal/DialogModal';
 
 interface EditDeleteButtonsPros {
   info: TimeBoxInfo;
@@ -50,27 +51,20 @@ export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
         />
       </EditModalWrapper>
       <DeleteModalWrapper>
-        <div className="flex flex-col items-center">
+        <DialogModal
+          leftText="취소"
+          rightText="삭제"
+          onLeftClick={() => closeDeleteModal()}
+          onRightClick={() => {
+            onSubmitDelete();
+            closeDeleteModal();
+          }}
+          isRightBold={true}
+        >
           <h1 className="px-20 py-10 text-xl font-bold">
             이 순서를 삭제하시겠습니까?
           </h1>
-
-          <div className="w-full border-t border-neutral-300" />
-          <div className="flex w-full flex-row items-center justify-center py-4">
-            <button className="w-1/2" onClick={() => closeDeleteModal()}>
-              <p className="w-full text-brand-sub2">취소</p>
-            </button>
-            <button
-              className="w-1/2"
-              onClick={() => {
-                onSubmitDelete();
-                closeDeleteModal();
-              }}
-            >
-              <p className="w-full font-bold text-brand-sub2">삭제</p>
-            </button>
-          </div>
-        </div>
+        </DialogModal>
       </DeleteModalWrapper>
     </>
   );

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -52,14 +52,15 @@ export default function EditDeleteButtons(props: EditDeleteButtonsPros) {
       </EditModalWrapper>
       <DeleteModalWrapper>
         <DialogModal
-          leftText="취소"
-          rightText="삭제"
-          onLeftClick={() => closeDeleteModal()}
-          onRightClick={() => {
-            onSubmitDelete();
-            closeDeleteModal();
+          left={{ text: '취소', onClick: () => closeDeleteModal() }}
+          right={{
+            text: '삭제',
+            onClick: () => {
+              onSubmitDelete();
+              closeDeleteModal();
+            },
+            isBold: true,
           }}
-          isRightBold={true}
         >
           <h1 className="px-20 py-10 text-xl font-bold">
             이 순서를 삭제하시겠습니까?

--- a/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
@@ -34,11 +34,11 @@ export default function DeleteModalButton({
       </button>
       <ModalWrapper>
         <DialogModal
-          leftText="취소"
-          rightText="삭제"
-          onLeftClick={() => closeModal()}
-          onRightClick={() => handleDelete()}
-          isRightBold={true}
+          left={{
+            text: '취소',
+            onClick: () => closeModal(),
+          }}
+          right={{ text: '삭제', onClick: () => handleDelete(), isBold: true }}
         >
           <div className="flex flex-col items-center space-y-2 px-20 py-10">
             <h1 className="text-xl font-bold">삭제하시겠습니까?</h1>

--- a/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
+++ b/src/page/TableListPage/components/Modal/DeleteModalButton.tsx
@@ -1,5 +1,6 @@
 import { AiOutlineDelete } from 'react-icons/ai';
 import { useModal } from '../../../../hooks/useModal';
+import DialogModal from '../../../../components/DialogModal/DialogModal';
 
 export default function DeleteModalButton({
   name,
@@ -32,25 +33,21 @@ export default function DeleteModalButton({
         <AiOutlineDelete />
       </button>
       <ModalWrapper>
-        <div className="flex flex-col items-center">
-          <h1 className="px-20 pb-4 pt-10 text-xl font-bold">
-            삭제하시겠습니까?
-          </h1>
-          <div className="flex flex-row items-center justify-center space-x-2 pb-10">
-            <p className="text-sm">테이블 이름</p>
-            <p className="text-sm font-semibold">{name}</p>
+        <DialogModal
+          leftText="취소"
+          rightText="삭제"
+          onLeftClick={() => closeModal()}
+          onRightClick={() => handleDelete()}
+          isRightBold={true}
+        >
+          <div className="flex flex-col items-center space-y-2 px-20 py-10">
+            <h1 className="text-xl font-bold">삭제하시겠습니까?</h1>
+            <div className="flex flex-row items-center space-x-2">
+              <h1 className="text-sm">테이블 이름</h1>
+              <h1 className="text-sm font-semibold">{name}</h1>
+            </div>
           </div>
-
-          <div className="w-full border-t border-neutral-300" />
-          <div className="flex w-full flex-row items-center justify-center py-4">
-            <button className="w-1/2" onClick={() => closeModal()}>
-              <p className="w-full text-brand-sub2">취소</p>
-            </button>
-            <button className="w-1/2" onClick={() => handleDelete()}>
-              <p className="w-full font-bold text-brand-sub2">삭제</p>
-            </button>
-          </div>
-        </div>
+        </DialogModal>
       </ModalWrapper>
     </>
   );


### PR DESCRIPTION
# 🚩 연관 이슈

closed #173

# 📝 작업 내용
## 개요
- 대화 상자형 모달 별도 컴포넌트인 `DialogModal`로 분리
- 해당 모달을 사용하는 페이지에 위 변경사항 적용
- `DialogModal` 관련 Storybook 및 테스트 코드 추가

## 용례
```tsx
<DialogModal
  leftText="왼쪽"
  rightText="오른쪽"
  onLeftClick={() => {}}
  onRightClick={() => {}}
  isRightBold={true}
>
   {/** 여기에 모달 안에 들어갈 텍스트 메시지 등 구현 */}
</DialogModal>
```

## 매개변수
### 필수
- `leftText` 왼쪽 버튼에 들어갈 텍스트
- `rightText` 오른쪽 버튼에 들어갈 텍스트
- `onLeftClick` 왼쪽 버튼 클릭 시 동작
- `onRightClick` 오른쪽 버튼 클릭 시 동작

### 선택
- `isLeftBold` 왼쪽 버튼의 텍스트 볼드 표시 (기본값 `false`)
- `isRightBold` 오른쪽 버튼의 텍스트 볼드 표시 (기본값 `false`)

## 추신
해당 모달의 컨텐츠 영역에는 기본적으로 어떤 padding도 적용되어 있지 않으니, 모달 사용 시 padding을 직접 넣어주어야 함

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음