### PR TITLE
[FIX] 작전시간 선택 후, 다임 시간표생성에서 작전시간이 유지되는 문제 수정

### DIFF
--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -26,7 +26,11 @@ export default function TimerCreationContent({
   );
 
   const [debateType, setDebateType] = useState<DebateType>(
-    beforeData?.type ?? initData?.type ?? 'OPENING',
+    beforeData?.type
+      ? beforeData?.type !== 'TIME_OUT'
+        ? beforeData?.type
+        : 'OPENING'
+      : (initData?.type ?? 'OPENING'),
   );
   const { minutes: initMinutes, seconds: initSeconds } =
     Formatting.formatSecondsToMinutes(


### PR DESCRIPTION
# 🚩 연관 이슈

closed #179

# 📝 작업 내용
죄송합니다. 계속 같은 문제로 PR을 작성하게 되네요. 수정부분 PR올립니다.
작전시간 선택 후, 다임 시간표생성에서 작전시간이 유지되는 문제 수정.

- before

https://github.com/user-attachments/assets/442d7843-ad8a-4b06-8b6b-0d5eeda406e5

- after

https://github.com/user-attachments/assets/e4742404-8839-4f3e-97c0-7978af8ec99b


# 🏞️ 스크린샷 (선택)
없음
# 🗣️ 리뷰 요구사항 (선택)
없음