### PR TITLE
[FIX] 에러페이지에서 홈으로 가기 버튼이 동작하지 않는 문제 수정 

### DIFF
--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -44,10 +44,22 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     console.log(error, errorInfo);
   }
 
+  resetError = () => {
+    this.setState({
+      hasError: false,
+      message: defaultMessage,
+      stack: defaultStack,
+    });
+  };
+
   render(): ReactNode {
     if (this.state.hasError) {
       return (
-        <ErrorPage message={this.state.message} stack={this.state.stack} />
+        <ErrorPage
+          message={this.state.message}
+          stack={this.state.stack}
+          onReset={this.resetError}
+        />
       );
     }
 

--- a/src/components/ErrorBoundary/ErrorPage.tsx
+++ b/src/components/ErrorBoundary/ErrorPage.tsx
@@ -5,11 +5,15 @@ import { useNavigate } from 'react-router-dom';
 interface ErrorPageProps {
   message: string;
   stack: string;
+  onReset: () => void;
 }
 
-export default function ErrorPage({ message, stack }: ErrorPageProps) {
+export default function ErrorPage({ message, stack, onReset }: ErrorPageProps) {
   const navigate = useNavigate();
-
+  const goToHome = () => {
+    onReset();
+    navigate('/', { replace: true }); // 현재 라우트가 "/"여도 강제 이동
+  };
   return (
     <DefaultLayout>
       <DefaultLayout.Header>
@@ -38,7 +42,7 @@ export default function ErrorPage({ message, stack }: ErrorPageProps) {
           <button
             className="rounded-full bg-zinc-300 px-8 py-4 hover:bg-zinc-400"
             type="button"
-            onClick={() => navigate('/')}
+            onClick={goToHome}
           >
             <div className="flex flex-row items-center justify-center space-x-4">
               <IoHome size={30} />


### PR DESCRIPTION
# 🚩 연관 이슈

closed #181

# 📝 작업 내용
- 에러페이지에서 홈으로 가기 버튼이 동작하지 않는 문제 수정 
ErrorBoundary.tsx 페이지에서 에러가 발생하면 hasError의 상태를 true 변경합니다. 하지만 기존에 홈으로 가기 버튼을 클릭해서 hasError의 상태가 여전히 true이기 때문에 에러페이지가 계속 보이게 됩니다. 
그래서 다음과 같은 함수를 만들어 이 에러 상태를 초기화 가능하게 추가했습니다.
```
  resetError = () => {
    this.setState({ hasError: false, message: defaultMessage, stack: defaultStack });
  };
```


# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음
