### PR TITLE
[FIX] 초기 speakerNumber를 상황에 맞게 초기화

### DIFF
--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -40,9 +40,11 @@ export default function TimerCreationContent({
   const [minutes, setMinutes] = useState(initMinutes);
   const [seconds, setSeconds] = useState(initSeconds);
   const [speakerNumber, setSpeakerNumber] = useState<number | null>(
-    (beforeData?.speakerNumber ?? initData?.stance === 'NEUTRAL')
-      ? null
-      : (initData?.speakerNumber ?? 1),
+    beforeData?.speakerNumber
+      ? beforeData.speakerNumber
+      : initData?.stance === 'NEUTRAL'
+        ? null
+        : (initData?.speakerNumber ?? 1),
   );
 
   const handleSubmit = () => {

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -42,9 +42,13 @@ export default function TimerCreationContent({
   const [speakerNumber, setSpeakerNumber] = useState<number | null>(
     beforeData?.speakerNumber
       ? beforeData.speakerNumber
-      : initData?.stance === 'NEUTRAL'
-        ? null
-        : (initData?.speakerNumber ?? 1),
+      : initData
+        ? initData.stance === 'NEUTRAL'
+          ? null
+          : initData.speakerNumber
+            ? initData.speakerNumber
+            : null
+        : 1,
   );
 
   const handleSubmit = () => {


### PR DESCRIPTION
# 🚩 연관 이슈

closed #185

# 📝 작업 내용
- 기존에 시간표 생성에 이전 설정 시간표에 따라 초기에 선택된 발언자가 달라지는데 이전이 작전시간이었다면, 발언자가 없음으로 나타나는 문제를 수정합니다.

- before

https://github.com/user-attachments/assets/dc8bffc6-0710-48b4-9c21-751b61707206


-after

https://github.com/user-attachments/assets/8dcc3029-8718-43c0-b3bd-dbb27a50643f


# 🏞️ 스크린샷 (선택)

# 🗣️ 리뷰 요구사항 (선택)
