### PR TITLE
[FIX] 타이머 버그 해결

### DIFF
--- a/src/page/TimerPage/components/TimeTable.tsx
+++ b/src/page/TimerPage/components/TimeTable.tsx
@@ -19,7 +19,7 @@ export default function TimeTable({
   titles,
 }: TimeTableProps) {
   return (
-    <div className="flex min-w-[720px] flex-col items-center justify-center">
+    <div className="flex min-w-[740px] flex-col items-center justify-center">
       <div
         data-testid="time-table"
         className="mb-[30px] flex w-full flex-col rounded-[23px] bg-neutral-100 pb-[20px]"
@@ -36,7 +36,7 @@ export default function TimeTable({
         </div>
 
         {/** Print time table items(timeboxes) */}
-        <div className="flex w-full flex-col space-y-[15px] px-[20px]">
+        <div className="flex w-full flex-col space-y-[15px] px-[10px]">
           {items.length > 0 && (
             <div className="flex w-full flex-col space-y-[15px]">
               <div className="h-[70px] w-full">

--- a/src/page/TimerPage/components/TimeTableItem.tsx
+++ b/src/page/TimerPage/components/TimeTableItem.tsx
@@ -23,7 +23,7 @@ export default function TimeTableItem({ isCurrent, item }: TimeTableItem) {
         ? 'justify-self-start'
         : 'justify-self-end'
       : 'justify-self-center';
-  const width = item.stance !== 'NEUTRAL' ? 'w-1/2' : 'w-full';
+  const width = item.stance !== 'NEUTRAL' ? 'min-w-[360px]' : 'w-full';
   const minute = Math.floor(Math.abs(item.time) / 60);
   const second = Math.abs(item.time % 60);
   const timeText = `${Formatting.formatTwoDigits(minute)}:${Formatting.formatTwoDigits(second)}`;

--- a/src/page/TimerPage/components/Timer.tsx
+++ b/src/page/TimerPage/components/Timer.tsx
@@ -78,12 +78,16 @@ export default function Timer({
 
       {/* Speaker's number, if necessary */}
       <div className="my-[20px] h-[40px]">
-        {item.stance !== 'NEUTRAL' && !isAdditionalTimerOn && (
-          <div className="flex w-full flex-row items-center space-x-2 text-neutral-900">
-            <RiSpeakFill className="size-[40px]" />
-            <h1 className="text-[28px] font-bold">1번 토론자</h1>
-          </div>
-        )}
+        {item.stance !== 'NEUTRAL' &&
+          !isAdditionalTimerOn &&
+          item.speakerNumber !== undefined && (
+            <div className="flex w-full flex-row items-center space-x-2 text-neutral-900">
+              <RiSpeakFill className="size-[40px]" />
+              <h1 className="text-[28px] font-bold">
+                {item.speakerNumber}번 토론자
+              </h1>
+            </div>
+          )}
       </div>
 
       {/* Timer display */}

--- a/src/page/TimerPage/components/Timer.tsx
+++ b/src/page/TimerPage/components/Timer.tsx
@@ -80,7 +80,7 @@ export default function Timer({
       <div className="my-[20px] h-[40px]">
         {item.stance !== 'NEUTRAL' &&
           !isAdditionalTimerOn &&
-          item.speakerNumber !== undefined && (
+          item.speakerNumber && (
             <div className="flex w-full flex-row items-center space-x-2 text-neutral-900">
               <RiSpeakFill className="size-[40px]" />
               <h1 className="text-[28px] font-bold">

--- a/src/page/TimerPage/stories/TimeTableItem.stories.tsx
+++ b/src/page/TimerPage/stories/TimeTableItem.stories.tsx
@@ -87,9 +87,9 @@ export const OnPossibleOverflow: Story = {
     isCurrent: true,
     item: {
       stance: 'PROS',
-      type: 'CLOSING',
+      type: 'CROSS',
       time: 1830,
-      speakerNumber: 30,
+      speakerNumber: 33,
     },
   },
 };


### PR DESCRIPTION
# 🚩 연관 이슈

closed #192 

# 📝 작업 내용
## `TimeTableItem` 오버플로우 오류 해결
- `TimeTableItem`의 너비를 `min-w-[360px]`로 설정, 너비를 고정하되 오버플로우 발생 시에만 늘어나도록 수정
- 시간표 자체의 너비를 20px 늘림

## 발언자 번호 1번으로 고정되는 오류 해결
- 발언자 번호가 1번으로 하드코딩되어 있던 부분을, 실제 발언자 번호를 표시하도록 수정함
- 발언자 번호가 `undefined`일 경우에는, 발언자 번호를 출력하지 않도록 구현

# 🏞️ 스크린샷 (선택)
## 경희대에서 문제가 되었던 상황
교차 질의 관련 시간표 아이템 예시

![image](https://github.com/user-attachments/assets/036ed92c-7c08-46f7-b42b-f45257640714)

# 🗣️ 리뷰 요구사항 (선택)
없음