### PR TITLE
[FEAT] /debate API 토론하기 버튼에 적용

### DIFF
--- a/src/apis/apis.ts
+++ b/src/apis/apis.ts
@@ -6,6 +6,7 @@ import {
   PostDebateTableResponseType,
   PostUserResponseType,
   PutDebateTableResponseType,
+  PatchDebateTableResponseType,
 } from './responseTypes';
 import { DetailDebateInfo, TimeBoxInfo } from '../type/type';
 import { setAccessToken } from '../util/accessToken';
@@ -152,4 +153,18 @@ export async function logout(): Promise<boolean> {
   const response = await request('POST', requestUrl + `/logout`, null, null);
 
   return response.status === 204 ? true : false;
+}
+
+export async function patchParliamentaryDebateTable(
+  tableId: number,
+): Promise<PatchDebateTableResponseType> {
+  const requestUrl: string = ApiUrl.parliamentary;
+  const response = await request<PatchDebateTableResponseType>(
+    'PATCH',
+    requestUrl + `/${tableId}/debate`,
+    null,
+    null,
+  );
+
+  return response.data;
 }

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -4,7 +4,7 @@ import { ErrorResponseType } from './responseTypes';
 import axiosInstance from './axiosInstance';
 
 // HTTP request methods
-export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
 // Low-level http request function
 export async function request<T>(

--- a/src/apis/responseTypes.ts
+++ b/src/apis/responseTypes.ts
@@ -40,7 +40,7 @@ export interface ErrorResponseType {
   message: string;
 }
 
-// PATCH /api/table/parliamentary/{tableId}
+// PATCH /api/table/parliamentary/{tableId}/debate
 export interface PatchDebateTableResponseType {
   id: number;
   info: DetailDebateInfo;

--- a/src/apis/responseTypes.ts
+++ b/src/apis/responseTypes.ts
@@ -39,3 +39,10 @@ export interface PutDebateTableResponseType {
 export interface ErrorResponseType {
   message: string;
 }
+
+// PATCH /api/table/parliamentary/{tableId}
+export interface PatchDebateTableResponseType {
+  id: number;
+  info: DetailDebateInfo;
+  table: TimeBoxInfo[];
+}

--- a/src/hooks/mutations/usePatchParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/usePatchParliamentaryDebateTable.ts
@@ -1,0 +1,25 @@
+import { useMutation } from '@tanstack/react-query';
+import { patchParliamentaryDebateTable } from '../../apis/apis';
+import { PatchDebateTableResponseType } from '../../apis/responseTypes';
+
+interface PatchParliamentaryTableParams {
+  tableId: number;
+}
+
+export function usePatchParliamentaryDebateTable(
+  onSuccess: (tableId: number) => void,
+) {
+  return useMutation<
+    PatchDebateTableResponseType,
+    Error,
+    PatchParliamentaryTableParams
+  >({
+    mutationFn: ({ tableId }) => patchParliamentaryDebateTable(tableId),
+    onSuccess: (response: PatchDebateTableResponseType) => {
+      onSuccess(response.id);
+    },
+    onError: (error) => {
+      console.error('Error patching parliamentary table:', error);
+    },
+  });
+}

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -6,12 +6,19 @@ import DebatePanel from '../TableComposition/components/DebatePanel/DebatePanel'
 import HeaderTableInfo from '../../components/HeaderTableInfo/HeaderTableInfo';
 import HeaderTitle from '../../components/HeaderTitle/HeaderTitle';
 import { RiEditFill, RiSpeakFill } from 'react-icons/ri';
+import { usePatchParliamentaryDebateTable } from '../../hooks/mutations/usePatchParliamentaryDebateTable';
+
 export default function TableOverview() {
   const pathParams = useParams();
   const tableId = Number(pathParams.id);
   const { data } = useGetParliamentaryTableData(tableId);
 
   const navigate = useNavigate();
+
+  // 토론하기 클릭 시 patch 요청 후 이동
+  const patchTableMutation = usePatchParliamentaryDebateTable((tableId) => {
+    navigate(`/table/parliamentary/${tableId}`);
+  });
 
   return (
     <DefaultLayout>
@@ -52,7 +59,7 @@ export default function TableOverview() {
           </button>
           <button
             className="flex h-16 w-full items-center justify-center gap-2 rounded-md bg-brand-main text-2xl font-semibold transition-colors duration-300 hover:bg-amber-600"
-            onClick={() => navigate(`/table/parliamentary/${tableId}`)}
+            onClick={() => patchTableMutation.mutate({ tableId })}
           >
             <RiSpeakFill />
             토론하기


### PR DESCRIPTION
# 🚩 연관 이슈

closed #193 

# 📝 작업 내용
## 개요
- /api/table/parliamentary/{tableId}/debate 호출 로직 추가
- '토론하기' 버튼 클릭 시 PATCH API 호출
- 성공 시 테이블 페이지로 이동, 실패시 에러 로깅

### 커스텀 훅 분리하지 않은 이유

- 재사용 가능성 낮음
- 로직이 단순함
- TableOverview 에서만 사용됨
```
  const patchTableMutation = usePatchParliamentaryDebateTable((tableId) => {
    navigate(`/table/parliamentary/${tableId}`);
  });
```


# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음
