### PR TITLE
[FIX] Discord 알림 스크립트 오류 수정

### DIFF
--- a/.github/workflows/Issue_Noti.yml
+++ b/.github/workflows/Issue_Noti.yml
@@ -14,13 +14,11 @@ jobs:
           TITLE: ${{ github.event.issue.title }}
         run: |
           echo "AVATAR_URL=${{ secrets.DISCORD_AVATAR_URL }}" >> $GITHUB_ENV
-          echo "COMMENT_BODY=$(echo "${{ github.event.issue.body }}" | base64)" >> $GITHUB_ENV
           echo "USERNAME=망곰" >> $GITHUB_ENV
           echo "WEB_HOOK=${{ secrets.DISCORD_WEB_HOOK }}" >> $GITHUB_ENV
 
       - name: Notify Discord
         env:
-          COMMENT_BODY: ${{ env.COMMENT_BODY }}
           AUTHOR_NAME: ${{ github.event.issue.user.login }}
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ISSUE_TITLE: ${{ github.event.issue.title }}
@@ -30,9 +28,7 @@ jobs:
           WEB_HOOK: ${{ env.WEB_HOOK }}
         run: |
           if [ -n "$WEB_HOOK" ]; then
-            DECODED_COMMENT_BODY=$(echo "$COMMENT_BODY" | base64 --decode)
             JSON_PAYLOAD=$(jq -n \
-              --arg comment_body "$(echo "$DECODED_COMMENT_BODY" | jq -R @json)" \
               --arg username "$USERNAME" \
               --arg avatar_url "$AVATAR_URL" \
               --arg issue_title "$ISSUE_TITLE" \
@@ -51,7 +47,6 @@ jobs:
                     name: $author_name,
                     icon_url: $author_url
                   },
-                  description: $comment_body,
                   color: ($color | tonumber),
                   timestamp: $timestamp
                 }]

--- a/.github/workflows/PR_Comment_Noti.yml
+++ b/.github/workflows/PR_Comment_Noti.yml
@@ -13,13 +13,11 @@ jobs:
       - name: Set Environment Variables
         run: |
           echo "AVATAR_URL=${{ secrets.DISCORD_AVATAR_URL }}" >> $GITHUB_ENV
-          echo "COMMENT_BODY=$(echo '${{ github.event.comment.body }}' | base64)" >> $GITHUB_ENV
           echo "USERNAME=망곰" >> $GITHUB_ENV
           echo "WEB_HOOK=${{ secrets.DISCORD_WEB_HOOK }}" >> $GITHUB_ENV
 
       - name: Notify Discord
         env:
-          COMMENT_BODY: ${{ env.COMMENT_BODY }}
           AUTHOR_NAME: ${{ github.event.comment.user.login }}
           PR_URL: ${{ github.event.issue.pull_request.html_url }}
           PR_TITLE: ${{ github.event.issue.title }}
@@ -29,9 +27,7 @@ jobs:
           WEB_HOOK: ${{ env.WEB_HOOK }}
         run: |
           if [ -n "$WEB_HOOK" ]; then
-            DECODED_COMMENT_BODY=$(echo "$COMMENT_BODY" | base64 --decode)
             JSON_PAYLOAD=$(jq -n \
-              --arg comment_body "$(echo "$DECODED_COMMENT_BODY" | jq -R @json)" \
               --arg username "$USERNAME" \
               --arg avatar_url "$AVATAR_URL" \
               --arg pr_title "$PR_TITLE" \
@@ -50,7 +46,6 @@ jobs:
                     name: $author_name,
                     icon_url: $author_url
                   },
-                  description: $comment_body,
                   color: ($color | tonumber),
                   timestamp: $timestamp
                 }]


### PR DESCRIPTION
# 🚩 연관 이슈

closed #204 

# 📝 작업 내용
## 개요
- 새 이슈 발행 시 Discord 알림 스크립트 수정
- 새 PR 댓글이 달렸을 때 Discord 알림 스크립트 수정

## 간단 요약
전부터 `COMMENT_BODY` 관련한 내용이 계속 문제를 일으켜 그냥 삭제했습니다. 현재 상황에서 중요한 이슈도 아니고, 게시글 본문은 Discord 알림에 있는 링크 타고 GitHub에서 직접 확인할 수 있으니까요. 같은 문제로 더 이상의 PR 올릴 일 없게 그냥 싹을 잘라버립시다.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음