### PR TITLE
[FEAT] Customize API 대응

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,7 +6,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import React from 'react';
 import { initialize, mswLoader } from 'msw-storybook-addon';
-import { handlers } from '../src/mocks/handlers';
+import { allHandlers } from '../src/mocks/handlers/global';
 
 initialize();
 
@@ -15,7 +15,7 @@ const queryClient = new QueryClient();
 const preview: Preview = {
   parameters: {
     msw: {
-      handlers: { ...handlers },
+      handlers: { ...allHandlers },
     },
     controls: {
       matchers: {

--- a/src/apis/apis/customize.ts
+++ b/src/apis/apis/customize.ts
@@ -1,3 +1,13 @@
+import { CustomizeDebateInfo, CustomizeTimeBoxInfo } from '../../type/type';
+import { ApiUrl } from '../endpoints';
+import { request } from '../primitives';
+import {
+  GetCustomizeTableResponseType,
+  PatchCustomizeTableResponseType,
+  PostCustomizeTableResponseType,
+  PutCustomizeTableResponseType,
+} from '../responses/customize';
+
 // Template
 /*
 export async function apiFunc(
@@ -15,4 +25,96 @@ export async function apiFunc(
 }
 */
 
+// GET /api/table/customize/{tableId}
+export async function getCustomizeTableData(
+  tableId: number,
+): Promise<GetCustomizeTableResponseType> {
+  const requestUrl: string = ApiUrl.customize;
+  const response = await request<GetCustomizeTableResponseType>(
+    'GET',
+    requestUrl + `/${tableId}`,
+    null,
+    null,
+  );
+
+  return response.data;
+}
+
 // POST /api/table/customize
+export async function postCustomizeTableData(
+  info: CustomizeDebateInfo,
+  tables: CustomizeTimeBoxInfo[],
+): Promise<PostCustomizeTableResponseType> {
+  const requestUrl: string = ApiUrl.customize;
+  const response = await request<PostCustomizeTableResponseType>(
+    'POST',
+    requestUrl,
+    {
+      info: {
+        name: info.name === '' ? '테이블 1' : info.name,
+        agenda: info.agenda,
+        warningBell: info.warningBell,
+        finishBell: info.finishBell,
+      },
+      table: tables,
+    },
+    null,
+  );
+
+  return response.data;
+}
+
+// PUT /api/table/customize/{tableId}
+export async function putCustomizeTableData(
+  tableId: number,
+  info: CustomizeDebateInfo,
+  tables: CustomizeTimeBoxInfo[],
+): Promise<PutCustomizeTableResponseType> {
+  const requestUrl: string = ApiUrl.customize;
+  const response = await request<PutCustomizeTableResponseType>(
+    'POST',
+    requestUrl + `/${tableId}`,
+    {
+      info: {
+        name: info.name,
+        agenda: info.agenda,
+        warningBell: info.warningBell,
+        finishBell: info.finishBell,
+      },
+      table: tables,
+    },
+    null,
+  );
+
+  return response.data;
+}
+
+// DELETE /api/table/customize/{tableId}
+export async function deleteCustomizeTableData(
+  tableId: number,
+): Promise<boolean> {
+  const requestUrl: string = ApiUrl.customize;
+  const response = await request(
+    'DELETE',
+    requestUrl + `/${tableId}`,
+    null,
+    null,
+  );
+
+  return response.status === 204 ? true : false;
+}
+
+// PATCH /api/table/customize/{tableId}
+export async function patchCustomizeTableData(
+  tableId: number,
+): Promise<PatchCustomizeTableResponseType> {
+  const requestUrl: string = ApiUrl.customize;
+  const response = await request<PatchCustomizeTableResponseType>(
+    'PATCH',
+    requestUrl + `/${tableId}`,
+    null,
+    null,
+  );
+
+  return response.data;
+}

--- a/src/apis/apis/customize.ts
+++ b/src/apis/apis/customize.ts
@@ -14,3 +14,5 @@ export async function apiFunc(
     return response.data;
 }
 */
+
+// POST /api/table/customize

--- a/src/apis/apis/customize.ts
+++ b/src/apis/apis/customize.ts
@@ -1,0 +1,16 @@
+// Template
+/*
+export async function apiFunc(
+  
+): Promise<ReturnType> {
+    const requestUrl: string = ApiUrl.
+    const response = await request<ReturnType>(
+        method,
+        requestUrl,
+        data,
+        params,
+    );
+
+    return response.data;
+}
+*/

--- a/src/apis/apis/member.ts
+++ b/src/apis/apis/member.ts
@@ -1,10 +1,8 @@
 import { setAccessToken } from '../../util/accessToken';
 import { ApiUrl } from '../endpoints';
 import { request } from '../primitives';
-import {
-  GetDebateTableListResponseType,
-  PostUserResponseType,
-} from '../responseTypes';
+import { GetDebateTableListResponseType } from '../responses/member';
+import { PostUserResponseType } from '../responses/member';
 
 // Template
 /*

--- a/src/apis/apis/member.ts
+++ b/src/apis/apis/member.ts
@@ -1,0 +1,67 @@
+import { setAccessToken } from '../../util/accessToken';
+import { ApiUrl } from '../endpoints';
+import { request } from '../primitives';
+import {
+  GetDebateTableListResponseType,
+  PostUserResponseType,
+} from '../responseTypes';
+
+// Template
+/*
+export async function apiFunc(
+  
+): Promise<ReturnType> {
+    const requestUrl: string = ApiUrl.
+    const response = await request<ReturnType>(
+        method,
+        requestUrl,
+        data,
+        params,
+    );
+
+    return response.data;
+}
+*/
+
+// POST /api/member
+export async function postUser(code: string): Promise<PostUserResponseType> {
+  const requestUrl: string = ApiUrl.member;
+  const response = await request<PostUserResponseType>(
+    'POST',
+    requestUrl,
+    { code, redirectUrl: import.meta.env.VITE_GOOGLE_O_AUTH_REDIRECT_URI },
+    null,
+  );
+  // 응답 헤더에서 Authorization 값을 추출합니다.
+  const authHeader = response.headers['authorization'];
+
+  if (authHeader) {
+    const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+    setAccessToken(token);
+  } else {
+    throw new Error('Authorization 헤더가 존재하지 않습니다.');
+  }
+
+  return response.data;
+}
+
+// GET /api/table
+export async function getDebateTableList(): Promise<GetDebateTableListResponseType> {
+  const requestUrl: string = ApiUrl.table;
+  const response = await request<GetDebateTableListResponseType>(
+    'GET',
+    requestUrl,
+    null,
+    null,
+  );
+
+  return response.data;
+}
+
+// POST /api/member/logout
+export async function logout(): Promise<boolean> {
+  const requestUrl: string = ApiUrl.member;
+  const response = await request('POST', requestUrl + `/logout`, null, null);
+
+  return response.status === 204 ? true : false;
+}

--- a/src/apis/apis/parliamentary.ts
+++ b/src/apis/apis/parliamentary.ts
@@ -1,11 +1,9 @@
 import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
 import { ApiUrl } from '../endpoints';
 import { request } from '../primitives';
-import {
-  GetTableDataResponseType,
-  PostDebateTableResponseType,
-  PutDebateTableResponseType,
-} from '../responseTypes';
+import { PutDebateTableResponseType } from '../responses/parliamentary';
+import { PostDebateTableResponseType } from '../responses/parliamentary';
+import { GetTableDataResponseType } from '../responses/parliamentary';
 
 // Template
 /*

--- a/src/apis/apis/parliamentary.ts
+++ b/src/apis/apis/parliamentary.ts
@@ -1,4 +1,4 @@
-import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
+import { DetailDebateInfo, ParliamentaryTimeBoxInfo } from '../../type/type';
 import { ApiUrl } from '../endpoints';
 import { request } from '../primitives';
 import { PutDebateTableResponseType } from '../responses/parliamentary';
@@ -40,7 +40,7 @@ export async function getParliamentaryTableData(
 // POST /api/table/parliamentary
 export async function postParliamentaryDebateTable(
   info: DetailDebateInfo,
-  tables: TimeBoxInfo[],
+  tables: ParliamentaryTimeBoxInfo[],
 ): Promise<PostDebateTableResponseType> {
   const requestUrl: string = ApiUrl.parliamentary;
   const response = await request<PostDebateTableResponseType>(
@@ -65,7 +65,7 @@ export async function postParliamentaryDebateTable(
 export async function putParliamentaryDebateTable(
   tableId: number,
   info: DetailDebateInfo,
-  tables: TimeBoxInfo[],
+  tables: ParliamentaryTimeBoxInfo[],
 ): Promise<PutDebateTableResponseType> {
   const requestUrl: string = ApiUrl.parliamentary;
   const response = await request<PutDebateTableResponseType>(

--- a/src/apis/apis/parliamentary.ts
+++ b/src/apis/apis/parliamentary.ts
@@ -1,55 +1,28 @@
-import { request } from './primitives';
-import { ApiUrl } from './endpoints';
+import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
+import { ApiUrl } from '../endpoints';
+import { request } from '../primitives';
 import {
-  GetDebateTableListResponseType,
   GetTableDataResponseType,
   PostDebateTableResponseType,
-  PostUserResponseType,
   PutDebateTableResponseType,
-} from './responseTypes';
-import { DetailDebateInfo, TimeBoxInfo } from '../type/type';
-import { setAccessToken } from '../util/accessToken';
+} from '../responseTypes';
 
-// String type identifier for TanStack Query's 'useQuery' function
-export const queryKeyIdentifier = {
-  getDebateTableList: 'DebateTableList',
-  getParliamentaryTableData: 'ParliamentaryTableData',
-};
+// Template
+/*
+export async function apiFunc(
+  
+): Promise<ReturnType> {
+    const requestUrl: string = ApiUrl.
+    const response = await request<ReturnType>(
+        method,
+        requestUrl,
+        data,
+        params,
+    );
 
-// POST "/api/member"
-export async function postUser(code: string): Promise<PostUserResponseType> {
-  const requestUrl: string = ApiUrl.member;
-  const response = await request<PostUserResponseType>(
-    'POST',
-    requestUrl,
-    { code, redirectUrl: import.meta.env.VITE_GOOGLE_O_AUTH_REDIRECT_URI },
-    null,
-  );
-  // 응답 헤더에서 Authorization 값을 추출합니다.
-  const authHeader = response.headers['authorization'];
-
-  if (authHeader) {
-    const token = authHeader.replace(/^Bearer\s+/i, '').trim();
-    setAccessToken(token);
-  } else {
-    throw new Error('Authorization 헤더가 존재하지 않습니다.');
-  }
-
-  return response.data;
+    return response.data;
 }
-
-// GET /api/table
-export async function getDebateTableList(): Promise<GetDebateTableListResponseType> {
-  const requestUrl: string = ApiUrl.table;
-  const response = await request<GetDebateTableListResponseType>(
-    'GET',
-    requestUrl,
-    null,
-    null,
-  );
-
-  return response.data;
-}
+*/
 
 // GET /api/table/parliamentary/{tableId}
 export async function getParliamentaryTableData(
@@ -126,30 +99,6 @@ export async function deleteParliamentaryDebateTable(
     null,
     null,
   );
-
-  return response.status === 204 ? true : false;
-}
-
-// Template
-/*
-export async function apiFunc(
-  
-): Promise<ReturnType> {
-    const requestUrl: string = ApiUrl.
-    const response = await request<ReturnType>(
-        method,
-        requestUrl,
-        data,
-        params,
-    );
-
-    return response.data;
-}
-*/
-
-export async function logout(): Promise<boolean> {
-  const requestUrl: string = ApiUrl.member;
-  const response = await request('POST', requestUrl + `/logout`, null, null);
 
   return response.status === 204 ? true : false;
 }

--- a/src/apis/apis/parliamentary.ts
+++ b/src/apis/apis/parliamentary.ts
@@ -1,4 +1,7 @@
-import { DetailDebateInfo, ParliamentaryTimeBoxInfo } from '../../type/type';
+import {
+  ParliamentaryDebateInfo,
+  ParliamentaryTimeBoxInfo,
+} from '../../type/type';
 import { ApiUrl } from '../endpoints';
 import { request } from '../primitives';
 import { PutDebateTableResponseType } from '../responses/parliamentary';
@@ -39,7 +42,7 @@ export async function getParliamentaryTableData(
 
 // POST /api/table/parliamentary
 export async function postParliamentaryDebateTable(
-  info: DetailDebateInfo,
+  info: ParliamentaryDebateInfo,
   tables: ParliamentaryTimeBoxInfo[],
 ): Promise<PostDebateTableResponseType> {
   const requestUrl: string = ApiUrl.parliamentary;
@@ -64,7 +67,7 @@ export async function postParliamentaryDebateTable(
 // PUT /api/table/parliamentary/{tableId}
 export async function putParliamentaryDebateTable(
   tableId: number,
-  info: DetailDebateInfo,
+  info: ParliamentaryDebateInfo,
   tables: ParliamentaryTimeBoxInfo[],
 ): Promise<PutDebateTableResponseType> {
   const requestUrl: string = ApiUrl.parliamentary;

--- a/src/apis/endpoints.ts
+++ b/src/apis/endpoints.ts
@@ -9,4 +9,5 @@ export const ApiUrl = {
   member: makeUrl('/member'),
   table: makeUrl('/table'),
   parliamentary: makeUrl('/table/parliamentary'),
+  customize: makeUrl('/table/customize'),
 };

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { AxiosResponse, AxiosError } from 'axios';
-import { ErrorResponseType } from './responseTypes';
+import { ErrorResponseType } from './responses/global';
 import axiosInstance from './axiosInstance';
 
 // HTTP request methods

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -4,7 +4,7 @@ import { ErrorResponseType } from './responses/global';
 import axiosInstance from './axiosInstance';
 
 // HTTP request methods
-export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE';
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
 // Low-level http request function
 export async function request<T>(

--- a/src/apis/responses/customize.ts
+++ b/src/apis/responses/customize.ts
@@ -1,0 +1,27 @@
+import { CustomizeDebateInfo, CustomizeTimeBoxInfo } from '../../type/type';
+
+// POST /api/table/customize
+export interface PostCustomizeTableResponseType {
+  info: CustomizeDebateInfo;
+  table: CustomizeTimeBoxInfo[];
+}
+
+// PUT /api/table/customize/{tableId}
+export interface PutCustomizeTableResponseType {
+  info: CustomizeDebateInfo;
+  table: CustomizeTimeBoxInfo[];
+}
+
+// GET /api/table/customize/{tableId}
+export interface GetCustomizeTableResponseType {
+  id: number;
+  info: CustomizeDebateInfo;
+  table: CustomizeTimeBoxInfo[];
+}
+
+// PATCH /api/table/customize/{tableId}
+export interface PatchCustomizeTableResponseType {
+  id: number;
+  info: CustomizeDebateInfo;
+  table: CustomizeTimeBoxInfo[];
+}

--- a/src/apis/responses/global.ts
+++ b/src/apis/responses/global.ts
@@ -1,0 +1,5 @@
+// Response types for error cases
+
+export interface ErrorResponseType {
+  message: string;
+}

--- a/src/apis/responses/member.ts
+++ b/src/apis/responses/member.ts
@@ -1,0 +1,12 @@
+import { DebateTable } from '../../type/type';
+
+// POST "/api/member"
+export interface PostUserResponseType {
+  id: number;
+  email: string;
+}
+
+// GET /api/table
+export interface GetDebateTableListResponseType {
+  tables: DebateTable[];
+}

--- a/src/apis/responses/parliamentary.ts
+++ b/src/apis/responses/parliamentary.ts
@@ -1,22 +1,25 @@
-import { DetailDebateInfo, ParliamentaryTimeBoxInfo } from '../../type/type';
+import {
+  ParliamentaryDebateInfo,
+  ParliamentaryTimeBoxInfo,
+} from '../../type/type';
 
 // GET /api/table/parliamentary/{tableId}
 export interface GetTableDataResponseType {
   id: number;
-  info: DetailDebateInfo;
+  info: ParliamentaryDebateInfo;
   table: ParliamentaryTimeBoxInfo[];
 }
 
 // POST /api/table/parliamentary
 export interface PostDebateTableResponseType {
   id: number;
-  info: DetailDebateInfo;
+  info: ParliamentaryDebateInfo;
   table: ParliamentaryTimeBoxInfo[];
 }
 
 // PUT /api/table/parliamentary/{tableId}
 export interface PutDebateTableResponseType {
   id: number;
-  info: DetailDebateInfo;
+  info: ParliamentaryDebateInfo;
   table: ParliamentaryTimeBoxInfo[];
 }

--- a/src/apis/responses/parliamentary.ts
+++ b/src/apis/responses/parliamentary.ts
@@ -1,15 +1,4 @@
-import { TimeBoxInfo, DebateTable, DetailDebateInfo } from '../type/type';
-
-// POST "/api/member"
-export interface PostUserResponseType {
-  id: number;
-  email: string;
-}
-
-// GET /api/table
-export interface GetDebateTableListResponseType {
-  tables: DebateTable[];
-}
+import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
 
 // GET /api/table/parliamentary/{tableId}
 export interface GetTableDataResponseType {
@@ -30,12 +19,4 @@ export interface PutDebateTableResponseType {
   id: number;
   info: DetailDebateInfo;
   table: TimeBoxInfo[];
-}
-
-// DELETE /api/table/parliamentary/{tableId}
-// This API only contains HTTP response code 204
-
-// Response types for error cases
-export interface ErrorResponseType {
-  message: string;
 }

--- a/src/apis/responses/parliamentary.ts
+++ b/src/apis/responses/parliamentary.ts
@@ -1,22 +1,22 @@
-import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
+import { DetailDebateInfo, ParliamentaryTimeBoxInfo } from '../../type/type';
 
 // GET /api/table/parliamentary/{tableId}
 export interface GetTableDataResponseType {
   id: number;
   info: DetailDebateInfo;
-  table: TimeBoxInfo[];
+  table: ParliamentaryTimeBoxInfo[];
 }
 
 // POST /api/table/parliamentary
 export interface PostDebateTableResponseType {
   id: number;
   info: DetailDebateInfo;
-  table: TimeBoxInfo[];
+  table: ParliamentaryTimeBoxInfo[];
 }
 
 // PUT /api/table/parliamentary/{tableId}
 export interface PutDebateTableResponseType {
   id: number;
   info: DetailDebateInfo;
-  table: TimeBoxInfo[];
+  table: ParliamentaryTimeBoxInfo[];
 }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,7 +1,7 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import ErrorPage from './ErrorPage';
 import { AxiosError } from 'axios';
-import { ErrorResponseType } from '../../apis/responseTypes';
+import { ErrorResponseType } from '../../apis/responses/global';
 
 interface ErrorBoundaryProps {
   children: ReactNode;

--- a/src/components/HeaderTableInfo/HeaderTableInfo.tsx
+++ b/src/components/HeaderTableInfo/HeaderTableInfo.tsx
@@ -1,9 +1,8 @@
-import { typeMapping } from '../../constants/languageMapping';
-import { Type } from '../../type/type';
+import { DebateType, DebateTypeToString } from '../../type/type';
 
 interface HeaderTitleProps {
   name?: string;
-  type: Type;
+  type: DebateType;
 }
 
 export default function HeaderTableInfo(props: HeaderTitleProps) {
@@ -11,7 +10,7 @@ export default function HeaderTableInfo(props: HeaderTitleProps) {
   const displayName = !name?.trim() ? '테이블 이름 없음' : name.trim();
   return (
     <div className="flex flex-col space-y-[4px]">
-      <h1 className="text-sm">{typeMapping[type]}</h1>
+      <h1 className="text-sm">{DebateTypeToString[type]}</h1>
       <h1 className="text-2xl font-bold">{displayName}</h1>
     </div>
   );

--- a/src/constants/languageMapping.ts
+++ b/src/constants/languageMapping.ts
@@ -1,5 +1,0 @@
-import { Type } from '../type/type';
-
-export const typeMapping: Record<Type, string> = {
-  PARLIAMENTARY: '의회식 토론',
-};

--- a/src/hooks/mutations/useAddCustomizeDebateTable.ts
+++ b/src/hooks/mutations/useAddCustomizeDebateTable.ts
@@ -1,0 +1,30 @@
+import { useMutation } from '@tanstack/react-query';
+import { CustomizeDebateInfo, CustomizeTimeBoxInfo } from '../../type/type';
+import { postCustomizeTableData } from '../../apis/apis/customize';
+
+interface UseAddCustomizeTableParams {
+  info: CustomizeDebateInfo;
+  table: CustomizeTimeBoxInfo[];
+}
+
+export default function useAddCustomizeTable(onSuccess: () => void) {
+  return useMutation({
+    mutationFn: async (params: UseAddCustomizeTableParams) => {
+      const response = await postCustomizeTableData(
+        {
+          name: params.info.name,
+          agenda: params.info.agenda,
+          prosTeamName: params.info.prosTeamName,
+          consTeamName: params.info.consTeamName,
+          warningBell: params.info.warningBell,
+          finishBell: params.info.finishBell,
+        },
+        params.table,
+      );
+      return response;
+    },
+    onSuccess: () => {
+      onSuccess();
+    },
+  });
+}

--- a/src/hooks/mutations/useAddParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/useAddParliamentaryDebateTable.ts
@@ -6,14 +6,16 @@ import {
 } from '../../type/type';
 import { PostDebateTableResponseType } from '../../apis/responses/parliamentary';
 
-interface UseAddTableParams {
+interface UseAddParliamentaryTableParams {
   info: ParliamentaryDebateInfo;
   table: ParliamentaryTimeBoxInfo[];
 }
 
-export default function useAddTable(onSuccess: (id: number) => void) {
+export default function useAddParliamentaryTable(
+  onSuccess: (id: number) => void,
+) {
   return useMutation({
-    mutationFn: async (params: UseAddTableParams) => {
+    mutationFn: async (params: UseAddParliamentaryTableParams) => {
       const response = await postParliamentaryDebateTable(
         {
           name: params.info.name,

--- a/src/hooks/mutations/useAddTable.ts
+++ b/src/hooks/mutations/useAddTable.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 import { postParliamentaryDebateTable } from '../../apis/apis/parliamentary';
 import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
-import { PostDebateTableResponseType } from '../../apis/responseTypes';
+import { PostDebateTableResponseType } from '../../apis/responses/parliamentary';
 
 interface UseAddTableParams {
   info: DetailDebateInfo;

--- a/src/hooks/mutations/useAddTable.ts
+++ b/src/hooks/mutations/useAddTable.ts
@@ -1,10 +1,13 @@
 import { useMutation } from '@tanstack/react-query';
 import { postParliamentaryDebateTable } from '../../apis/apis/parliamentary';
-import { DetailDebateInfo, ParliamentaryTimeBoxInfo } from '../../type/type';
+import {
+  ParliamentaryDebateInfo,
+  ParliamentaryTimeBoxInfo,
+} from '../../type/type';
 import { PostDebateTableResponseType } from '../../apis/responses/parliamentary';
 
 interface UseAddTableParams {
-  info: DetailDebateInfo;
+  info: ParliamentaryDebateInfo;
   table: ParliamentaryTimeBoxInfo[];
 }
 

--- a/src/hooks/mutations/useAddTable.ts
+++ b/src/hooks/mutations/useAddTable.ts
@@ -1,11 +1,11 @@
 import { useMutation } from '@tanstack/react-query';
 import { postParliamentaryDebateTable } from '../../apis/apis/parliamentary';
-import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
+import { DetailDebateInfo, ParliamentaryTimeBoxInfo } from '../../type/type';
 import { PostDebateTableResponseType } from '../../apis/responses/parliamentary';
 
 interface UseAddTableParams {
   info: DetailDebateInfo;
-  table: TimeBoxInfo[];
+  table: ParliamentaryTimeBoxInfo[];
 }
 
 export default function useAddTable(onSuccess: (id: number) => void) {

--- a/src/hooks/mutations/useAddTable.ts
+++ b/src/hooks/mutations/useAddTable.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { postParliamentaryDebateTable } from '../../apis/apis';
+import { postParliamentaryDebateTable } from '../../apis/apis/parliamentary';
 import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
 import { PostDebateTableResponseType } from '../../apis/responseTypes';
 

--- a/src/hooks/mutations/useDeleteCustomizeDebateTable.ts
+++ b/src/hooks/mutations/useDeleteCustomizeDebateTable.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { deleteCustomizeTableData } from '../../apis/apis/customize';
+
+interface DeleteCustomizeTableParams {
+  tableId: number;
+}
+
+export function useDeleteCustomizeDebateTable() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ tableId }: DeleteCustomizeTableParams) =>
+      await deleteCustomizeTableData(tableId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['DebateTableList'] });
+
+      setTimeout(() => {
+        alert('테이블이 제거되었습니다.');
+      }, 300);
+    },
+    onError: (error) => {
+      console.error('Error deleting customize table:', error);
+    },
+  });
+}

--- a/src/hooks/mutations/useDeleteParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/useDeleteParliamentaryDebateTable.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { deleteParliamentaryDebateTable } from '../../apis/apis';
+import { deleteParliamentaryDebateTable } from '../../apis/apis/parliamentary';
 
 interface DeleteParliamentaryTableParams {
   tableId: number;

--- a/src/hooks/mutations/useLogout.ts
+++ b/src/hooks/mutations/useLogout.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { logout } from '../../apis/apis';
+import { logout } from '../../apis/apis/member';
 import { removeAccessToken } from '../../util/accessToken';
 
 export default function useLogout(onSuccess: () => void) {

--- a/src/hooks/mutations/usePatchCustomizeDebateTable.ts
+++ b/src/hooks/mutations/usePatchCustomizeDebateTable.ts
@@ -1,0 +1,25 @@
+import { useMutation } from '@tanstack/react-query';
+import { patchCustomizeTableData } from '../../apis/apis/customize';
+import { PatchCustomizeTableResponseType } from '../../apis/responses/customize';
+
+interface UsePatchCustomizeTableParams {
+  id: number;
+}
+
+export default function usePatchCustomizeTable(
+  onSuccess: (tableId: number) => void,
+) {
+  return useMutation<
+    PatchCustomizeTableResponseType,
+    Error,
+    UsePatchCustomizeTableParams
+  >({
+    mutationFn: async ({ id }) => patchCustomizeTableData(id),
+    onSuccess: (response: PatchCustomizeTableResponseType) => {
+      onSuccess(response.id);
+    },
+    onError: (error) => {
+      console.error('Error starting customize debate:', error);
+    },
+  });
+}

--- a/src/hooks/mutations/usePostUser.ts
+++ b/src/hooks/mutations/usePostUser.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { PostUserResponseType } from '../../apis/responseTypes';
-import { postUser } from '../../apis/apis';
+import { postUser } from '../../apis/apis/member';
 
 export function usePostUser(onSuccess: (data: PostUserResponseType) => void) {
   return useMutation({

--- a/src/hooks/mutations/usePostUser.ts
+++ b/src/hooks/mutations/usePostUser.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { PostUserResponseType } from '../../apis/responseTypes';
+import { PostUserResponseType } from '../../apis/responses/member';
 import { postUser } from '../../apis/apis/member';
 
 export function usePostUser(onSuccess: (data: PostUserResponseType) => void) {

--- a/src/hooks/mutations/usePutCustomizeDebateTable.ts
+++ b/src/hooks/mutations/usePutCustomizeDebateTable.ts
@@ -1,0 +1,27 @@
+import { useMutation } from '@tanstack/react-query';
+import { CustomizeDebateInfo, CustomizeTimeBoxInfo } from '../../type/type';
+import { PutCustomizeTableResponseType } from '../../apis/responses/customize';
+import { putCustomizeTableData } from '../../apis/apis/customize';
+
+interface PutCustomizeTableParams {
+  tableId: number;
+  info: CustomizeDebateInfo;
+  table: CustomizeTimeBoxInfo[];
+}
+
+export function usePutCustomizeDebateTable(onSuccess: () => void) {
+  return useMutation<
+    PutCustomizeTableResponseType,
+    Error,
+    PutCustomizeTableParams
+  >({
+    mutationFn: ({ tableId, info, table }) =>
+      putCustomizeTableData(tableId, info, table),
+    onSuccess: () => {
+      onSuccess();
+    },
+    onError: (error) => {
+      console.error('Error updating parliamentary table:', error);
+    },
+  });
+}

--- a/src/hooks/mutations/usePutCustomizeDebateTable.ts
+++ b/src/hooks/mutations/usePutCustomizeDebateTable.ts
@@ -21,7 +21,7 @@ export function usePutCustomizeDebateTable(onSuccess: () => void) {
       onSuccess();
     },
     onError: (error) => {
-      console.error('Error updating parliamentary table:', error);
+      console.error('Error updating customize table:', error);
     },
   });
 }

--- a/src/hooks/mutations/usePutParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/usePutParliamentaryDebateTable.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import { putParliamentaryDebateTable } from '../../apis/apis/parliamentary';
-import { PutDebateTableResponseType } from '../../apis/responseTypes';
+import { PutDebateTableResponseType } from '../../apis/responses/parliamentary';
 import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
 
 interface PutParliamentaryTableParams {

--- a/src/hooks/mutations/usePutParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/usePutParliamentaryDebateTable.ts
@@ -1,11 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
 import { putParliamentaryDebateTable } from '../../apis/apis/parliamentary';
 import { PutDebateTableResponseType } from '../../apis/responses/parliamentary';
-import { DetailDebateInfo, ParliamentaryTimeBoxInfo } from '../../type/type';
+import {
+  ParliamentaryDebateInfo,
+  ParliamentaryTimeBoxInfo,
+} from '../../type/type';
 
 interface PutParliamentaryTableParams {
   tableId: number;
-  info: DetailDebateInfo;
+  info: ParliamentaryDebateInfo;
   table: ParliamentaryTimeBoxInfo[];
 }
 

--- a/src/hooks/mutations/usePutParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/usePutParliamentaryDebateTable.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { putParliamentaryDebateTable } from '../../apis/apis';
+import { putParliamentaryDebateTable } from '../../apis/apis/parliamentary';
 import { PutDebateTableResponseType } from '../../apis/responseTypes';
 import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
 

--- a/src/hooks/mutations/usePutParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/usePutParliamentaryDebateTable.ts
@@ -1,12 +1,12 @@
 import { useMutation } from '@tanstack/react-query';
 import { putParliamentaryDebateTable } from '../../apis/apis/parliamentary';
 import { PutDebateTableResponseType } from '../../apis/responses/parliamentary';
-import { DetailDebateInfo, TimeBoxInfo } from '../../type/type';
+import { DetailDebateInfo, ParliamentaryTimeBoxInfo } from '../../type/type';
 
 interface PutParliamentaryTableParams {
   tableId: number;
   info: DetailDebateInfo;
-  table: TimeBoxInfo[];
+  table: ParliamentaryTimeBoxInfo[];
 }
 
 export function usePutParliamentaryDebateTable(

--- a/src/hooks/query/useGetCustomizeTableData.ts
+++ b/src/hooks/query/useGetCustomizeTableData.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { getCustomizeTableData } from '../../apis/apis/customize';
+
+export function useGetCustomizeTableData(tableId: number, enabled?: boolean) {
+  return useQuery({
+    queryKey: ['CustomizeTableData', tableId],
+    queryFn: () => getCustomizeTableData(tableId),
+    enabled,
+  });
+}

--- a/src/hooks/query/useGetDebateTableList.ts
+++ b/src/hooks/query/useGetDebateTableList.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getDebateTableList } from '../../apis/apis';
+import { getDebateTableList } from '../../apis/apis/member';
 
 export function useGetDebateTableList() {
   return useQuery({

--- a/src/hooks/query/useGetParliamentaryTableData.ts
+++ b/src/hooks/query/useGetParliamentaryTableData.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getParliamentaryTableData } from '../../apis/apis';
+import { getParliamentaryTableData } from '../../apis/apis/parliamentary';
 
 export function useGetParliamentaryTableData(
   tableId: number,

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,4 +1,4 @@
 import { setupWorker } from 'msw/browser';
-import { handlers } from './handlers';
+import { allHandlers } from './handlers/global';
 
-export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...allHandlers);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,6 +1,6 @@
 import { http, HttpResponse } from 'msw';
 import { ApiUrl } from '../apis/endpoints';
-import { PostDebateTableResponseType } from '../apis/responseTypes';
+import { PostDebateTableResponseType } from '../apis/responses/parliamentary';
 
 export const handlers = [
   // POST "/api/member"

--- a/src/mocks/handlers/customize.ts
+++ b/src/mocks/handlers/customize.ts
@@ -1,0 +1,324 @@
+import { http, HttpResponse } from 'msw';
+import { ApiUrl } from '../../apis/endpoints';
+import {
+  PostCustomizeTableResponseType,
+  PutCustomizeTableResponseType,
+} from '../../apis/responses/customize';
+
+export const customizeHandlers = [
+  // GET /api/table/customize/{tableId}
+  http.get(ApiUrl.customize + '/:tableId', ({ params }) => {
+    const { tableId } = params;
+    console.log(`# tableId  = ${tableId}`);
+
+    return HttpResponse.json({
+      id: 5,
+      info: {
+        name: '나의 자유토론 테이블',
+        type: 'CUSTOMIZE',
+        agenda: '토론 주제',
+        prosTeamName: '찬성',
+        consTeamName: '반대',
+        warningBell: true,
+        finishBell: true,
+      },
+      table: [
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '작전 시간',
+          boxType: 'NORMAL',
+          time: 60,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: null,
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '자유토론',
+          boxType: 'TIME_BASED',
+          time: null,
+          timePerTeam: 120,
+          timePerSpeaking: 40,
+          speaker: null,
+        },
+        {
+          stance: 'CONS',
+          speechType: '최종 발언',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+        {
+          stance: 'PROS',
+          speechType: '최종 발언',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+      ],
+    });
+  }),
+
+  // POST /api/table/customize
+  http.post(ApiUrl.customize, async ({ request }) => {
+    const result = (await request.json()) as PostCustomizeTableResponseType;
+    console.log(
+      `# tableAgenda = ${result?.info.agenda}, tableName = ${result?.info.name}`,
+    );
+
+    return HttpResponse.json({
+      info: {
+        name: '나의 자유토론 테이블',
+        type: 'CUSTOMIZE',
+        agenda: '토론 주제',
+        prosTeamName: '찬성',
+        consTeamName: '반대',
+        warningBell: true,
+        finishBell: true,
+      },
+      table: [
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '작전 시간',
+          boxType: 'NORMAL',
+          time: 60,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: null,
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '자유토론',
+          boxType: 'TIME_BASED',
+          time: null,
+          timePerTeam: 120,
+          timePerSpeaking: 40,
+          speaker: null,
+        },
+        {
+          stance: 'CONS',
+          speechType: '최종 발언',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+        {
+          stance: 'PROS',
+          speechType: '최종 발언',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+      ],
+    });
+  }),
+
+  // PUT /api/table/customize/{tableId}
+  http.put(ApiUrl.customize + '/:tableId', async ({ request, params }) => {
+    const { tableId } = params;
+    const result = (await request.json()) as PutCustomizeTableResponseType;
+    console.log(
+      `# tableId = ${tableId}, tableAgenda = ${result?.info.agenda}, tableName = ${result?.info.name}`,
+    );
+
+    return HttpResponse.json({
+      info: {
+        name: '나의 자유토론 테이블',
+        type: 'CUSTOMIZE',
+        agenda: '토론 주제',
+        prosTeamName: '찬성',
+        consTeamName: '반대',
+        warningBell: true,
+        finishBell: true,
+      },
+      table: [
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '작전 시간',
+          boxType: 'NORMAL',
+          time: 60,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: null,
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '자유토론',
+          boxType: 'TIME_BASED',
+          time: null,
+          timePerTeam: 120,
+          timePerSpeaking: 40,
+          speaker: null,
+        },
+        {
+          stance: 'CONS',
+          speechType: '최종 발언',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+        {
+          stance: 'PROS',
+          speechType: '최종 발언',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+      ],
+    });
+  }),
+
+  // DELETE /api/table/customize/{tableId}
+  http.delete(ApiUrl.customize + '/:tableId', ({ params }) => {
+    const { tableId } = params;
+    console.log(`# tableId  = ${tableId}`);
+
+    return new HttpResponse(null, {
+      status: 204,
+    });
+  }),
+
+  // PATCH /api/table/customize/{tableId}
+  http.patch(ApiUrl.customize + '/:tableId', async ({ request, params }) => {
+    const { tableId } = params;
+    const result = (await request.json()) as PutCustomizeTableResponseType;
+    console.log(
+      `# tableId = ${tableId}, tableAgenda = ${result?.info.agenda}, tableName = ${result?.info.name}`,
+    );
+
+    return HttpResponse.json({
+      id: 302,
+      info: {
+        name: '나의 자유토론 테이블',
+        type: 'CUSTOMIZE',
+        agenda: '토론 주제',
+        prosTeamName: '찬성',
+        consTeamName: '반대',
+        warningBell: true,
+        finishBell: true,
+      },
+      table: [
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '작전 시간',
+          boxType: 'NORMAL',
+          time: 60,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: null,
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '자유토론',
+          boxType: 'TIME_BASED',
+          time: null,
+          timePerTeam: 120,
+          timePerSpeaking: 40,
+          speaker: null,
+        },
+        {
+          stance: 'CONS',
+          speechType: '최종 발언',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+        {
+          stance: 'PROS',
+          speechType: '최종 발언',
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+      ],
+    });
+  }),
+];

--- a/src/mocks/handlers/global.ts
+++ b/src/mocks/handlers/global.ts
@@ -1,0 +1,9 @@
+import { customizeHandlers } from './customize';
+import { memberHandlers } from './member';
+import { parliamentaryHandlers } from './parliamentary';
+
+export const allHandlers = [
+  ...memberHandlers,
+  ...parliamentaryHandlers,
+  ...customizeHandlers,
+];

--- a/src/mocks/handlers/member.ts
+++ b/src/mocks/handlers/member.ts
@@ -1,0 +1,72 @@
+import { http, HttpResponse } from 'msw';
+import { ApiUrl } from '../../apis/endpoints';
+
+export const memberHandlers = [
+  // POST "/api/member"
+  http.post(ApiUrl.member, async () => {
+    return HttpResponse.json({
+      id: 1,
+      nickname: '홍길동',
+    });
+  }),
+
+  // GET /api/table?memberId={memberId}
+  http.get(ApiUrl.table, ({ request }) => {
+    const url = new URL(request.url);
+    const memberId = url.searchParams.get('memberId');
+    console.log(`# memberId = ${memberId}`);
+
+    return HttpResponse.json({
+      tables: [
+        {
+          id: 1,
+          name: '테이블 1',
+          type: 'PARLIAMENTARY',
+          duration: '1800',
+        },
+        {
+          id: 2,
+          name: '테이블 2',
+          type: 'PARLIAMENTARY',
+          duration: '1750',
+        },
+        {
+          id: 3,
+          name: '테이블 1',
+          type: 'PARLIAMENTARY',
+          duration: '1800',
+        },
+        {
+          id: 4,
+          name: '테이블 2',
+          type: 'PARLIAMENTARY',
+          duration: '1750',
+        },
+        {
+          id: 5,
+          name: '테이블 1',
+          type: 'PARLIAMENTARY',
+          duration: '1800',
+        },
+        {
+          id: 6,
+          name: '테이블 2',
+          type: 'PARLIAMENTARY',
+          duration: '1750',
+        },
+        {
+          id: 7,
+          name: '테이블 1',
+          type: 'PARLIAMENTARY',
+          duration: '1800',
+        },
+        {
+          id: 8,
+          name: '테이블 2',
+          type: 'PARLIAMENTARY',
+          duration: '1750',
+        },
+      ],
+    });
+  }),
+];

--- a/src/mocks/handlers/parliamentary.ts
+++ b/src/mocks/handlers/parliamentary.ts
@@ -1,82 +1,12 @@
 import { http, HttpResponse } from 'msw';
-import { ApiUrl } from '../apis/endpoints';
-import { PostDebateTableResponseType } from '../apis/responses/parliamentary';
+import { ApiUrl } from '../../apis/endpoints';
+import { PostDebateTableResponseType } from '../../apis/responses/parliamentary';
 
-export const handlers = [
-  // POST "/api/member"
-  http.post(ApiUrl.member, async () => {
-    return HttpResponse.json({
-      id: 1,
-      nickname: '홍길동',
-    });
-  }),
-
-  // GET /api/table?memberId={memberId}
-  http.get(ApiUrl.table, ({ request }) => {
-    const url = new URL(request.url);
-    const memberId = url.searchParams.get('memberId');
-    console.log(`# memberId = ${memberId}`);
-
-    return HttpResponse.json({
-      tables: [
-        {
-          id: 1,
-          name: '테이블 1',
-          type: 'PARLIAMENTARY',
-          duration: '1800',
-        },
-        {
-          id: 2,
-          name: '테이블 2',
-          type: 'PARLIAMENTARY',
-          duration: '1750',
-        },
-        {
-          id: 3,
-          name: '테이블 1',
-          type: 'PARLIAMENTARY',
-          duration: '1800',
-        },
-        {
-          id: 4,
-          name: '테이블 2',
-          type: 'PARLIAMENTARY',
-          duration: '1750',
-        },
-        {
-          id: 5,
-          name: '테이블 1',
-          type: 'PARLIAMENTARY',
-          duration: '1800',
-        },
-        {
-          id: 6,
-          name: '테이블 2',
-          type: 'PARLIAMENTARY',
-          duration: '1750',
-        },
-        {
-          id: 7,
-          name: '테이블 1',
-          type: 'PARLIAMENTARY',
-          duration: '1800',
-        },
-        {
-          id: 8,
-          name: '테이블 2',
-          type: 'PARLIAMENTARY',
-          duration: '1750',
-        },
-      ],
-    });
-  }),
-
-  // GET /api/table/parliamentary/{tableId}?memberId={memberId}
-  http.get(ApiUrl.parliamentary + '/:tableId', ({ request, params }) => {
-    const url = new URL(request.url);
-    const memberId = url.searchParams.get('memberId');
+export const parliamentaryHandlers = [
+  // GET /api/table/parliamentary/{tableId}
+  http.get(ApiUrl.parliamentary + '/:tableId', ({ params }) => {
     const { tableId } = params;
-    console.log(`# memberId = ${memberId}, tableId  = ${tableId}`);
+    console.log(`# tableId  = ${tableId}`);
 
     return HttpResponse.json({
       id: 1,
@@ -115,14 +45,12 @@ export const handlers = [
     });
   }),
 
-  // POST /api/table/parliamentary?memberId={memberId}
+  // POST /api/table/parliamentary
   http.post(ApiUrl.parliamentary, async ({ request }) => {
-    const url = new URL(request.url);
-    const memberId = url.searchParams.get('memberId');
     const result = (await request.json()) as PostDebateTableResponseType;
     // This console log calling shows error(ts(2339)) but will be executed with any problems.
     console.log(
-      `# memberId = ${memberId}, tableAgenda = ${result?.info.agenda}, tableName = ${result?.info.name}`,
+      `# tableAgenda = ${result?.info.agenda}, tableName = ${result?.info.name}`,
     );
 
     return HttpResponse.json({
@@ -220,15 +148,16 @@ export const handlers = [
     });
   }),
 
-  // DELETE /api/table/parliamentary/{tableId}?memberId={memberId}
-  http.delete(ApiUrl.parliamentary + '/:tableId', ({ request, params }) => {
-    const url = new URL(request.url);
-    const memberId = url.searchParams.get('memberId');
+  // DELETE /api/table/parliamentary/{tableId}
+  http.delete(ApiUrl.parliamentary + '/:tableId', ({ params }) => {
     const { tableId } = params;
-    console.log(`# memberId = ${memberId}, tableId  = ${tableId}`);
+    console.log(`# tableId  = ${tableId}`);
 
     return new HttpResponse(null, {
       status: 204,
     });
   }),
+
+  // PATCH /api/table/parliamentary/{tableId}
+  // TODO
 ];

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,4 +1,4 @@
 import { setupServer } from 'msw/node';
-import { handlers } from './handlers';
+import { allHandlers } from './handlers/global';
 
-export const server = setupServer(...handlers);
+export const server = setupServer(...allHandlers);

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -6,7 +6,7 @@ import TimeBoxStep from './components/TimeBoxStep/TimeBoxStep';
 import { useGetParliamentaryTableData } from '../../hooks/query/useGetParliamentaryTableData';
 import { useSearchParams } from 'react-router-dom';
 import { useMemo } from 'react';
-import { Type } from '../../type/type';
+import { DebateType } from '../../type/type';
 
 export type TableCompositionStep = 'NameAndType' | 'TimeBox';
 type Mode = 'edit' | 'add';
@@ -18,7 +18,7 @@ export default function TableComposition() {
   // 1) URL 등으로부터 "editMode"와 "tableId"를 추출
   const [searchParams] = useSearchParams();
   const mode = searchParams.get('mode') as Mode;
-  const type = (searchParams.get('type') as Type) ?? '';
+  const type = (searchParams.get('type') as DebateType) ?? '';
   const tableId = Number(searchParams.get('tableId') || 0);
 
   // (2) edit 모드일 때만 서버에서 initData를 가져옴

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -2,7 +2,7 @@ import { HTMLAttributes } from 'react';
 import EditDeleteButtons from '../EditDeleteButtons/EditDeleteButtons';
 import {
   ParliamentaryTimeBoxInfo,
-  DebateTypeToString,
+  ParliamentarySpeechTypeToString,
 } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 import { LuArrowUpDown } from 'react-icons/lu';
@@ -16,7 +16,7 @@ export default function DebatePanel(props: DebatePanelProps) {
   const { stance, type, time, speakerNumber } = props.info;
   const { onSubmitEdit, onSubmitDelete, onMouseDown } = props;
 
-  const debateTypeLabel = DebateTypeToString[type];
+  const debateTypeLabel = ParliamentarySpeechTypeToString[type];
   const { minutes, seconds } = Formatting.formatSecondsToMinutes(time);
   const timeStr = `${minutes}분 ${seconds}초`;
 

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -1,11 +1,14 @@
 import { HTMLAttributes } from 'react';
 import EditDeleteButtons from '../EditDeleteButtons/EditDeleteButtons';
-import { TimeBoxInfo, DebateTypeToString } from '../../../../type/type';
+import {
+  ParliamentaryTimeBoxInfo,
+  DebateTypeToString,
+} from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 import { LuArrowUpDown } from 'react-icons/lu';
 interface DebatePanelProps extends HTMLAttributes<HTMLDivElement> {
-  info: TimeBoxInfo;
-  onSubmitEdit?: (updatedInfo: TimeBoxInfo) => void;
+  info: ParliamentaryTimeBoxInfo;
+  onSubmitEdit?: (updatedInfo: ParliamentaryTimeBoxInfo) => void;
   onSubmitDelete?: () => void;
 }
 

--- a/src/page/TableComposition/components/DropdownForDebateType/DropdownForDebateType.tsx
+++ b/src/page/TableComposition/components/DropdownForDebateType/DropdownForDebateType.tsx
@@ -1,11 +1,10 @@
 import { useState } from 'react';
-import { Type } from '../../../../type/type';
-import { typeMapping } from '../../../../constants/languageMapping';
+import { DebateType, DebateTypeToString } from '../../../../type/type';
 import { IoMdArrowDropdown } from 'react-icons/io';
 
 interface DropdownForDebateTypeProps {
-  type: Type;
-  onChange: (type: Type) => void;
+  type: DebateType;
+  onChange: (type: DebateType) => void;
 }
 
 export default function DropdownForDebateType(
@@ -14,16 +13,16 @@ export default function DropdownForDebateType(
   const { type, onChange } = props;
 
   const reverseTypeMapping: Record<string, string> = Object.fromEntries(
-    Object.entries(typeMapping).map(([key, value]) => [value, key]),
+    Object.entries(DebateTypeToString).map(([key, value]) => [value, key]),
   );
 
-  const koreanTypes = Object.values(typeMapping);
+  const koreanTypes = Object.values(DebateTypeToString);
 
   const [isToggleOpen, setIsToggleOpen] = useState(false);
 
   const handleTypeSelect = (selectedKoreanType: string) => {
     const selectedEnglishType = reverseTypeMapping[selectedKoreanType];
-    onChange(selectedEnglishType as Type);
+    onChange(selectedEnglishType as DebateType);
     setIsToggleOpen(false);
   };
 
@@ -37,7 +36,7 @@ export default function DropdownForDebateType(
         onClick={() => setIsToggleOpen(!isToggleOpen)}
         className="flex w-full items-center justify-between rounded-md border border-neutral-300 bg-white p-3 text-sm text-black focus:outline-none md:text-base"
       >
-        <span>{typeMapping[type]}</span>
+        <span>{DebateTypeToString[type]}</span>
         <IoMdArrowDropdown
           className={`ml-2 text-xl transition-transform ${
             isToggleOpen ? 'rotate-180' : ''

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.stories.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import EditDeleteButtons from './EditDeleteButtons';
-import { TimeBoxInfo } from '../../../../type/type';
+import { ParliamentaryTimeBoxInfo } from '../../../../type/type';
 
 const meta: Meta<typeof EditDeleteButtons> = {
   title: 'page/TableSetup/components/EditDeleteButtons',
@@ -12,7 +12,7 @@ export default meta;
 
 type Story = StoryObj<typeof EditDeleteButtons>;
 
-const mockInfo: TimeBoxInfo = {
+const mockInfo: ParliamentaryTimeBoxInfo = {
   stance: 'PROS',
   type: 'OPENING',
   time: 150,

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -1,12 +1,12 @@
 import { RiEditFill, RiDeleteBinFill } from 'react-icons/ri';
-import { TimeBoxInfo } from '../../../../type/type';
+import { ParliamentaryTimeBoxInfo } from '../../../../type/type';
 import { useModal } from '../../../../hooks/useModal';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 import DialogModal from '../../../../components/DialogModal/DialogModal';
 
 interface EditDeleteButtonsPros {
-  info: TimeBoxInfo;
-  onSubmitEdit: (updatedInfo: TimeBoxInfo) => void;
+  info: ParliamentaryTimeBoxInfo;
+  onSubmitEdit: (updatedInfo: ParliamentaryTimeBoxInfo) => void;
   onSubmitDelete: () => void;
 }
 

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -2,10 +2,10 @@ import ClearableInput from '../../../../components/ClearableInput/ClearableInput
 import HeaderTitle from '../../../../components/HeaderTitle/HeaderTitle';
 import LabeledCheckbox from '../../../../components/LabledCheckBox/LabeledCheckbox';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
-import { DetailDebateInfo, DebateType } from '../../../../type/type';
+import { ParliamentaryDebateInfo, DebateType } from '../../../../type/type';
 import DropdownForDebateType from '../DropdownForDebateType/DropdownForDebateType';
 
-type ExtendedDebateInfo = DetailDebateInfo & {
+type ExtendedDebateInfo = ParliamentaryDebateInfo & {
   type: DebateType;
 };
 interface TableNameAndTypeProps {

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -2,11 +2,11 @@ import ClearableInput from '../../../../components/ClearableInput/ClearableInput
 import HeaderTitle from '../../../../components/HeaderTitle/HeaderTitle';
 import LabeledCheckbox from '../../../../components/LabledCheckBox/LabeledCheckbox';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
-import { DetailDebateInfo, Type } from '../../../../type/type';
+import { DetailDebateInfo, DebateType } from '../../../../type/type';
 import DropdownForDebateType from '../DropdownForDebateType/DropdownForDebateType';
 
 type ExtendedDebateInfo = DetailDebateInfo & {
-  type: Type;
+  type: DebateType;
 };
 interface TableNameAndTypeProps {
   info: ExtendedDebateInfo;

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -2,7 +2,7 @@ import DebatePanel from '../DebatePanel/DebatePanel';
 import TimerCreationButton from '../TimerCreationButton/TimerCreationButton';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 import { useModal } from '../../../../hooks/useModal';
-import { TimeBoxInfo } from '../../../../type/type';
+import { ParliamentaryTimeBoxInfo } from '../../../../type/type';
 import { useDragAndDrop } from '../../../../hooks/useDragAndDrop';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import PropsAndConsTitle from '../../../../components/ProsAndConsTitle/PropsAndConsTitle';
@@ -12,7 +12,9 @@ import HeaderTitle from '../../../../components/HeaderTitle/HeaderTitle';
 
 interface TimeBoxStepProps {
   initData: TableFormData;
-  onTimeBoxChange: React.Dispatch<React.SetStateAction<TimeBoxInfo[]>>;
+  onTimeBoxChange: React.Dispatch<
+    React.SetStateAction<ParliamentaryTimeBoxInfo[]>
+  >;
   onButtonClick: () => void;
   isEdit?: boolean;
 }
@@ -28,7 +30,10 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       throttleDelay: 50,
     });
 
-  const handleSubmitEdit = (indexToEdit: number, updatedInfo: TimeBoxInfo) => {
+  const handleSubmitEdit = (
+    indexToEdit: number,
+    updatedInfo: ParliamentaryTimeBoxInfo,
+  ) => {
     onTimeBoxChange((prevData) =>
       prevData.map((item, index) =>
         index === indexToEdit ? updatedInfo : item,

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import {
   ParliamentaryTimeBoxInfo,
-  DebateType,
+  ParliamentarySpeechType,
   Stance,
 } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
@@ -29,7 +29,7 @@ export default function TimerCreationContent({
       : (initData?.stance ?? 'PROS'),
   );
 
-  const [debateType, setDebateType] = useState<DebateType>(
+  const [debateType, setDebateType] = useState<ParliamentarySpeechType>(
     beforeData?.type
       ? beforeData?.type !== 'TIME_OUT'
         ? beforeData?.type
@@ -113,7 +113,7 @@ export default function TimerCreationContent({
               ) {
                 setStance('PROS');
               }
-              setDebateType(e.target.value as DebateType);
+              setDebateType(e.target.value as ParliamentarySpeechType);
             }}
           >
             <option value="OPENING">입론</option>

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -1,11 +1,15 @@
 import { useState } from 'react';
-import { TimeBoxInfo, DebateType, Stance } from '../../../../type/type';
+import {
+  ParliamentaryTimeBoxInfo,
+  DebateType,
+  Stance,
+} from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 
 interface TimerCreationContentProps {
-  beforeData?: TimeBoxInfo;
-  initData?: TimeBoxInfo;
-  onSubmit: (data: TimeBoxInfo) => void;
+  beforeData?: ParliamentaryTimeBoxInfo;
+  initData?: ParliamentaryTimeBoxInfo;
+  onSubmit: (data: ParliamentaryTimeBoxInfo) => void;
   onClose: () => void;
 }
 

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -3,7 +3,7 @@ import { useNavigate, useNavigationType } from 'react-router-dom';
 import { TableCompositionStep } from '../TableComposition';
 import useBrowserStorage from '../../../hooks/useBrowserStorage';
 import {
-  DetailDebateInfo,
+  ParliamentaryDebateInfo,
   ParliamentaryTimeBoxInfo,
   DebateType,
 } from '../../../type/type';
@@ -11,7 +11,7 @@ import useAddTable from '../../../hooks/mutations/useAddTable';
 import { usePutParliamentaryDebateTable } from '../../../hooks/mutations/usePutParliamentaryDebateTable';
 
 export interface TableFormData {
-  info: DetailDebateInfo & { type: DebateType };
+  info: ParliamentaryDebateInfo & { type: DebateType };
   table: ParliamentaryTimeBoxInfo[];
 }
 const useTableFrom = (

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -2,13 +2,17 @@ import { useEffect } from 'react';
 import { useNavigate, useNavigationType } from 'react-router-dom';
 import { TableCompositionStep } from '../TableComposition';
 import useBrowserStorage from '../../../hooks/useBrowserStorage';
-import { DetailDebateInfo, TimeBoxInfo, Type } from '../../../type/type';
+import {
+  DetailDebateInfo,
+  ParliamentaryTimeBoxInfo,
+  Type,
+} from '../../../type/type';
 import useAddTable from '../../../hooks/mutations/useAddTable';
 import { usePutParliamentaryDebateTable } from '../../../hooks/mutations/usePutParliamentaryDebateTable';
 
 export interface TableFormData {
   info: DetailDebateInfo & { type: Type };
-  table: TimeBoxInfo[];
+  table: ParliamentaryTimeBoxInfo[];
 }
 const useTableFrom = (
   currentStep: TableCompositionStep,
@@ -82,15 +86,17 @@ const useTableFrom = (
     });
   };
 
-  const updateTable: React.Dispatch<React.SetStateAction<TimeBoxInfo[]>> = (
-    action,
-  ) => {
+  const updateTable: React.Dispatch<
+    React.SetStateAction<ParliamentaryTimeBoxInfo[]>
+  > = (action) => {
     setFormData((prev) => {
-      let newTable: TimeBoxInfo[];
+      let newTable: ParliamentaryTimeBoxInfo[];
       if (typeof action === 'function') {
-        newTable = (action as (arg: TimeBoxInfo[]) => TimeBoxInfo[])(
-          prev.table,
-        );
+        newTable = (
+          action as (
+            arg: ParliamentaryTimeBoxInfo[],
+          ) => ParliamentaryTimeBoxInfo[]
+        )(prev.table);
       } else {
         newTable = action;
       }

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -5,13 +5,13 @@ import useBrowserStorage from '../../../hooks/useBrowserStorage';
 import {
   DetailDebateInfo,
   ParliamentaryTimeBoxInfo,
-  Type,
+  DebateType,
 } from '../../../type/type';
 import useAddTable from '../../../hooks/mutations/useAddTable';
 import { usePutParliamentaryDebateTable } from '../../../hooks/mutations/usePutParliamentaryDebateTable';
 
 export interface TableFormData {
-  info: DetailDebateInfo & { type: Type };
+  info: DetailDebateInfo & { type: DebateType };
   table: ParliamentaryTimeBoxInfo[];
 }
 const useTableFrom = (
@@ -62,7 +62,7 @@ const useTableFrom = (
     React.SetStateAction<{
       name: string;
       agenda: string;
-      type: Type;
+      type: DebateType;
       warningBell: boolean;
       finishBell: boolean;
     }>
@@ -71,7 +71,7 @@ const useTableFrom = (
       let newInfo: {
         name: string;
         agenda: string;
-        type: Type;
+        type: DebateType;
         warningBell: boolean;
         finishBell: boolean;
       };

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -7,7 +7,7 @@ import {
   ParliamentaryTimeBoxInfo,
   DebateType,
 } from '../../../type/type';
-import useAddTable from '../../../hooks/mutations/useAddTable';
+import useAddParliamentaryTable from '../../../hooks/mutations/useAddParliamentaryDebateTable';
 import { usePutParliamentaryDebateTable } from '../../../hooks/mutations/usePutParliamentaryDebateTable';
 
 export interface TableFormData {
@@ -107,12 +107,11 @@ const useTableFrom = (
     });
   };
 
-  const { mutate: AddTable, isPending: isAddTablePending } = useAddTable(
-    (tableId: number) => {
+  const { mutate: AddTable, isPending: isAddTablePending } =
+    useAddParliamentaryTable((tableId: number) => {
       removeValue();
       navigate(`/overview/${tableId}`);
-    },
-  );
+    });
   const { mutate: EditTable, isPending: isEditTablePending } =
     usePutParliamentaryDebateTable((tableId: number) => {
       removeValue();

--- a/src/page/TableListPage/components/Modal/EditButton.tsx
+++ b/src/page/TableListPage/components/Modal/EditButton.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { AiOutlineEdit } from 'react-icons/ai';
 import { useNavigate } from 'react-router-dom';
-import { Type } from '../../../../type/type';
+import { DebateType } from '../../../../type/type';
 interface EditButtonProps {
   tableId: number;
-  type?: Type;
+  type?: DebateType;
 }
 export default function EditButton({ tableId, type }: EditButtonProps) {
   const navigate = useNavigate();

--- a/src/page/TableListPage/components/Table/Table.tsx
+++ b/src/page/TableListPage/components/Table/Table.tsx
@@ -1,8 +1,7 @@
 import { useNavigate } from 'react-router-dom';
-import { DebateTable } from '../../../../type/type';
+import { DebateTable, DebateTypeToString } from '../../../../type/type';
 import EditButton from '../Modal/EditButton';
 import DeleteModalButton from '../Modal/DeleteModalButton';
-import { typeMapping } from '../../../../constants/languageMapping';
 
 interface DebateTableWithDelete extends DebateTable {
   onDelete: (name: string) => void;
@@ -33,7 +32,7 @@ export default function Table({
       <div className="flex h-full flex-col items-start justify-center">
         <h1 className="mb-[30px] text-[40px] font-bold">{name}</h1>
         <div className="flex max-w-full flex-col items-start justify-center text-[36px] font-bold">
-          <span>유형 | {typeMapping[type]}</span>
+          <span>유형 | {DebateTypeToString[type]}</span>
           <span
             className="w-full truncate"
             title={agenda && agenda?.length > 15 ? agenda : undefined}

--- a/src/page/TableOverviewPage/TableOverview.stories.tsx
+++ b/src/page/TableOverviewPage/TableOverview.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 import TableOverview from './TableOverview';
-import { TimeBoxInfo } from '../../type/type';
+import { ParliamentaryTimeBoxInfo } from '../../type/type';
 
 // 1) 메타 설정
 const meta: Meta<typeof TableOverview> = {
@@ -29,6 +29,6 @@ export const Default: Story = {
         time: 180,
         speakerNumber: 2,
       },
-    ] as TimeBoxInfo[],
+    ] as ParliamentaryTimeBoxInfo[],
   },
 };

--- a/src/page/TimerPage/components/TimeTable.tsx
+++ b/src/page/TimerPage/components/TimeTable.tsx
@@ -1,11 +1,11 @@
-import { TimeBoxInfo } from '../../../type/type';
+import { ParliamentaryTimeBoxInfo } from '../../../type/type';
 import TimeTableItem from './TimeTableItem';
 import { FaArrowLeft, FaArrowRight } from 'react-icons/fa';
 
 interface TimeTableProps {
   goToOtherItem: (isPrev: boolean) => void;
   currIndex: number;
-  items: TimeBoxInfo[];
+  items: ParliamentaryTimeBoxInfo[];
   titles?: {
     pros: string;
     cons: string;

--- a/src/page/TimerPage/components/TimeTableItem.tsx
+++ b/src/page/TimerPage/components/TimeTableItem.tsx
@@ -1,6 +1,6 @@
 import { RiSpeakFill } from 'react-icons/ri';
 import {
-  DebateTypeToString,
+  ParliamentarySpeechTypeToString,
   ParliamentaryTimeBoxInfo,
 } from '../../../type/type';
 import { Formatting } from '../../../util/formatting';
@@ -37,7 +37,7 @@ export default function TimeTableItem({ isCurrent, item }: TimeTableItem) {
       className={`flex h-max ${width} flex-row items-center justify-center space-x-2 ${pos} ${bgColorClass} ${roundedClass} p-[16px] text-[28px] font-bold ${textColorClass}`}
     >
       {/* Print what type is this sequence (e.g., opening, time-out, etc.) */}
-      <h1>{DebateTypeToString[item.type]}</h1>
+      <h1>{ParliamentarySpeechTypeToString[item.type]}</h1>
 
       {/* Print running time */}
       <p>| {timeText}</p>

--- a/src/page/TimerPage/components/TimeTableItem.tsx
+++ b/src/page/TimerPage/components/TimeTableItem.tsx
@@ -1,10 +1,13 @@
 import { RiSpeakFill } from 'react-icons/ri';
-import { DebateTypeToString, TimeBoxInfo } from '../../../type/type';
+import {
+  DebateTypeToString,
+  ParliamentaryTimeBoxInfo,
+} from '../../../type/type';
 import { Formatting } from '../../../util/formatting';
 
 interface TimeTableItem {
   isCurrent: boolean;
-  item: TimeBoxInfo;
+  item: ParliamentaryTimeBoxInfo;
 }
 
 export default function TimeTableItem({ isCurrent, item }: TimeTableItem) {

--- a/src/page/TimerPage/components/Timer.tsx
+++ b/src/page/TimerPage/components/Timer.tsx
@@ -1,6 +1,6 @@
 import { RiSpeakFill } from 'react-icons/ri';
 import {
-  DebateTypeToString,
+  ParliamentarySpeechTypeToString,
   StanceToString,
   ParliamentaryTimeBoxInfo,
 } from '../../../type/type';
@@ -46,10 +46,12 @@ export default function Timer({
         ? 'bg-camp-blue'
         : 'bg-camp-red';
   const titleText = isAdditionalTimerOn
-    ? DebateTypeToString['TIME_OUT']
+    ? ParliamentarySpeechTypeToString['TIME_OUT']
     : item.stance === 'NEUTRAL'
-      ? DebateTypeToString[item.type]
-      : StanceToString[item.stance] + ' ' + DebateTypeToString[item.type];
+      ? ParliamentarySpeechTypeToString[item.type]
+      : StanceToString[item.stance] +
+        ' ' +
+        ParliamentarySpeechTypeToString[item.type];
 
   return (
     <div

--- a/src/page/TimerPage/components/Timer.tsx
+++ b/src/page/TimerPage/components/Timer.tsx
@@ -2,7 +2,7 @@ import { RiSpeakFill } from 'react-icons/ri';
 import {
   DebateTypeToString,
   StanceToString,
-  TimeBoxInfo,
+  ParliamentaryTimeBoxInfo,
 } from '../../../type/type';
 import TimerController from './TimerController';
 import { Formatting } from '../../../util/formatting';
@@ -22,7 +22,7 @@ interface TimerProps {
   isRunning: boolean;
   isLastItem: boolean;
   isFirstItem: boolean;
-  item: TimeBoxInfo;
+  item: ParliamentaryTimeBoxInfo;
 }
 
 export default function Timer({

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -32,7 +32,7 @@ export const CustomizeTimeBoxTypeToString: Record<
   string
 > = {
   NORMAL: '일반 타이머',
-  TIME_BASED: '자요토론 타이머',
+  TIME_BASED: '자유토론 타이머',
 };
 
 export const DebateTypeToString: Record<DebateType, string> = {
@@ -63,9 +63,18 @@ export interface CustomizeTimeBoxInfo {
   speaker?: string;
 }
 
-export interface DetailDebateInfo {
+export interface ParliamentaryDebateInfo {
   name: string;
   agenda: string;
+  warningBell: boolean;
+  finishBell: boolean;
+}
+
+export interface CustomizeDebateInfo {
+  name: string;
+  agenda: string;
+  prosTeamName: string;
+  consTeamName: string;
   warningBell: boolean;
   finishBell: boolean;
 }

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -25,7 +25,7 @@ export interface User {
   name: string;
 }
 
-export interface TimeBoxInfo {
+export interface ParliamentaryTimeBoxInfo {
   stance: Stance;
   type: DebateType;
   time: number;

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -1,18 +1,25 @@
+// Types
 export type Stance = 'PROS' | 'CONS' | 'NEUTRAL';
-export type DebateType =
+export type ParliamentarySpeechType =
   | 'OPENING'
   | 'REBUTTAL'
   | 'CROSS'
   | 'CLOSING'
   | 'TIME_OUT';
+export type CustomizeTimeBoxType = 'NORMAL' | 'TIME_BASED';
+export type DebateType = 'PARLIAMENTARY' | 'CUSTOMIZE';
 
+// Type converters
 export const StanceToString: Record<Stance, string> = {
   PROS: '찬성',
   CONS: '반대',
   NEUTRAL: '중립',
 };
 
-export const DebateTypeToString: Record<DebateType, string> = {
+export const ParliamentarySpeechTypeToString: Record<
+  ParliamentarySpeechType,
+  string
+> = {
   OPENING: '입론',
   REBUTTAL: '반론',
   CROSS: '교차 질의',
@@ -20,6 +27,20 @@ export const DebateTypeToString: Record<DebateType, string> = {
   TIME_OUT: '작전 시간',
 };
 
+export const CustomizeTimeBoxTypeToString: Record<
+  CustomizeTimeBoxType,
+  string
+> = {
+  NORMAL: '일반 타이머',
+  TIME_BASED: '자요토론 타이머',
+};
+
+export const DebateTypeToString: Record<DebateType, string> = {
+  PARLIAMENTARY: '의회식 토론',
+  CUSTOMIZE: '사용자 지정 토론',
+};
+
+// Interfaces
 export interface User {
   id: string;
   name: string;
@@ -27,9 +48,19 @@ export interface User {
 
 export interface ParliamentaryTimeBoxInfo {
   stance: Stance;
-  type: DebateType;
+  type: ParliamentarySpeechType;
   time: number;
   speakerNumber?: number;
+}
+
+export interface CustomizeTimeBoxInfo {
+  stance: Stance;
+  speechType: string;
+  boxType: CustomizeTimeBoxType;
+  time: number;
+  timePerTeam: number;
+  timePerSpeaking: number;
+  speaker?: string;
 }
 
 export interface DetailDebateInfo {
@@ -42,8 +73,6 @@ export interface DetailDebateInfo {
 export interface DebateTable {
   id: number;
   name: string;
-  type: Type;
+  type: DebateType;
   agenda: string;
 }
-
-export type Type = 'PARLIAMENTARY';


### PR DESCRIPTION
# 🚩 연관 이슈

closed #203 

# 📝 작업 내용
## 들어가기 전
파일 변경 사항이 매우 많습니다. 이는 일부 소스 코드가 Customize API의 추가를 대비하지 않고 만들어졌기 때문에, Customize API와 Parliamentary API 간 구별을 위한 리팩터링 작업이 필요했기 때문입니다. 따라서 핵심 파일 위주로만 보실 수 있게, 아래 리스트에 주요 변경 파일들을 적어 두겠습니다!

## 주요 추가/변경 디렉토리
- **(신규) /src/apis/apis**
- **(신규) /src/apis/responses**
- **(신규) /src/hooks**
- **(신규) /src/mocks/handlers**
- **(변경) /src/type/type.ts**

## 주요 변경 사항
### Customize API 관련
- Customize API 추가 (/src/apis/apis/customize.ts)
- Customize API의 응답 형식 인터페이스 추가 (/src/apis/responses/customize.ts)
- Customize API의 React 훅 추가 (/src/hooks/mutations, /src/hooks/query)
- Customize API의 msw 핸들러 추가 (/src/mocks/handlers/customize.ts)
- Customize API 요청에 필요한 상수 및 문자열 변환 함수 추가 (/src/type/type.ts)

## 세부 설명
### Customize API 관련 코드 추가
제목이 곧 내용입니다.

### 문자열 변환 함수 일원화
상수 타입(`type`)으로 선언된 자료형을 문자열로 변환하는 함수들은, 같은 역할을 함에도 불구하고 다음 두 파일에 나누어져 있었습니다:
- /src/constants/languageMapping.ts
- /src/type/type.ts

이들을 모두 /src/type/type.ts에 통합하였습니다.

### API 함수, msw 핸들러, 응답 형식 인터페이스(response type interfaces) 분리
원래 API 함수, msw 핸들러와 응답 형식 인터페이스들은 각각 하나의 파일에 전부 통합되어 있었습니다: 
- API 함수들은 /src/apis/apis.ts 1개의 파일
- 응답 형식 인터페이스는 /src/apis/responseTypes.ts 1개의 파일
- msw 핸들러들은 /src/mocks/handlers.ts 1개의 파일

이번에 Customize API의 추가에 따라, 추후 개발 편의와 가독성 향상을 위해 Member/Parliamentary/Customize API들을 별도의 파일로 구분 및 분리하였습니다.

## 여담
PR #197 '[FEAT] /debate API 토론하기 버튼에 적용'에서, 의회식 토론의 PATCH API에 대한 msw 핸들러가 추가되어 있지 않습니다. 그러나, 이 PR에서 API 전반에서 큰 변화가 발생한 만큼, 이 PR이 병합되고 난 후에 해당 msw 핸들러를 추가하는 것이 적절할 것으로 생각됩니다.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음