### PR TITLE
[FEAT] parliamentary/debate api 토론하기 버튼 재연결

### DIFF
--- a/src/apis/apis/parliamentary.ts
+++ b/src/apis/apis/parliamentary.ts
@@ -4,9 +4,12 @@ import {
 } from '../../type/type';
 import { ApiUrl } from '../endpoints';
 import { request } from '../primitives';
-import { PutDebateTableResponseType } from '../responses/parliamentary';
-import { PostDebateTableResponseType } from '../responses/parliamentary';
-import { GetTableDataResponseType } from '../responses/parliamentary';
+import {
+  PutDebateTableResponseType,
+  PostDebateTableResponseType,
+  GetTableDataResponseType,
+  PatchDebateTableResponseType,
+} from '../responses/parliamentary';
 
 // Template
 /*
@@ -102,4 +105,19 @@ export async function deleteParliamentaryDebateTable(
   );
 
   return response.status === 204 ? true : false;
+}
+
+// PATCH /api/table/parliamentary/{tableId}/debate
+export async function patchParliamentaryDebateTable(
+  tableId: number,
+): Promise<PatchDebateTableResponseType> {
+  const requestUrl: string = ApiUrl.parliamentary;
+  const response = await request<PatchDebateTableResponseType>(
+    'PATCH',
+    requestUrl + `/${tableId}/debate`,
+    null,
+    null,
+  );
+
+  return response.data;
 }

--- a/src/apis/responses/parliamentary.ts
+++ b/src/apis/responses/parliamentary.ts
@@ -23,3 +23,10 @@ export interface PutDebateTableResponseType {
   info: ParliamentaryDebateInfo;
   table: ParliamentaryTimeBoxInfo[];
 }
+
+// PATCH /api/table/parliamentary/{tableId}/debate
+export interface PatchDebateTableResponseType {
+  id: number;
+  info: ParliamentaryDebateInfo;
+  table: ParliamentaryTimeBoxInfo[];
+}

--- a/src/hooks/mutations/usePatchParliamentaryDebateTable.ts
+++ b/src/hooks/mutations/usePatchParliamentaryDebateTable.ts
@@ -1,0 +1,25 @@
+import { useMutation } from '@tanstack/react-query';
+import { patchParliamentaryDebateTable } from '../../apis/apis/parliamentary';
+import { PatchDebateTableResponseType } from '../../apis/responses/parliamentary';
+
+interface UsePatchParliamentaryTableParams {
+  tableId: number;
+}
+
+export function usePatchParliamentaryTable(
+  onSuccess: (tableId: number) => void,
+) {
+  return useMutation<
+    PatchDebateTableResponseType,
+    Error,
+    UsePatchParliamentaryTableParams
+  >({
+    mutationFn: async ({ tableId }) => patchParliamentaryDebateTable(tableId),
+    onSuccess: (response: PatchDebateTableResponseType) => {
+      onSuccess(response.id);
+    },
+    onError: (error) => {
+      console.error('Error patching parliamentary debate:', error);
+    },
+  });
+}

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -6,12 +6,19 @@ import DebatePanel from '../TableComposition/components/DebatePanel/DebatePanel'
 import HeaderTableInfo from '../../components/HeaderTableInfo/HeaderTableInfo';
 import HeaderTitle from '../../components/HeaderTitle/HeaderTitle';
 import { RiEditFill, RiSpeakFill } from 'react-icons/ri';
+import { usePatchParliamentaryTable } from '../../hooks/mutations/usePatchParliamentaryDebateTable';
+
 export default function TableOverview() {
   const pathParams = useParams();
   const tableId = Number(pathParams.id);
   const { data } = useGetParliamentaryTableData(tableId);
 
   const navigate = useNavigate();
+
+  // 토론하기 클릭 시 patch 요청 후 이동
+  const patchTableMutation = usePatchParliamentaryTable((tableId) => {
+    navigate(`/table/parliamentary/${tableId}`);
+  });
 
   return (
     <DefaultLayout>
@@ -54,7 +61,7 @@ export default function TableOverview() {
           </button>
           <button
             className="button enabled h-16 w-full"
-            onClick={() => navigate(`/table/parliamentary/${tableId}`)}
+            onClick={() => patchTableMutation.mutate({ tableId })}
           >
             <div className="flex items-center justify-center gap-2">
               <RiSpeakFill />


### PR DESCRIPTION
# 🚩 연관 이슈

closed #193 

# 📝 작업 내용
## 개요

- PR #208 이후 변경 사항 머지 후 PATCH 로직 적용
- /api/table/parliamentary/{tableId}/debate 호출 로직 추가
- '토론하기' 버튼 클릭 시 PATCH API 호출
- 성공 시 테이블 페이지로 이동, 실패시 에러 로깅

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음