### PR TITLE
[DESIGN] `DialogModal` 버튼 호버 색상 추가

### DIFF
--- a/src/components/DialogModal/DialogModal.tsx
+++ b/src/components/DialogModal/DialogModal.tsx
@@ -35,11 +35,11 @@ export default function DialogModal({
 
       {/** Buttons */}
       <div className="w-full border-t border-neutral-300" />
-      <div className="flex w-full flex-row items-center justify-center py-4">
+      <div className="flex w-full flex-row items-center justify-center">
         {/** Left button */}
         <button
           data-testid="button-left"
-          className="w-1/2 hover:bg-neutral-300"
+          className="w-1/2 py-4 hover:bg-neutral-300"
           onClick={() => left.onClick()}
         >
           <p
@@ -52,7 +52,7 @@ export default function DialogModal({
         {/** Right button */}
         <button
           data-testid="button-right"
-          className="w-1/2 hover:bg-brand-main"
+          className="w-1/2 py-4 hover:bg-brand-main"
           onClick={() => right.onClick()}
         >
           <p

--- a/src/components/DialogModal/DialogModal.tsx
+++ b/src/components/DialogModal/DialogModal.tsx
@@ -39,7 +39,7 @@ export default function DialogModal({
         {/** Left button */}
         <button
           data-testid="button-left"
-          className="w-1/2"
+          className="w-1/2 hover:bg-neutral-300"
           onClick={() => left.onClick()}
         >
           <p
@@ -52,7 +52,7 @@ export default function DialogModal({
         {/** Right button */}
         <button
           data-testid="button-right"
-          className="w-1/2"
+          className="w-1/2 hover:bg-brand-main"
           onClick={() => right.onClick()}
         >
           <p


### PR DESCRIPTION
# 🚩 연관 이슈

closed #212

# 📝 작업 내용
`DialogModal` 버튼에 다음 호버 색상을 추가하였습니다:
- 왼쪽 `neutral-300`
- 오른쪽 `brand-main`

# 🏞️ 스크린샷 (선택)
## 왼쪽 버튼 호버
![스크린샷 2025-03-31 100706](https://github.com/user-attachments/assets/9e81ab14-9075-4884-93ac-92f93daebc4e)

## 오른쪽 버튼 호버
![스크린샷 2025-03-31 100646](https://github.com/user-attachments/assets/273ee6e5-37a0-49c4-920f-6bc11db53e5d)

# 🗣️ 리뷰 요구사항 (선택)
없음