### PR TITLE
[FIX] 커스텀 토론 페이지 식별된 버그 수정

### DIFF
--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -636,7 +636,7 @@ export default function CustomizeTimerPage() {
                   {index === data.table.length - 1 && (
                     <RoundControlButton
                       type="DONE"
-                      onClick={() => navigate('/')}
+                      onClick={() => navigate(`/overview/${tableId}`)}
                     />
                   )}
                   {index !== data.table.length - 1 && (

--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -88,7 +88,9 @@ export default function NormalTimer({
       {/* Speaker's number, if necessary */}
       <div className="my-[20px] h-[40px]">
         <div className="flex w-full flex-row items-center space-x-2 text-neutral-900">
-          <MdRecordVoiceOver className="size-[40px]" />
+          {item.stance !== 'NEUTRAL' && (
+            <MdRecordVoiceOver className="size-[40px]" />
+          )}
           <h3 className="text-[28px] font-bold">
             {teamName && teamName + '  팀 '}
             {item.speaker && '| ' + item.speaker + ' 토론자'}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #223

# 📝 작업 내용
- 시간표에서 사전에 세팅한 작전시간 타이머의 경우, 아래 사진처럼 발언자 이모티콘이 표시되는 문제 수정
- '토론 종료' 버튼을 눌렀을 경우, 시간표(overview) 화면으로 넘어가도록 수정
# 🏞️ 스크린샷 (선택)
before
![image](https://github.com/user-attachments/assets/68322084-7082-4776-a963-bdc167df1377)

after
<img width="653" alt="image" src="https://github.com/user-attachments/assets/1978743f-4465-45f3-a172-e5e5fdf3fd3e" />

