### PR TITLE
[FIX] Storybook 배포 진행되지 않는 문제 수정

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   deploy:
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   deploy:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +29,10 @@ jobs:
         run: npm ci
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
-        with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --sha=$(git rev-parse HEAD)
+
+      # - name: Publish to Chromatic
+      #   uses: chromaui/action@v1
+      #   with:
+      #     projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      #     token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
 
     steps:
       - name: Setup NodeJS
@@ -28,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: Publish to Chromatic
-        run: npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --sha=$(git rev-parse HEAD)
+        run: npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --sha=${{ github.sha }} --exit-zero-on-changes
 
       # - name: Publish to Chromatic
       #   uses: chromaui/action@v1

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -2,9 +2,8 @@ name: Deploy-storybook
 
 on:
   workflow_dispatch:
-  pull_request:
+  push:
     branches: ['develop']
-    types: ['closed']
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
 
     steps:
       - name: Setup NodeJS


### PR DESCRIPTION
# 🚩 연관 이슈

closed #222 

# 📝 작업 내용
## 문제
- 현재 이 저장소는 Squash-merging 후 기존 브랜치를 삭제하는 전략 사용 중
- 그러나 병합 후 브랜치가 삭제되어, Storybook 배포 스크립트가 삭제된 Feature 브랜치의 헤드를 찾지 못해 배포가 진행되지 않았음

## 해결책
배포 명령어를 다음과 같이 개선:
```yaml
run: npx chromatic --project-token=${{ secrets.CHROMATIC_PROJECT_TOKEN }} --sha=${{ github.sha }} --exit-zero-on-changes
```

세부 옵션에 대한 설명:
- `--project-token` Chromatic 배포에 사용되는 고유 토큰
- `--sha` 배포할 기준 커밋의 해시 번호 (SHA)
- `--exit-zero-on-changes` React 컴포넌트에 직접적 디자인적 변경 사항이 있어도 오류를 뱉지 않고 계속 진행할 것을 명령

이상의 명령어는 GitHub Actions 러너에게 develop 브랜치에서 헤드를 찾아 배포하도록 함

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
원래는 PR이 단순히 닫히는 게 아니라 병합까지 되어야만 스크립트가 동작하도록 수정했었는데, 이러면 너무 융통성이 없어져서 이 조건문을 지웠습니다. 이 조건문이 들어가면 생기는 또 하나의 단점은, 지금 `workflow_dispatch` 옵션으로 인해 수동 실행이 가능하도록 설정되어 있는데, 조건문으로 인해 사실상 수동 실행이 막힌다는 점입니다.

이 부분에 대한 여러분 의견이 궁금합니다.