### PR TITLE
[FIX] 자유토론 타이머 오류 해결

### DIFF
--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -56,7 +56,7 @@ export function useModal(options: UseModalOptions = {}) {
     return (
       <GlobalPortal.Consumer>
         <div
-          className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
+          className="fixed inset-0 z-20 flex items-center justify-center bg-black bg-opacity-50"
           onClick={handleOverlayClick}
         >
           <div className="relative overflow-hidden rounded-lg bg-white shadow-lg">

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -56,7 +56,7 @@ export function useModal(options: UseModalOptions = {}) {
     return (
       <GlobalPortal.Consumer>
         <div
-          className="fixed inset-0 z-20 flex items-center justify-center bg-black bg-opacity-50"
+          className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50"
           onClick={handleOverlayClick}
         >
           <div className="relative overflow-hidden rounded-lg bg-white shadow-lg">

--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -545,7 +545,7 @@ export default function CustomizeTimerPage() {
               />
             )}
             {data.table[index].boxType === 'TIME_BASED' && (
-              <div className="flex flex-row items-center justify-center space-x-[-30px]">
+              <div className="relative flex flex-row items-center justify-center space-x-[30px]">
                 {/* 왼쪽 타이머 */}
                 <TimeBasedTimer
                   onStart={() => timer1.startTimer()}
@@ -589,17 +589,6 @@ export default function CustomizeTimerPage() {
                   teamName={data.info.prosTeamName}
                 />
 
-                {/* ENTER 버튼 */}
-                <button
-                  onClick={() => {
-                    switchCamp();
-                  }}
-                  className="z-10 flex h-[100px] w-[100px] flex-col items-center justify-center rounded-full bg-neutral-600 text-white shadow-lg transition hover:bg-neutral-500"
-                >
-                  <FaExchangeAlt className="text-[36px]" />
-                  <span className="text-[18px] font-bold">ENTER</span>
-                </button>
-
                 {/* 오른쪽 타이머 */}
                 <TimeBasedTimer
                   onStart={() => timer2.startTimer()}
@@ -642,6 +631,17 @@ export default function CustomizeTimerPage() {
                   prosCons="cons"
                   teamName={data.info.consTeamName}
                 />
+
+                {/* ENTER 버튼 */}
+                <button
+                  onClick={() => {
+                    switchCamp();
+                  }}
+                  className="absolute left-1/2 top-1/2 flex h-[100px] w-[100px] -translate-x-20 -translate-y-8 flex-col items-center justify-center rounded-full bg-neutral-600 text-white shadow-lg transition hover:bg-neutral-500"
+                >
+                  <FaExchangeAlt className="text-[36px]" />
+                  <span className="text-[18px] font-bold">ENTER</span>
+                </button>
               </div>
             )}
             {/* Round control buttons on the bottom side */}

--- a/src/page/CustomizeTimerPage/components/FirstUseToolTip.tsx
+++ b/src/page/CustomizeTimerPage/components/FirstUseToolTip.tsx
@@ -1,5 +1,4 @@
 import { PropsWithChildren } from 'react';
-import { IoHourglassOutline } from 'react-icons/io5';
 import { LuKeyboard } from 'react-icons/lu';
 import { MdOutlineTimer } from 'react-icons/md';
 

--- a/src/page/CustomizeTimerPage/components/FirstUseToolTip.tsx
+++ b/src/page/CustomizeTimerPage/components/FirstUseToolTip.tsx
@@ -29,7 +29,10 @@ export default function FirstUseToolTip({ onClose }: FirstUseToolTipProps) {
           </ListItem>
           <ListItem>초기화 버튼을 눌러 타이머를 원래 시간으로 초기화</ListItem>
           <ListItem>마우스를 사용하여 타이머를 클릭 시, 진영 변경</ListItem>
-          <ListItem>타이머 작동 중, 진영 변경 시, 상대 진영 자동 재생</ListItem>
+          <ListItem>
+            타이머 동작 중 진영이 변경될 경우, 상대 진영의 타이머로 전환과
+            동시에 시작
+          </ListItem>
         </div>
       </div>
 
@@ -63,29 +66,6 @@ export default function FirstUseToolTip({ onClose }: FirstUseToolTipProps) {
           <ListItem>좌우 방향키로 이전/다음 차례로 이동</ListItem>
           <ListItem>A/L 키로 토론 진영 변경</ListItem>
           <ListItem>Enter 키로 상대 진영으로 변경</ListItem>
-        </div>
-      </div>
-
-      <div className="flex flex-col space-y-1 text-slate-50">
-        <div className="mb-2 flex flex-row items-center space-x-4">
-          <IoHourglassOutline size={18} />
-          <h2 className="text-xl font-bold">
-            작전 시간을 사전에 설정하지 않는 경우
-          </h2>
-        </div>
-
-        <div className="text-m flex flex-col space-y-1 md:text-lg">
-          <ListItem>
-            타이머의 초기화 버튼 왼쪽의 &#39;작전 시간 사용&#39; 버튼을 눌러,
-            별도의 작전 시간 타이머를 열 수 있음
-          </ListItem>
-          <ListItem>
-            찬성 또는 반대 측에서 작전 시간을 요청할 경우 사용
-          </ListItem>
-          <ListItem>
-            각 팀에서 요청한 작전 시간 만큼 타이머를 설정할 수 있음 (±30초,
-            ±10초 단위)
-          </ListItem>
         </div>
       </div>
 

--- a/src/page/CustomizeTimerPage/components/FirstUseToolTip.tsx
+++ b/src/page/CustomizeTimerPage/components/FirstUseToolTip.tsx
@@ -12,99 +12,91 @@ interface FirstUseToolTipProps {
 
 export default function FirstUseToolTip({ onClose }: FirstUseToolTipProps) {
   return (
-    <div className="fixed z-30 m-4 flex justify-center">
-      <div
-        data-testid="tooltip"
-        className="flex w-max flex-col space-y-6 rounded-2xl bg-neutral-900 bg-opacity-80 p-6"
-      >
-        <div className="flex flex-col text-neutral-50">
-          <div className="mb-2 flex flex-row items-center space-x-4">
-            <MdOutlineTimer size={18} />
-            <h2 className="text-xl font-bold">자유 토론 타이머 조작</h2>
-          </div>
-
-          <div className="text-m flex flex-col space-y-1 md:text-lg">
-            <ListItem>재생 버튼을 눌러 타이머를 시작</ListItem>
-            <ListItem>
-              타이머가 동작 중일 때, 일시정지 버튼을 눌러 타이머를 일시정지
-            </ListItem>
-            <ListItem>
-              초기화 버튼을 눌러 타이머를 원래 시간으로 초기화
-            </ListItem>
-            <ListItem>마우스를 사용하여 타이머를 클릭 시, 진영 변경</ListItem>
-            <ListItem>
-              타이머 작동 중, 진영 변경 시, 상대 진영 자동 재생
-            </ListItem>
-          </div>
+    <div
+      data-testid="tooltip"
+      className="flex w-max flex-col space-y-6 bg-neutral-900 p-6"
+    >
+      <div className="flex flex-col text-neutral-50">
+        <div className="mb-2 flex flex-row items-center space-x-4">
+          <MdOutlineTimer size={18} />
+          <h2 className="text-xl font-bold">자유 토론 타이머 조작</h2>
         </div>
 
-        <div className="flex flex-col text-neutral-50">
-          <div className="mb-2 flex flex-row items-center space-x-4">
-            <MdOutlineTimer size={18} />
-            <h2 className="text-xl font-bold">일반 토론 타이머 조작</h2>
-          </div>
+        <div className="text-m flex flex-col space-y-1 md:text-lg">
+          <ListItem>재생 버튼을 눌러 타이머를 시작</ListItem>
+          <ListItem>
+            타이머가 동작 중일 때, 일시정지 버튼을 눌러 타이머를 일시정지
+          </ListItem>
+          <ListItem>초기화 버튼을 눌러 타이머를 원래 시간으로 초기화</ListItem>
+          <ListItem>마우스를 사용하여 타이머를 클릭 시, 진영 변경</ListItem>
+          <ListItem>타이머 작동 중, 진영 변경 시, 상대 진영 자동 재생</ListItem>
+        </div>
+      </div>
 
-          <div className="text-m flex flex-col space-y-1 md:text-lg">
-            <ListItem>재생 버튼을 눌러 타이머를 시작</ListItem>
-            <ListItem>
-              타이머가 동작 중일 때, 일시정지 버튼을 눌러 타이머를 일시정지
-            </ListItem>
-            <ListItem>
-              초기화 버튼을 눌러 타이머를 원래 시간으로 초기화
-            </ListItem>
-            <ListItem>
-              작전 시간 사용 버튼을 눌러 별도의 작전 시간 타이머 사용 가능
-            </ListItem>
-          </div>
+      <div className="flex flex-col text-neutral-50">
+        <div className="mb-2 flex flex-row items-center space-x-4">
+          <MdOutlineTimer size={18} />
+          <h2 className="text-xl font-bold">일반 토론 타이머 조작</h2>
         </div>
 
-        <div className="flex flex-col space-y-1 text-slate-50">
-          <div className="mb-2 flex flex-row items-center space-x-4">
-            <LuKeyboard size={18} />
-            <h1 className="text-xl font-bold">키보드 조작</h1>
-          </div>
+        <div className="text-m flex flex-col space-y-1 md:text-lg">
+          <ListItem>재생 버튼을 눌러 타이머를 시작</ListItem>
+          <ListItem>
+            타이머가 동작 중일 때, 일시정지 버튼을 눌러 타이머를 일시정지
+          </ListItem>
+          <ListItem>초기화 버튼을 눌러 타이머를 원래 시간으로 초기화</ListItem>
+          <ListItem>
+            작전 시간 사용 버튼을 눌러 별도의 작전 시간 타이머 사용 가능
+          </ListItem>
+        </div>
+      </div>
 
-          <div className="text-m flex flex-col space-y-1 md:text-lg">
-            <ListItem>스페이스 바로 타이머를 시작 및 일시정지</ListItem>
-            <ListItem>R 키로 타이머 초기화</ListItem>
-            <ListItem>좌우 방향키로 이전/다음 차례로 이동</ListItem>
-            <ListItem>A/L 키로 토론 진영 변경</ListItem>
-            <ListItem>Enter 키로 상대 진영으로 변경</ListItem>
-          </div>
+      <div className="flex flex-col space-y-1 text-slate-50">
+        <div className="mb-2 flex flex-row items-center space-x-4">
+          <LuKeyboard size={18} />
+          <h1 className="text-xl font-bold">키보드 조작</h1>
         </div>
 
-        <div className="flex flex-col space-y-1 text-slate-50">
-          <div className="mb-2 flex flex-row items-center space-x-4">
-            <IoHourglassOutline size={18} />
-            <h2 className="text-xl font-bold">
-              작전 시간을 사전에 설정하지 않는 경우
-            </h2>
-          </div>
+        <div className="text-m flex flex-col space-y-1 md:text-lg">
+          <ListItem>스페이스 바로 타이머를 시작 및 일시정지</ListItem>
+          <ListItem>R 키로 타이머 초기화</ListItem>
+          <ListItem>좌우 방향키로 이전/다음 차례로 이동</ListItem>
+          <ListItem>A/L 키로 토론 진영 변경</ListItem>
+          <ListItem>Enter 키로 상대 진영으로 변경</ListItem>
+        </div>
+      </div>
 
-          <div className="text-m flex flex-col space-y-1 md:text-lg">
-            <ListItem>
-              타이머의 초기화 버튼 왼쪽의 &#39;작전 시간 사용&#39; 버튼을 눌러,
-              별도의 작전 시간 타이머를 열 수 있음
-            </ListItem>
-            <ListItem>
-              찬성 또는 반대 측에서 작전 시간을 요청할 경우 사용
-            </ListItem>
-            <ListItem>
-              각 팀에서 요청한 작전 시간 만큼 타이머를 설정할 수 있음 (±30초,
-              ±10초 단위)
-            </ListItem>
-          </div>
+      <div className="flex flex-col space-y-1 text-slate-50">
+        <div className="mb-2 flex flex-row items-center space-x-4">
+          <IoHourglassOutline size={18} />
+          <h2 className="text-xl font-bold">
+            작전 시간을 사전에 설정하지 않는 경우
+          </h2>
         </div>
 
-        <div className="flex justify-end">
-          <button
-            data-testid="tooltip-button"
-            className="w-fit justify-end rounded-2xl bg-neutral-50 px-6 py-2 font-bold text-neutral-900 hover:bg-neutral-300"
-            onClick={() => onClose()}
-          >
-            닫기
-          </button>
+        <div className="text-m flex flex-col space-y-1 md:text-lg">
+          <ListItem>
+            타이머의 초기화 버튼 왼쪽의 &#39;작전 시간 사용&#39; 버튼을 눌러,
+            별도의 작전 시간 타이머를 열 수 있음
+          </ListItem>
+          <ListItem>
+            찬성 또는 반대 측에서 작전 시간을 요청할 경우 사용
+          </ListItem>
+          <ListItem>
+            각 팀에서 요청한 작전 시간 만큼 타이머를 설정할 수 있음 (±30초,
+            ±10초 단위)
+          </ListItem>
         </div>
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          data-testid="tooltip-button"
+          className="w-fit justify-end rounded-2xl bg-neutral-50 px-6 py-2 font-bold text-neutral-900 hover:bg-neutral-300"
+          onClick={() => onClose()}
+        >
+          닫기
+        </button>
       </div>
     </div>
   );

--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -69,15 +69,18 @@ export default function NormalTimer({
       <div
         className={`flex h-[139px] w-full items-center justify-between rounded-t-[45px] ${bgColorClass} relative text-[75px] font-bold text-neutral-50`}
       >
-        {/* Title text  */}
+        {/* Title text  
         <h1 className="absolute left-1/2 w-max -translate-x-1/2 transform">
           {titleText}
-        </h1>
+        </h1> */}
+        <p className="w-full items-center text-center text-[75px] font-bold">
+          {titleText}
+        </p>
 
         {/* Close button, if additional timer is enabled */}
         {isAdditionalTimerOn && (
           <button
-            className="ml-auto px-[30px]"
+            className="absolute right-10 top-1/2 -translate-y-1/2"
             onClick={() => onChangingTimer()}
           >
             <IoCloseOutline className="size-[40px] hover:text-neutral-300" />
@@ -107,7 +110,7 @@ export default function NormalTimer({
       </div>
 
       {/* Timer controller and additional timer controller */}
-      <div className="my-[30px]">
+      <div className="my-[30px] flex w-full items-center justify-center">
         {!isAdditionalTimerOn && (
           <TimerController
             isRunning={isRunning}

--- a/src/page/CustomizeTimerPage/hooks/useNormalTimer.ts
+++ b/src/page/CustomizeTimerPage/hooks/useNormalTimer.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-export function useNomalTimer() {
+export function useNormalTimer() {
   const [timer, setTimer] = useState<number | null>(null);
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
   const [defaultTimer, setDefaultTimer] = useState(0);

--- a/src/page/CustomizeTimerPage/stories/NormalTimer.stories.tsx
+++ b/src/page/CustomizeTimerPage/stories/NormalTimer.stories.tsx
@@ -1,0 +1,180 @@
+import { Meta, StoryObj } from '@storybook/react';
+import NormalTimer from '../components/NormalTimer';
+
+const meta: Meta<typeof NormalTimer> = {
+  title: 'page/CustomizeTimerPage/Components/NormalTimer',
+  component: NormalTimer,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NormalTimer>;
+
+export const OnPros: Story = {
+  args: {
+    onChangingTimer: () => {},
+    onPause: () => {},
+    onReset: () => {},
+    onStart: () => {},
+    goToOtherItem: (isPrev: boolean) => {
+      console.log(isPrev);
+    },
+    addOnTimer: () => {},
+    timer: 150,
+    isAdditionalTimerOn: false,
+    isTimerChangeable: false,
+    isRunning: false,
+    isLastItem: false,
+    isFirstItem: false,
+    item: {
+      stance: 'PROS',
+      speechType: '입론1',
+      boxType: 'NORMAL',
+      time: 30,
+      timePerTeam: null,
+      timePerSpeaking: null,
+      speaker: '발언자',
+    },
+  },
+};
+
+export const OnCons: Story = {
+  args: {
+    onChangingTimer: () => {},
+    onPause: () => {},
+    onReset: () => {},
+    onStart: () => {},
+    goToOtherItem: (isPrev: boolean) => {
+      console.log(isPrev);
+    },
+    addOnTimer: () => {},
+    timer: 150,
+    isAdditionalTimerOn: false,
+    isTimerChangeable: false,
+    isRunning: false,
+    isLastItem: false,
+    isFirstItem: false,
+    item: {
+      stance: 'CONS',
+      speechType: '입론1',
+      boxType: 'NORMAL',
+      time: 30,
+      timePerTeam: null,
+      timePerSpeaking: null,
+      speaker: '발언자',
+    },
+  },
+};
+
+export const OnNeutral: Story = {
+  args: {
+    onChangingTimer: () => {},
+    onPause: () => {},
+    onReset: () => {},
+    onStart: () => {},
+    goToOtherItem: (isPrev: boolean) => {
+      console.log(isPrev);
+    },
+    addOnTimer: () => {},
+    timer: 150,
+    isAdditionalTimerOn: false,
+    isTimerChangeable: false,
+    isRunning: false,
+    isLastItem: false,
+    isFirstItem: false,
+    item: {
+      stance: 'NEUTRAL',
+      speechType: '작전 시간',
+      boxType: 'NORMAL',
+      time: 30,
+      timePerTeam: null,
+      timePerSpeaking: null,
+      speaker: '홍길동',
+    },
+  },
+};
+
+export const OnRunning: Story = {
+  args: {
+    onChangingTimer: () => {},
+    onPause: () => {},
+    onReset: () => {},
+    onStart: () => {},
+    goToOtherItem: (isPrev: boolean) => {
+      console.log(isPrev);
+    },
+    addOnTimer: () => {},
+    timer: 150,
+    isAdditionalTimerOn: false,
+    isTimerChangeable: false,
+    isRunning: true,
+    isLastItem: false,
+    isFirstItem: false,
+    item: {
+      stance: 'PROS',
+      speechType: '입론 1',
+      boxType: 'NORMAL',
+      time: 30,
+      timePerTeam: null,
+      timePerSpeaking: null,
+      speaker: '홍길동',
+    },
+  },
+};
+
+export const WhenAdditionalTimerAvailable: Story = {
+  args: {
+    onChangingTimer: () => {},
+    onPause: () => {},
+    onReset: () => {},
+    onStart: () => {},
+    goToOtherItem: (isPrev: boolean) => {
+      console.log(isPrev);
+    },
+    addOnTimer: () => {},
+    timer: 150,
+    isAdditionalTimerOn: false,
+    isTimerChangeable: true,
+    isRunning: true,
+    isLastItem: false,
+    isFirstItem: false,
+    item: {
+      stance: 'PROS',
+      speechType: '입론 1',
+      boxType: 'NORMAL',
+      time: 30,
+      timePerTeam: null,
+      timePerSpeaking: null,
+      speaker: '홍길동',
+    },
+  },
+};
+
+export const OnAdditionalTimerEnabled: Story = {
+  args: {
+    onChangingTimer: () => {},
+    onPause: () => {},
+    onReset: () => {},
+    onStart: () => {},
+    goToOtherItem: (isPrev: boolean) => {
+      console.log(isPrev);
+    },
+    addOnTimer: () => {},
+    timer: 150,
+    isAdditionalTimerOn: true,
+    isTimerChangeable: false,
+    isRunning: false,
+    isLastItem: false,
+    isFirstItem: false,
+    item: {
+      stance: 'PROS',
+      speechType: '입론1',
+      boxType: 'TIME_BASED',
+      time: 30,
+      timePerTeam: null,
+      timePerSpeaking: null,
+      speaker: '발언자',
+    },
+  },
+};

--- a/src/page/CustomizeTimerPage/stories/TimeBasedTimer.stories.tsx
+++ b/src/page/CustomizeTimerPage/stories/TimeBasedTimer.stories.tsx
@@ -2,7 +2,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import TimeBasedTimer from '../components/TimeBasedTimer';
 
 const meta: Meta<typeof TimeBasedTimer> = {
-  title: 'page/CustomizeTimerPage/Components/Timer',
+  title: 'page/CustomizeTimerPage/Components/TimeBasedTimer',
   component: TimeBasedTimer,
   tags: ['autodocs'],
 };


### PR DESCRIPTION
# 🚩 연관 이슈

closed #228

# 📝 작업 내용
## 개요
- 자유토론 타이머 중 `NormalTimer` 사용 시 키보드 일시정지(Space) 및 초기화(R) 동작하지 않는 문제 수정
- 자유토론 타이머의 특정 스타일 태그(`absolute 등`)로 인해, `FirstUseToolTip`이 깨져서 출력되는 문제 수정
- 자유토론 타이머의 툴팁에서 작전 시간 타이머 관련 내용 제거

## 첨언
`useModal`의 `z-20` 태그는 `TimeBasedTimer`의 가운데 진영 변경 버튼(Enter)이 `z-10`을 먹고 있어, 인덱스가 10보다 크지 않으면 모달 위로 버튼이 튀어나와 추가하였습니다.

# 🏞️ 스크린샷 (선택)
## `NormalTimer`에서 툴팁 열 경우
![스크린샷_5-4-2025_112742_localhost](https://github.com/user-attachments/assets/f0ffae15-af78-4149-b2e3-12623d8de38e)

## `TimeBasedTimer`에서 툴팁 열 경우
![스크린샷_5-4-2025_112724_localhost](https://github.com/user-attachments/assets/d63e44fb-0700-447e-abd2-05921c161b37)

# 🗣️ 리뷰 요구사항 (선택)
없음
