### PR TITLE
[FIX] 사전에 작전시간을 설정한 경우, 타이머 페이지에서 작전 시간 선택 버튼이 보이지 않도록 수정

### DIFF
--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -330,11 +330,11 @@ export default function CustomizeTimerPage() {
     switchCamp,
   ]);
 
-  // 테이블에 TIME_OUT 발언이 있는 경우 작전시간 타이머 변경 비활성화
+  // 테이블에 작전시간 발언이 있는 경우 작전시간 타이머 변경 비활성화
   useEffect(() => {
     if (data) {
       data.table.forEach((value) => {
-        if (value.speechType === 'TIME_OUT') {
+        if (value.speechType === '작전시간') {
           setIsTimerChangeable(false);
         }
       });


### PR DESCRIPTION
# 🚩 연관 이슈

closed #230

# 📝 작업 내용
- speechType이 string으로 변경됨에 따른 조건문 수정

# 🏞️ 스크린샷 (선택)
### before
<img width="653" alt="image" src="https://github.com/user-attachments/assets/6fdec7c3-5694-483a-b995-8497bdf5e81b" />

(케이티 브랜치에서 촬영한 것이어서 발언 아이콘은 무시해도됩니다.)

### after
<img width="653" alt="image" src="https://github.com/user-attachments/assets/4be4060f-825e-44b5-84f2-6e0fa141351d" />

# 🗣️ 리뷰 요구사항 (선택)
없음
