### PR TITLE
[FIX] 커스텀 토론 페이지 자유토론 타이머 2차 QA 수정

### DIFF
--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -323,9 +323,9 @@ export default function CustomizeTimerPage() {
             normalTimer.resetTimer();
           } else {
             if (prosConsSelected === 'pros') {
-              timer1.resetTimer();
+              timer1.resetCurrentTimer();
             } else {
-              timer2.resetTimer();
+              timer2.resetCurrentTimer();
             }
           }
           break;
@@ -395,10 +395,10 @@ export default function CustomizeTimerPage() {
   useEffect(() => {
     if (prosConsSelected === 'cons') {
       if (timer1.speakingTimer === null) return;
-      timer1.resetTimer();
+      timer1.resetTimerForNextPhase();
     } else if (prosConsSelected === 'pros') {
       if (timer2.speakingTimer === null) return;
-      timer2.resetTimer();
+      timer2.resetTimerForNextPhase();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prosConsSelected]);
@@ -550,7 +550,7 @@ export default function CustomizeTimerPage() {
                 <TimeBasedTimer
                   onStart={() => timer1.startTimer()}
                   onPause={() => timer1.pauseTimer()}
-                  onReset={() => timer1.resetTimer()}
+                  onReset={() => timer1.resetCurrentTimer()}
                   addOnTimer={(delta: number) =>
                     timer1.setTimers(timer1.totalTimer ?? 0 + delta)
                   }
@@ -562,7 +562,7 @@ export default function CustomizeTimerPage() {
                   isFirstItem={index === 0}
                   goToOtherItem={(isPrev: boolean) => {
                     goToOtherItem(isPrev);
-                    timer1.resetTimer();
+                    timer1.resetTimerForNextPhase();
                   }}
                   isTimerChangeable={isTimerChangeable}
                   onChangingTimer={() => {
@@ -593,7 +593,7 @@ export default function CustomizeTimerPage() {
                 <TimeBasedTimer
                   onStart={() => timer2.startTimer()}
                   onPause={() => timer2.pauseTimer()}
-                  onReset={() => timer2.resetTimer()}
+                  onReset={() => timer2.resetCurrentTimer()}
                   addOnTimer={(delta: number) =>
                     timer2.setTimers(timer2.totalTimer ?? 0 + delta)
                   }
@@ -605,7 +605,7 @@ export default function CustomizeTimerPage() {
                   isFirstItem={index === 0}
                   goToOtherItem={(isPrev: boolean) => {
                     goToOtherItem(isPrev);
-                    timer2.resetTimer();
+                    timer2.resetTimerForNextPhase();
                   }}
                   isTimerChangeable={isTimerChangeable}
                   onChangingTimer={() => {


### PR DESCRIPTION
# 🚩 연관 이슈

closed #232

# 📝 작업 내용
### 초기화 버튼 로직과 팀 전환으로 인한 타이머 초기화 로직 분리
기존  resetTimer의 호출되는 경우는
- R과 reset버튼을 눌렀을 때,
- 팀 전환간에 타이머 정보를 초기화할때,

2가지 경우다.

다음과 같이 진행할 경우, 
https://www.notion.so/2-QA-1cc1550c60cf8095af16ea3d5671f3b1
해당 QA에서 같이 가장 최신의 타이머 정보로 reset하기 어려운 문제가 있다.
이를 해결하기 위해 R과 reset버튼을 눌렀을 때와 팀 전환간에 타이머 정보를 초기화할때, 로직을 분리하였다.

수정 반영 화면

https://github.com/user-attachments/assets/cf999fd2-917e-4e60-854e-c7cc0e33d5f7

https://github.com/user-attachments/assets/1597c904-2f76-475b-ae86-35980f9d5763

# 🗣️ 리뷰 요구사항 (선택)
증복없이 통합할 수 있는 방법이 있을까요?