### PR TITLE
[FIX] NomalTimer의 헤더 문구가 설정된 문자열에 출력되지 않는 문제 수정

### DIFF
--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -90,12 +90,14 @@ export default function NormalTimer({
       <div className="my-[20px] h-[40px]">
         <div className="flex w-full flex-row items-center space-x-2 text-neutral-900">
           {item.stance !== 'NEUTRAL' && (
-            <MdRecordVoiceOver className="size-[40px]" />
+            <>
+              <MdRecordVoiceOver className="size-[40px]" />
+              <h3 className="text-[28px] font-bold">
+                {teamName && teamName + '  팀 '}
+                {item.speaker && '| ' + item.speaker + ' 토론자'}
+              </h3>
+            </>
           )}
-          <h3 className="text-[28px] font-bold">
-            {teamName && teamName + '  팀 '}
-            {item.speaker && '| ' + item.speaker + ' 토론자'}
-          </h3>
         </div>
       </div>
 

--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -48,9 +48,7 @@ export default function NormalTimer({
         : 'bg-camp-red';
   const titleText = isAdditionalTimerOn
     ? ParliamentarySpeechTypeToString['TIME_OUT']
-    : item.stance === 'NEUTRAL'
-      ? ParliamentarySpeechTypeToString['TIME_OUT']
-      : item.speechType;
+    : item.speechType;
 
   const boxShadow = isRunning
     ? item.stance === 'NEUTRAL'


### PR DESCRIPTION
# 🚩 연관 이슈

closed #237


# 📝 작업 내용
- NomalTimer의 헤더 문구가 설정된 문자열에 출력되지 않는 문제 수정
- 일반 타이머에서 중립에서는 팀 이름, 토론자 정보 제거

### before
<img width="646" alt="image" src="https://github.com/user-attachments/assets/ea8668c8-90ee-48d6-af5b-bbff150a1f3b" />

### after
<img width="646" alt="image" src="https://github.com/user-attachments/assets/f0f4e600-cc6b-44d2-a1ff-0398f06479c3" />


# 🏞️ 스크린샷 (선택)

# 🗣️ 리뷰 요구사항 (선택)
