### PR TITLE
[FIX] 사용자 지정 토론 NormalTimer의 추가 작전 시간 발언자 정보 삭제

### DIFF
--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -75,6 +75,7 @@ export default function NormalTimer({
           {titleText}
         </p>
 
+        {/* */}
         {/* Close button, if additional timer is enabled */}
         {isAdditionalTimerOn && (
           <button

--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -89,7 +89,7 @@ export default function NormalTimer({
       {/* Speaker's number, if necessary */}
       <div className="my-[20px] h-[40px]">
         <div className="flex w-full flex-row items-center space-x-2 text-neutral-900">
-          {item.stance !== 'NEUTRAL' && (
+          {item.stance !== 'NEUTRAL' && !isAdditionalTimerOn && (
             <>
               <MdRecordVoiceOver className="size-[40px]" />
               <h3 className="text-[28px] font-bold">


### PR DESCRIPTION
# 🚩 연관 이슈

closed #239 

# 📝 작업 내용
- 사용자 지정 토론 NormalTimer의 추가 작전 시간 발언자 정보 삭제

# 🏞️ 스크린샷 (선택)

# 🗣️ 리뷰 요구사항 (선택)
