### PR TITLE
[CHORE] 의회식 토론 생성 차단

### DIFF
--- a/src/mocks/handlers/customize.ts
+++ b/src/mocks/handlers/customize.ts
@@ -98,6 +98,7 @@ export const customizeHandlers = [
     );
 
     return HttpResponse.json({
+      id: 1,
       info: {
         name: '나의 자유토론 테이블',
         type: 'CUSTOMIZE',

--- a/src/page/TableComposition/TableComposition.test.tsx
+++ b/src/page/TableComposition/TableComposition.test.tsx
@@ -27,7 +27,7 @@ function TestWrapper({
 
             {/* 실제로 이동하고 싶은 /overview 경로 - 테스트용 컴포넌트 */}
             <Route
-              path="/overview/parliamentary/1"
+              path="/overview/customize/1"
               element={<h1 data-testid="overview-page">Overview Page</h1>}
             />
           </Routes>
@@ -55,7 +55,6 @@ describe('TableComposition', () => {
         name: '토론 정보를 설정해주세요',
       }),
     );
-    expect(screen.getByText('토론 유형')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '다음' })).toBeInTheDocument();
   });
 

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -3,7 +3,6 @@ import HeaderTitle from '../../../../components/HeaderTitle/HeaderTitle';
 import LabeledCheckbox from '../../../../components/LabledCheckBox/LabeledCheckbox';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import { ParliamentaryInfo, CustomizeInfo } from '../../../../type/type';
-import DropdownForDebateType from '../DropdownForDebateType/DropdownForDebateType';
 
 type ExtendedDebateInfo = ParliamentaryInfo | CustomizeInfo;
 
@@ -79,6 +78,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
             onClear={() => clearField('agenda')}
             placeholder="토론 주제를 입력해주세요"
           />
+          {/**
           {!isEdit && (
             <>
               <label className="flex items-center text-base font-semibold md:text-2xl">
@@ -91,7 +91,9 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
                 }
               />
             </>
-          )}
+          )
+          }
+          */}
           {isCustomize(info) && (
             <>
               <label className="flex items-center text-base font-semibold md:text-2xl">

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -39,7 +39,9 @@ const useTableFrom = (
         info: {
           name: '',
           agenda: '',
-          type: 'PARLIAMENTARY',
+          type: 'CUSTOMIZE',
+          prosTeamName: '찬성',
+          consTeamName: '반대',
           warningBell: true,
           finishBell: true,
         },


### PR DESCRIPTION
# 🚩 연관 이슈

closed #243 

# 📝 작업 내용
## 변경 사항
- **토론 유형 설정 드롭다운 박스 삭제**
  `PARLIAMENTARY`/`CUSTOMIZED` 중 하나를 고를 수 있었던 드롭다운 박스를 아예 삭제했어요.
- **토론 생성 시 데이터 기본값을 `CUSTOMIZED`로 변경**
  원래 토론 생성 시 기본값은 `PARLIAMENTARY`었는데, 이를 `CUSTOMIZED`으로 변경했어요.

위 2가지 변경 사항이 합쳐져서, 이제부터 새 토론 생성 시 `CUSTOMIZED`가 기본값이고, 이를 `PARLIAMENTARY`로 바꿀 수 있는 드롭다운 메뉴가 삭제됐기 때문에, 사용자는 토론 유형을 변경할 수가 없어요.

## 결론적으로 사용자 입장에서는?
- 바뀌는 점은, 이제 사용자 지정 토론만 생성이 가능합니다
- 바뀌지 않은 점은, 이미 생성된 의회식 토론은 수정 및 사용이 가능합니다

# 🏞️ 스크린샷 (선택)
## 토론 생성 페이지
기존에 존재하던 의회식 토론, 사용자 지정 토론을 고를 수 있었던 드롭다운 박스가 존재하지 않습니다.
![image](https://github.com/user-attachments/assets/becc3b24-6a8c-4269-b450-142d53ac1491)

# 🗣️ 리뷰 요구사항 (선택)
없음
