### PR TITLE
[FIX] 사용자 지정 토론 타이머들의 콜론 위치 중앙에 고정

### DIFF
--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -103,11 +103,21 @@ export default function NormalTimer({
       </div>
 
       {/* Timer display */}
+      {/*
       <div
         className={`flex h-[220px] w-[600px] items-center justify-center bg-white text-[120px] font-bold text-neutral-900 shadow-inner`}
       >
         {timer < 0 && '-'}
         {minute} : {second}
+      </div>
+      */}
+      <div
+        className={`flex h-[230px] w-[600px] flex-row items-center justify-center space-x-5 bg-slate-50 text-center text-[150px] font-bold text-neutral-900`}
+      >
+        {timer < 0 && <p className="w-[70px]">-</p>}
+        <p className="w-[200px]">{minute}</p>
+        <p className="w-[50px]">:</p>
+        <p className="w-[200px]">{second}</p>
       </div>
 
       {/* Timer controller and additional timer controller */}

--- a/src/page/CustomizeTimerPage/components/TimeBasedTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/TimeBasedTimer.tsx
@@ -100,7 +100,14 @@ export default function TimeBasedTimer({
                 <div className="absolute left-3 top-2 text-sm font-semibold">
                   전체 시간
                 </div>
+                {/*
                 {minute} : {second}
+                */}
+                <div className="flex flex-row items-center justify-center space-x-5 text-center">
+                  <p className="w-[160px]">{minute}</p>
+                  <p className="w-[30px]">:</p>
+                  <p className="w-[160px]">{second}</p>
+                </div>
               </div>
 
               {/* 현재시간 타이머 (크게 표시) */}
@@ -110,7 +117,14 @@ export default function TimeBasedTimer({
                 <div className="absolute left-3 top-2 text-sm font-semibold">
                   현재 시간
                 </div>
+                {/*
                 {speakingMinute} : {speakingSecond}
+                */}
+                <div className="flex flex-row items-center justify-center space-x-5  text-center">
+                  <p className="w-[160px]">{speakingMinute}</p>
+                  <p className="w-[30px]">:</p>
+                  <p className="w-[160px]">{speakingSecond}</p>
+                </div>
               </div>
             </>
           ) : (


### PR DESCRIPTION
# 🚩 연관 이슈

closed #251 

# 📝 작업 내용
고려대 UT에서도 식별된 내용인데, 타이머의 시간(20:27처럼 생긴 이거) 문자열 길이에 따라 콜론 위치가 움직이는 문제가 있었어요. 이를 해결하고자 하는 PR입니다.

- 사용자 지정 토론의 `NormalTimer` 콜론 위치 중앙으로 조정
- 사용자 지정 토론의 `TimeBasedTimer` 콜론 위치 중앙으로 조정

# 🏞️ 스크린샷 (선택)
## `NormalTimer` 스크린샷
![image](https://github.com/user-attachments/assets/189a66ac-866c-4003-9d3f-9a167c51232c)

## `TimeBasedTimer` 스크린샷
![image](https://github.com/user-attachments/assets/69a5e195-9f78-4c5b-9314-a0ebc702d9e9)

# 🗣️ 리뷰 요구사항 (선택)
없음