### PR TITLE
[FIX] 타종 관련 버그 수정 (30초 종이 30초 타이머에서 울리는 현상, 무한 타종)

### DIFF
--- a/src/mocks/handlers/customize.ts
+++ b/src/mocks/handlers/customize.ts
@@ -29,7 +29,7 @@ export const customizeHandlers = [
           boxType: 'TIME_BASED',
           time: null,
           timePerTeam: 60,
-          timePerSpeaking: 20,
+          timePerSpeaking: 30,
           speaker: null,
         },
         {

--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -188,31 +188,62 @@ export default function CustomizeTimerPage() {
 
   // 벨 소리 재생
   useEffect(() => {
-    if (
-      warningBellRef.current &&
-      (timer1.isRunning || timer2.isRunning || normalTimer.isRunning) &&
-      isWarningBellOn &&
-      (timer1.speakingTimer === 30 ||
-        timer1.totalTimer === 30 ||
-        timer2.speakingTimer === 30 ||
-        timer2.totalTimer === 30 ||
-        normalTimer.timer === 30)
-    ) {
+    const shouldPlayWarningBell = () => {
+      const isAnyTimerRunning =
+        timer1.isRunning || timer2.isRunning || normalTimer.isRunning;
+      if (!warningBellRef.current || !isAnyTimerRunning || !isWarningBellOn)
+        return false;
+
+      const isTimer1WarningTime =
+        (timer1.speakingTimer === 30 &&
+          timer1.defaultTime.defaultSpeakingTimer !== 30) ||
+        (timer1.defaultTime.defaultSpeakingTimer === null &&
+          timer1.totalTimer === 30 &&
+          timer1.defaultTime.defaultTotalTimer !== 30);
+
+      const isTimer2WarningTime =
+        (timer2.speakingTimer === 30 &&
+          timer2.defaultTime.defaultSpeakingTimer !== 30) ||
+        (timer2.defaultTime.defaultSpeakingTimer === null &&
+          timer2.totalTimer === 30 &&
+          timer2.defaultTime.defaultTotalTimer !== 30);
+
+      const isNormalTimerWarningTime =
+        normalTimer.timer === 30 && normalTimer.defaultTimer !== 30;
+
+      return (
+        isTimer1WarningTime || isTimer2WarningTime || isNormalTimerWarningTime
+      );
+    };
+
+    // 사용
+    if (warningBellRef.current && shouldPlayWarningBell()) {
       warningBellRef.current.play();
     }
 
-    if (
-      finishBellRef.current &&
-      (timer1.isRunning || timer2.isRunning || normalTimer.isRunning) &&
-      isFinishBellOn &&
-      (timer1.speakingTimer === 0 ||
-        timer1.totalTimer === 0 ||
-        timer2.speakingTimer === 0 ||
-        timer2.totalTimer === 0 ||
-        normalTimer.timer === 0)
-    ) {
+    const shouldPlayFinishBell = () => {
+      const isTimer1Finished =
+        timer1.speakingTimer === 0 || timer1.totalTimer === 0;
+
+      const isTimer2Finished =
+        timer2.speakingTimer === 0 || timer2.totalTimer === 0;
+
+      const isNormalTimerFinished = normalTimer.timer === 0;
+
+      const isAnyTimerRunning =
+        timer1.isRunning || timer2.isRunning || normalTimer.isRunning;
+      return (
+        isAnyTimerRunning &&
+        isFinishBellOn &&
+        (isTimer1Finished || isTimer2Finished || isNormalTimerFinished)
+      );
+    };
+
+    // 사용
+    if (finishBellRef.current && shouldPlayFinishBell()) {
       finishBellRef.current.play();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isFinishBellOn,
     isWarningBellOn,
@@ -221,9 +252,14 @@ export default function CustomizeTimerPage() {
     normalTimer.isRunning,
     timer1.speakingTimer,
     timer1.totalTimer,
+    timer1.defaultTime.defaultTotalTimer,
+    timer1.defaultTime.defaultSpeakingTimer,
     timer2.speakingTimer,
     timer2.totalTimer,
+    timer1.defaultTime.defaultTotalTimer,
+    timer2.defaultTime.defaultSpeakingTimer,
     normalTimer.timer,
+    normalTimer.defaultTimer,
   ]);
 
   // 새로운 index(차례)로 이동했을 때 → 타이머 초기화 및 세팅

--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -195,21 +195,25 @@ export default function CustomizeTimerPage() {
         return false;
 
       const isTimer1WarningTime =
-        (timer1.speakingTimer === 30 &&
+        (timer1.isRunning &&
+          timer1.speakingTimer === 30 &&
           timer1.defaultTime.defaultSpeakingTimer !== 30) ||
         (timer1.defaultTime.defaultSpeakingTimer === null &&
           timer1.totalTimer === 30 &&
           timer1.defaultTime.defaultTotalTimer !== 30);
 
       const isTimer2WarningTime =
-        (timer2.speakingTimer === 30 &&
+        (timer2.isRunning &&
+          timer2.speakingTimer === 30 &&
           timer2.defaultTime.defaultSpeakingTimer !== 30) ||
         (timer2.defaultTime.defaultSpeakingTimer === null &&
           timer2.totalTimer === 30 &&
           timer2.defaultTime.defaultTotalTimer !== 30);
 
       const isNormalTimerWarningTime =
-        normalTimer.timer === 30 && normalTimer.defaultTimer !== 30;
+        normalTimer.isRunning &&
+        normalTimer.timer === 30 &&
+        normalTimer.defaultTimer !== 30;
 
       return (
         isTimer1WarningTime || isTimer2WarningTime || isNormalTimerWarningTime
@@ -223,12 +227,15 @@ export default function CustomizeTimerPage() {
 
     const shouldPlayFinishBell = () => {
       const isTimer1Finished =
-        timer1.speakingTimer === 0 || timer1.totalTimer === 0;
+        timer1.isRunning &&
+        (timer1.speakingTimer === 0 || timer1.totalTimer === 0);
 
       const isTimer2Finished =
-        timer2.speakingTimer === 0 || timer2.totalTimer === 0;
+        timer2.isRunning &&
+        (timer2.speakingTimer === 0 || timer2.totalTimer === 0);
 
-      const isNormalTimerFinished = normalTimer.timer === 0;
+      const isNormalTimerFinished =
+        normalTimer.isRunning && normalTimer.timer === 0;
 
       const isAnyTimerRunning =
         timer1.isRunning || timer2.isRunning || normalTimer.isRunning;

--- a/src/page/CustomizeTimerPage/hooks/useCustomTimer.ts
+++ b/src/page/CustomizeTimerPage/hooks/useCustomTimer.ts
@@ -145,6 +145,7 @@ export function useCustomTimer({
     speakingTimer,
     isRunning,
     isDone,
+    defaultTime,
     startTimer,
     pauseTimer,
     resetTimerForNextPhase,

--- a/src/page/CustomizeTimerPage/hooks/useNormalTimer.ts
+++ b/src/page/CustomizeTimerPage/hooks/useNormalTimer.ts
@@ -57,6 +57,7 @@ export function useNormalTimer() {
   return {
     timer,
     isRunning,
+    defaultTimer,
     setTimer,
     startTimer,
     pauseTimer,


### PR DESCRIPTION
# 🚩 연관 이슈

closed #254

# 📝 작업 내용
## 티종관련 버그 수정
---
### 30초 종이 30초 타이머 울리지 않게 하기
- useCustomTimer훅의 defaultTime.defaultSpeakingTimer(타이머 새로고침을 위한 작전 시간 저장 값)을 이용해서 타이머를 시작한는 시간이 30초일 경우에만  타종하지 않도록 구현
```ts
     const isTimer1WarningTime =
        (timer1.speakingTimer === 30 &&
          timer1.defaultTime.defaultSpeakingTimer !== 30) ||
        (timer1.defaultTime.defaultSpeakingTimer === null &&
          timer1.totalTimer === 30 &&
          timer1.defaultTime.defaultTotalTimer !== 30);
```
- 1회당 발언시간이 있는 자유토론 타이머에서 남음 전체시간에 따라 타종이 하지 않도록 수정
  ex) 전체시간 : 30초, 현재 시간 : 15초

- 조건문 추가로 인한 코드 가독성을 개선하기 위해 조건문을 상수로 분리
  - isTimer1WarningTime : 좌측 타이머에서의 타종 조건문
  - isTimer2WarningTime : 우측 타이머에서의 타종 조건문
  - isNormalTimerWarningTime : 일반 타이머에서의 타종 조건문


### 1회당 발언 시간이 없는 자유토론 타임박스에서 무한 타종
1회당 발언시간이 없는 자유토론에서, 0초 또는 30초인 상황에서 다른 팀으로 전환하여 타이머를 시작하면 무한 타종 현상이 발생하는 문제가 발생.
해당 현상은 타종 분기에서 타이머가 동작중이 아님에도 0초나 30초로 설정되어 있다면 타종 조건을 만족하여 발생하는 문제

이를 해결하기 위해, 타종 조건문에서 timer가 동작 중일때만 타종이 되도록 조건을 추가
```ts
      const isTimer1WarningTime =
        (timer1.isRunning && // 타이머가 동작 중에만 타종이 가능하도록 조건을 추가
          timer1.speakingTimer === 30 &&
          timer1.defaultTime.defaultSpeakingTimer !== 30) ||
        (timer1.defaultTime.defaultSpeakingTimer === null &&
          timer1.totalTimer === 30 &&
          timer1.defaultTime.defaultTotalTimer !== 30);
```

# 🗣️ 리뷰 요구사항 (선택)
이전에 비해서 조건문에 대한 가독성이 유의미하게 발전하였는지 궁금합니다. 혹은 가독성을 개선할 수 있는 추가적인 방법이 있으시다면 공유해주세요!
