### PR TITLE
[FIX] 31초 -> 30초가 되는 순간에만 타종하도록 로직을 변경

### DIFF
--- a/src/mocks/handlers/customize.ts
+++ b/src/mocks/handlers/customize.ts
@@ -29,7 +29,7 @@ export const customizeHandlers = [
           boxType: 'TIME_BASED',
           time: null,
           timePerTeam: 60,
-          timePerSpeaking: 30,
+          timePerSpeaking: 33,
           speaker: null,
         },
         {
@@ -37,7 +37,7 @@ export const customizeHandlers = [
           speechType: '자유토론',
           boxType: 'TIME_BASED',
           time: null,
-          timePerTeam: 60,
+          timePerTeam: 35,
           timePerSpeaking: null,
           speaker: null,
         },

--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -212,29 +212,29 @@ export default function CustomizeTimerPage() {
         timer1.isRunning || timer2.isRunning || normalTimer.isRunning;
       if (!warningBellRef.current || !isAnyTimerRunning || !isWarningBellOn)
         return false;
-
-      const timerJustReached30 = (
+      const waringTime = 30;
+      const timerJustReached = (
         prevTime: number | null,
         currentTime: number | null,
         defaultTime: number | null,
       ) => {
         return (
           prevTime !== null &&
-          prevTime > 30 &&
-          currentTime === 30 &&
-          defaultTime !== 30
+          prevTime > waringTime &&
+          currentTime === waringTime &&
+          defaultTime !== waringTime
         );
       };
 
       const isTimer1WarningTime =
         timer1.isRunning &&
-        (timerJustReached30(
+        (timerJustReached(
           prevTimer1Ref.current.speakingTimer,
           timer1.speakingTimer,
           timer1.defaultTime.defaultSpeakingTimer,
         ) ||
           (timer1.speakingTimer === null &&
-            timerJustReached30(
+            timerJustReached(
               prevTimer1Ref.current.totalTimer,
               timer1.totalTimer,
               timer1.defaultTime.defaultTotalTimer,
@@ -242,13 +242,13 @@ export default function CustomizeTimerPage() {
 
       const isTimer2WarningTime =
         timer2.isRunning &&
-        (timerJustReached30(
+        (timerJustReached(
           prevTimer2Ref.current.speakingTimer,
           timer2.speakingTimer,
           timer2.defaultTime.defaultSpeakingTimer,
         ) ||
           (timer2.speakingTimer === null &&
-            timerJustReached30(
+            timerJustReached(
               prevTimer2Ref.current.totalTimer,
               timer2.totalTimer,
               timer2.defaultTime.defaultTotalTimer,
@@ -257,9 +257,9 @@ export default function CustomizeTimerPage() {
       const isNormalTimerWarningTime =
         normalTimer.isRunning &&
         prevNormalTimerRef.current !== null &&
-        prevNormalTimerRef.current > 30 &&
-        normalTimer.timer === 30 &&
-        normalTimer.defaultTimer !== 30;
+        prevNormalTimerRef.current > waringTime &&
+        normalTimer.timer === waringTime &&
+        normalTimer.defaultTimer !== waringTime;
 
       return (
         isTimer1WarningTime || isTimer2WarningTime || isNormalTimerWarningTime

--- a/src/page/CustomizeTimerPage/hooks/useCustomTimer.ts
+++ b/src/page/CustomizeTimerPage/hooks/useCustomTimer.ts
@@ -146,6 +146,7 @@ export function useCustomTimer({
     isRunning,
     isDone,
     defaultTime,
+    isSpeakingTimer,
     startTimer,
     pauseTimer,
     resetTimerForNextPhase,


### PR DESCRIPTION
# 🚩 연관 이슈

closed #254

# 📝 작업 내용
이전 타종 버그 수정에서는 처음부터 30초로 설정된 타이머는 타종하지 않았지만 30초에서 타이머를 멈추고 다시 재생 시, 타종을 하던 문제가 발생했어요.
해당 문제를 수정하기 위해 정확히 31초에서 30초로 가는 상황에서만 타종을 하는 로직이 필요하다고 판단하였습니다. 이전 초의 상태를 기억하는 useRef를 추가했어요
```ts
  // 타이머의 이전상태를 저장(타종 31->30초인 상황에서만 타종하기위한 로직)
  const prevTimer1Ref = useRef<{
    speakingTimer: number | null;
    totalTimer: number | null;
  }>({
    speakingTimer: null,
    totalTimer: null,
  });

  const prevTimer2Ref = useRef<{
    speakingTimer: number | null;
    totalTimer: number | null;
  }>({
    speakingTimer: null,
    totalTimer: null,
  });

  const prevNormalTimerRef = useRef<number | null>(null);
```

해당 상태를 타종을 담당하는 useEffect하단에 다음과 같이 변경하여 매번 이전 상태를 기억하도록 합니다.
```ts
useEffect(() => {
  // 위의 벨 소리 로직...

  // 이전 타이머 값 저장 (맨 아래에 추가)
  prevTimer1Ref.current = {
    speakingTimer: timer1.speakingTimer,
    totalTimer: timer1.totalTimer,
  };
  prevTimer2Ref.current = {
    speakingTimer: timer2.speakingTimer,
    totalTimer: timer2.totalTimer,
  };
  prevNormalTimerRef.current = normalTimer.timer;
}, 
```

해당 함수로 31초에서 30초로 변경되는 경우에만 true를 반환하는 함수를 추가로 구현했습니다.
```ts
      const timerJustReached30 = (
        prevTime: number | null,
        currentTime: number | null,
        defaultTime: number | null,
      ) => {
        return (
          prevTime !== null &&
          prevTime > 30 &&
          currentTime === 30 &&
          defaultTime !== 30
        );
      };
```

# 🏞️ 스크린샷 (선택)
영상까지 보여드리면 좋을 것 같으나 소리까지 녹음하기 어려울 것 같아서 구현사항은 storybook을 확인해주세요

# 🗣️ 리뷰 요구사항 (선택)
가능하시다면 storybook을 통해 이 이상의 버그가 발생하는지 확인해주시면 감사하겠습니다.
한번에 버그 픽스가 이루어지지 못한점 죄송합니다