### PR TITLE
[DESIGN] 타이머 반응형 구현

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -43,6 +43,14 @@ const preview: Preview = {
           },
           type: 'desktop',
         },
+        laptopMac13: {
+          name: 'MacBook 13-inch',
+          styles: {
+            width: '1280px',
+            height: '800px',
+          },
+          type: 'desktop',
+        },
       },
       defaultViewport: 'responsive',
     },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,7 +7,6 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import React from 'react';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { allHandlers } from '../src/mocks/handlers/global';
-import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 initialize();
 

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -7,6 +7,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import React from 'react';
 import { initialize, mswLoader } from 'msw-storybook-addon';
 import { allHandlers } from '../src/mocks/handlers/global';
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport';
 
 initialize();
 
@@ -22,6 +23,28 @@ const preview: Preview = {
         color: /(background|color)$/i,
         date: /Date$/i,
       },
+    },
+    viewport: {
+      viewports: {
+        ...INITIAL_VIEWPORTS,
+        laptop1024: {
+          name: 'Laptop 1024',
+          styles: {
+            width: '1024px',
+            height: '768px',
+          },
+          type: 'desktop',
+        },
+        desktop1440: {
+          name: 'Desktop 1440',
+          styles: {
+            width: '1440px',
+            height: '900px',
+          },
+          type: 'desktop',
+        },
+      },
+      defaultViewport: 'responsive',
     },
   },
   loaders: [mswLoader],

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -26,7 +26,6 @@ const preview: Preview = {
     },
     viewport: {
       viewports: {
-        ...INITIAL_VIEWPORTS,
         laptop1024: {
           name: 'Laptop 1024',
           styles: {
@@ -48,6 +47,14 @@ const preview: Preview = {
           styles: {
             width: '1280px',
             height: '800px',
+          },
+          type: 'desktop',
+        },
+        laptopMac16: {
+          name: 'MacBook Pro 16-inch',
+          styles: {
+            width: '1536px',
+            height: '960px',
           },
           type: 'desktop',
         },

--- a/src/components/RoundControlButton/RoundControlButton.tsx
+++ b/src/components/RoundControlButton/RoundControlButton.tsx
@@ -13,27 +13,29 @@ export default function RoundControlButton({
 }: RoundControlButtonProps) {
   return (
     <button
-      className="flex h-[60px] w-[170px] flex-row items-center justify-center space-x-2 rounded-full border-[1px] border-neutral-300 bg-neutral-200 shadow-lg hover:bg-brand-main xl:h-[68px] xl:w-[200px]"
+      className="flex h-[50px] w-[150px] flex-row items-center justify-center space-x-2 rounded-full border-[1px] border-neutral-300 bg-neutral-200 shadow-lg hover:bg-brand-main lg:h-[60px] lg:w-[170px] xl:h-[68px] xl:w-[200px]"
       onClick={() => onClick()}
     >
       {type === 'PREV' && (
         <>
-          <FaArrowLeft className="size-[31px] xl:size-[36px]" />
-          <h1 className="text-[24px] font-semibold xl:text-[28px]">
+          <FaArrowLeft className="size-[25px] lg:size-[31px] xl:size-[36px]" />
+          <h1 className="text-[22px] font-semibold lg:text-[24px] xl:text-[28px]">
             이전 차례
           </h1>
         </>
       )}
       {type === 'NEXT' && (
         <>
-          <h1 className="text-[24px] font-semibold xl:text-[28px]">
+          <h1 className="text-[22px] font-semibold lg:text-[24px] xl:text-[28px]">
             다음 차례
           </h1>
-          <FaArrowRight className="size-[31px] xl:size-[36px]" />
+          <FaArrowRight className="size-[25px] lg:size-[31px] xl:size-[36px]" />
         </>
       )}
       {type === 'DONE' && (
-        <h1 className="text-[24px] font-semibold xl:text-[28px]">토론 종료</h1>
+        <h1 className="text-[22px] font-semibold lg:text-[24px] xl:text-[28px]">
+          토론 종료
+        </h1>
       )}
     </button>
   );

--- a/src/components/RoundControlButton/RoundControlButton.tsx
+++ b/src/components/RoundControlButton/RoundControlButton.tsx
@@ -13,23 +13,27 @@ export default function RoundControlButton({
 }: RoundControlButtonProps) {
   return (
     <button
-      className="flex h-[68px] w-[200px] flex-row items-center justify-center space-x-2 rounded-full border-[1px] border-neutral-300 bg-neutral-200 shadow-lg hover:bg-brand-main"
+      className="flex h-[60px] w-[170px] flex-row items-center justify-center space-x-2 rounded-full border-[1px] border-neutral-300 bg-neutral-200 shadow-lg hover:bg-brand-main xl:h-[68px] xl:w-[200px]"
       onClick={() => onClick()}
     >
       {type === 'PREV' && (
         <>
-          <FaArrowLeft className="size-[36px]" />
-          <h1 className="text-[28px] font-semibold">이전 차례</h1>
+          <FaArrowLeft className="size-[31px] xl:size-[36px]" />
+          <h1 className="text-[24px] font-semibold xl:text-[28px]">
+            이전 차례
+          </h1>
         </>
       )}
       {type === 'NEXT' && (
         <>
-          <h1 className="text-[28px] font-semibold">다음 차례</h1>
-          <FaArrowRight className="size-[36px]" />
+          <h1 className="text-[24px] font-semibold xl:text-[28px]">
+            다음 차례
+          </h1>
+          <FaArrowRight className="size-[31px] xl:size-[36px]" />
         </>
       )}
       {type === 'DONE' && (
-        <h1 className="text-[28px] font-semibold">토론 종료</h1>
+        <h1 className="text-[24px] font-semibold xl:text-[28px]">토론 종료</h1>
       )}
     </button>
   );

--- a/src/components/RoundControlButton/RoundControlButton.tsx
+++ b/src/components/RoundControlButton/RoundControlButton.tsx
@@ -19,21 +19,21 @@ export default function RoundControlButton({
       {type === 'PREV' && (
         <>
           <FaArrowLeft className="size-[25px] lg:size-[31px] xl:size-[36px]" />
-          <h1 className="text-[22px] font-semibold lg:text-[24px] xl:text-[28px]">
+          <h1 className="text-[21px] font-semibold lg:text-[24px] xl:text-[28px]">
             이전 차례
           </h1>
         </>
       )}
       {type === 'NEXT' && (
         <>
-          <h1 className="text-[22px] font-semibold lg:text-[24px] xl:text-[28px]">
+          <h1 className="text-[21px] font-semibold lg:text-[24px] xl:text-[28px]">
             다음 차례
           </h1>
           <FaArrowRight className="size-[25px] lg:size-[31px] xl:size-[36px]" />
         </>
       )}
       {type === 'DONE' && (
-        <h1 className="text-[22px] font-semibold lg:text-[24px] xl:text-[28px]">
+        <h1 className="text-[21px] font-semibold lg:text-[24px] xl:text-[28px]">
           토론 종료
         </h1>
       )}

--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -637,17 +637,19 @@ export default function CustomizeTimerPage() {
                   onClick={() => {
                     switchCamp();
                   }}
-                  className="absolute left-1/2 top-1/2 flex h-[100px] w-[100px] -translate-x-20 -translate-y-8 flex-col items-center justify-center rounded-full bg-neutral-600 text-white shadow-lg transition hover:bg-neutral-500"
+                  className="absolute left-1/2 top-1/2 flex h-[78px] w-[78px] -translate-x-[70px] -translate-y-6 flex-col items-center justify-center rounded-full bg-neutral-600 text-white shadow-lg transition hover:bg-neutral-500 lg:h-[100px] lg:w-[100px] lg:-translate-x-20 lg:-translate-y-8"
                 >
-                  <FaExchangeAlt className="text-[36px]" />
-                  <span className="text-[18px] font-bold">ENTER</span>
+                  <FaExchangeAlt className="text-[28px] lg:text-[36px]" />
+                  <span className="text-[12px] font-semibold lg:text-[18px] lg:font-bold">
+                    ENTER
+                  </span>
                 </button>
               </div>
             )}
             {/* Round control buttons on the bottom side */}
             {data && (
               <div className="flex flex-row space-x-1 xl:space-x-8">
-                <div className="flex h-[70px] w-[200px] items-center justify-center">
+                <div className="flex h-[70px] w-[175px] items-center justify-center lg:w-[200px]">
                   {index === 0 && <></>}
                   {index !== 0 && (
                     <RoundControlButton
@@ -660,7 +662,7 @@ export default function CustomizeTimerPage() {
                   )}
                 </div>
 
-                <div className="flex h-[70px] w-[200px] items-center justify-center">
+                <div className="flex h-[70px] w-[175px] items-center justify-center lg:w-[200px]">
                   {index === data.table.length - 1 && (
                     <RoundControlButton
                       type="DONE"

--- a/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
+++ b/src/page/CustomizeTimerPage/CustomizeTimerPage.tsx
@@ -499,7 +499,7 @@ export default function CustomizeTimerPage() {
         {/* Containers */}
         <DefaultLayout.ContentContainer noPadding={true}>
           <div
-            className={`flex h-full w-full flex-col items-center justify-center space-y-[40px] ${bgColorMap[bg]}`}
+            className={`flex h-full w-full flex-col items-center justify-center space-y-[25px] xl:space-y-[40px] ${bgColorMap[bg]}`}
           >
             {/* 타이머 두 개 + ENTER 버튼 */}
             {data.table[index].boxType === 'NORMAL' && (
@@ -646,7 +646,7 @@ export default function CustomizeTimerPage() {
             )}
             {/* Round control buttons on the bottom side */}
             {data && (
-              <div className="flex flex-row space-x-8">
+              <div className="flex flex-row space-x-1 xl:space-x-8">
                 <div className="flex h-[70px] w-[200px] items-center justify-center">
                   {index === 0 && <></>}
                   {index !== 0 && (

--- a/src/page/CustomizeTimerPage/NormalTimerTestPage.stories.tsx
+++ b/src/page/CustomizeTimerPage/NormalTimerTestPage.stories.tsx
@@ -1,0 +1,19 @@
+// NormalTimerTestPage.stories.tsx
+import { Meta, StoryObj } from '@storybook/react';
+import NormalTimerTestPage from './NormalTimerTestPage';
+
+const meta: Meta<typeof NormalTimerTestPage> = {
+  title: 'page/CustomizeTimerPage/NormalTimerTestPage',
+  component: NormalTimerTestPage,
+  parameters: {
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NormalTimerTestPage>;
+
+export const Default: Story = {
+  render: () => <NormalTimerTestPage />,
+};

--- a/src/page/CustomizeTimerPage/NormalTimerTestPage.tsx
+++ b/src/page/CustomizeTimerPage/NormalTimerTestPage.tsx
@@ -31,7 +31,7 @@ export default function NormalTimerTestPage() {
 
       {/* Content */}
       <DefaultLayout.ContentContainer noPadding>
-        <div className="flex flex-1 flex-col items-center justify-center gap-8 bg-neutral-100">
+        <div className="flex flex-1 flex-col items-center justify-center space-y-[25px] bg-neutral-100 xl:space-y-[40px]">
           <NormalTimer
             timer={item.time ?? 0}
             isRunning={false}
@@ -50,7 +50,7 @@ export default function NormalTimerTestPage() {
           />
 
           {/* NEXT 버튼만 하단에 표시 */}
-          <div className="flex flex-row space-x-4 xl:space-x-8">
+          <div className="flex flex-row space-x-1 xl:space-x-8">
             <div className="flex h-[70px] w-[200px] items-center justify-center">
               <RoundControlButton type="PREV" onClick={() => alert('이전')} />
             </div>

--- a/src/page/CustomizeTimerPage/NormalTimerTestPage.tsx
+++ b/src/page/CustomizeTimerPage/NormalTimerTestPage.tsx
@@ -8,9 +8,9 @@ import RoundControlButton from '../../components/RoundControlButton/RoundControl
 export default function NormalTimerTestPage() {
   const item: CustomizeTimeBoxInfo = {
     boxType: 'NORMAL',
-    speechType: '입론1',
+    speechType: '입론',
     stance: 'PROS',
-    speaker: '홍길동',
+    speaker: '케이티',
     time: 120,
     timePerTeam: null,
     timePerSpeaking: null,
@@ -21,17 +21,17 @@ export default function NormalTimerTestPage() {
       {/* Header */}
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
-          <HeaderTableInfo name="테스트 테이블" type="CUSTOMIZE" />
+          <HeaderTableInfo name="테스트 시간표" type="CUSTOMIZE" />
         </DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center>
-          <HeaderTitle title="정적 타이머 테스트" />
+          <HeaderTitle title="일반타이머 테스트입니다" />
         </DefaultLayout.Header.Center>
         <DefaultLayout.Header.Right defaultIcons={['home', 'logout']} />
       </DefaultLayout.Header>
 
       {/* Content */}
       <DefaultLayout.ContentContainer noPadding>
-        <div className="flex h-full w-full flex-col items-center justify-center space-y-[40px] bg-neutral-100">
+        <div className="flex flex-1 flex-col items-center justify-center gap-8 bg-neutral-100">
           <NormalTimer
             timer={item.time ?? 0}
             isRunning={false}
@@ -50,7 +50,7 @@ export default function NormalTimerTestPage() {
           />
 
           {/* NEXT 버튼만 하단에 표시 */}
-          <div className="flex flex-row space-x-8">
+          <div className="flex flex-row space-x-4 xl:space-x-8">
             <div className="flex h-[70px] w-[200px] items-center justify-center">
               <RoundControlButton type="PREV" onClick={() => alert('이전')} />
             </div>

--- a/src/page/CustomizeTimerPage/NormalTimerTestPage.tsx
+++ b/src/page/CustomizeTimerPage/NormalTimerTestPage.tsx
@@ -51,10 +51,10 @@ export default function NormalTimerTestPage() {
 
           {/* NEXT 버튼만 하단에 표시 */}
           <div className="flex flex-row space-x-1 xl:space-x-8">
-            <div className="flex h-[70px] w-[200px] items-center justify-center">
+            <div className="flex h-[70px] w-[175px] items-center justify-center lg:w-[200px]">
               <RoundControlButton type="PREV" onClick={() => alert('이전')} />
             </div>
-            <div className="flex h-[70px] w-[200px] items-center justify-center">
+            <div className="flex h-[70px] w-[175px] items-center justify-center lg:w-[200px]">
               <RoundControlButton type="NEXT" onClick={() => alert('다음')} />
             </div>
           </div>

--- a/src/page/CustomizeTimerPage/NormalTimerTestPage.tsx
+++ b/src/page/CustomizeTimerPage/NormalTimerTestPage.tsx
@@ -1,0 +1,65 @@
+import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
+import NormalTimer from './components/NormalTimer';
+import { CustomizeTimeBoxInfo } from '../../type/type';
+import HeaderTableInfo from '../../components/HeaderTableInfo/HeaderTableInfo';
+import HeaderTitle from '../../components/HeaderTitle/HeaderTitle';
+import RoundControlButton from '../../components/RoundControlButton/RoundControlButton';
+
+export default function NormalTimerTestPage() {
+  const item: CustomizeTimeBoxInfo = {
+    boxType: 'NORMAL',
+    speechType: '입론1',
+    stance: 'PROS',
+    speaker: '홍길동',
+    time: 120,
+    timePerTeam: null,
+    timePerSpeaking: null,
+  };
+
+  return (
+    <DefaultLayout>
+      {/* Header */}
+      <DefaultLayout.Header>
+        <DefaultLayout.Header.Left>
+          <HeaderTableInfo name="테스트 테이블" type="CUSTOMIZE" />
+        </DefaultLayout.Header.Left>
+        <DefaultLayout.Header.Center>
+          <HeaderTitle title="정적 타이머 테스트" />
+        </DefaultLayout.Header.Center>
+        <DefaultLayout.Header.Right defaultIcons={['home', 'logout']} />
+      </DefaultLayout.Header>
+
+      {/* Content */}
+      <DefaultLayout.ContentContainer noPadding>
+        <div className="flex h-full w-full flex-col items-center justify-center space-y-[40px] bg-neutral-100">
+          <NormalTimer
+            timer={item.time ?? 0}
+            isRunning={false}
+            isAdditionalTimerOn={false}
+            isTimerChangeable={true}
+            onChangingTimer={() => {}}
+            onStart={() => {}}
+            onPause={() => {}}
+            onReset={() => {}}
+            goToOtherItem={() => {}}
+            addOnTimer={() => {}}
+            isFirstItem={true}
+            isLastItem={false}
+            item={item}
+            teamName="찬성"
+          />
+
+          {/* NEXT 버튼만 하단에 표시 */}
+          <div className="flex flex-row space-x-8">
+            <div className="flex h-[70px] w-[200px] items-center justify-center">
+              <RoundControlButton type="PREV" onClick={() => alert('이전')} />
+            </div>
+            <div className="flex h-[70px] w-[200px] items-center justify-center">
+              <RoundControlButton type="NEXT" onClick={() => alert('다음')} />
+            </div>
+          </div>
+        </div>
+      </DefaultLayout.ContentContainer>
+    </DefaultLayout>
+  );
+}

--- a/src/page/CustomizeTimerPage/components/AdditionalTimerControlButton.tsx
+++ b/src/page/CustomizeTimerPage/components/AdditionalTimerControlButton.tsx
@@ -9,10 +9,12 @@ export default function AdditionalTimerControlButton({
 }: AdditionalTimerControlButtonProps) {
   return (
     <button
-      className="flex h-[50px] w-[100px] items-center justify-center rounded-[13px] bg-neutral-300 shadow-lg"
+      className="flex h-[45px] w-[80px] items-center justify-center rounded-[13px] bg-neutral-300 shadow-lg xl:h-[50px] xl:w-[100px]"
       onClick={() => addOnTimer()}
     >
-      <p className="text-center text-[25px] font-semibold">{text}</p>
+      <p className="text-center text-[20px] font-semibold xl:text-[25px]">
+        {text}
+      </p>
     </button>
   );
 }

--- a/src/page/CustomizeTimerPage/components/AdditionalTimerController.tsx
+++ b/src/page/CustomizeTimerPage/components/AdditionalTimerController.tsx
@@ -17,7 +17,7 @@ export default function AdditionalTimerController({
   return (
     <div
       data-testid="additional-timer-controller"
-      className="flex h-[180px] w-[730px] flex-row items-center justify-center"
+      className="flex h-[140px] w-[520px] flex-row items-center justify-center xl:h-[180px] xl:w-[730px]"
     >
       {/* Buttons that subtracts times */}
       <AdditionalTimerControlButton
@@ -33,7 +33,7 @@ export default function AdditionalTimerController({
       {/* Start and pause buttons */}
       {isRunning && (
         <button
-          className="mx-[25px] size-[152px] rounded-full bg-neutral-900 p-[45px] hover:bg-[#000000]"
+          className="mx-[25px] size-[130px] rounded-full bg-neutral-900 p-[40px] hover:bg-[#000000] xl:size-[152px] xl:p-[45px]"
           onClick={() => onPause()}
         >
           <FaStop className="size-full justify-center text-neutral-50" />
@@ -41,7 +41,7 @@ export default function AdditionalTimerController({
       )}
       {!isRunning && (
         <button
-          className="mx-[25px] size-[152px] rounded-full bg-neutral-900 p-[45px] hover:bg-[#000000]"
+          className="mx-[25px] size-[130px] rounded-full bg-neutral-900 p-[40px] hover:bg-[#000000] xl:size-[152px] xl:p-[45px]"
           onClick={() => onStart()}
         >
           <FaPlay className="size-full justify-center text-neutral-50" />

--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -61,17 +61,17 @@ export default function NormalTimer({
   return (
     <div
       data-testid="timer"
-      className={`flex min-h-[300px] w-[720px] flex-col items-center rounded-[45px] bg-neutral-200 duration-100 ${boxShadow}`}
+      className={`flex w-[600px] flex-col items-center rounded-[45px] bg-neutral-200 duration-100 ${boxShadow} xl:w-[720px]`}
     >
       {/* Title of timer */}
       <div
-        className={`flex h-[139px] w-full items-center justify-between rounded-t-[45px] ${bgColorClass} relative text-[75px] font-bold text-neutral-50`}
+        className={`flex h-[105px] w-full items-center justify-center rounded-t-[45px] xl:h-[139px] ${bgColorClass} relative font-bold text-neutral-50`}
       >
         {/* Title text  
         <h1 className="absolute left-1/2 w-max -translate-x-1/2 transform">
           {titleText}
         </h1> */}
-        <p className="w-full items-center text-center text-[75px] font-bold">
+        <p className="w-full items-center text-center text-[60px] font-bold xl:text-[75px]">
           {titleText}
         </p>
 
@@ -82,18 +82,18 @@ export default function NormalTimer({
             className="absolute right-10 top-1/2 -translate-y-1/2"
             onClick={() => onChangingTimer()}
           >
-            <IoCloseOutline className="size-[40px] hover:text-neutral-300" />
+            <IoCloseOutline className="size-[35px] hover:text-neutral-300 xl:size-[40px]" />
           </button>
         )}
       </div>
 
       {/* Speaker's number, if necessary */}
-      <div className="my-[20px] h-[40px]">
-        <div className="flex w-full flex-row items-center space-x-2 text-neutral-900">
+      <div className="my-[17px] h-[30px] xl:my-[20px] xl:h-[40px]">
+        <div className="flex w-full flex-row items-center justify-center space-x-2 text-neutral-900">
           {item.stance !== 'NEUTRAL' && !isAdditionalTimerOn && (
             <>
-              <MdRecordVoiceOver className="size-[40px]" />
-              <h3 className="text-[28px] font-bold">
+              <MdRecordVoiceOver className="size-[35px] xl:size-[40px]" />
+              <h3 className="text-[24px] font-bold xl:text-[28px]">
                 {teamName && teamName + '  팀 '}
                 {item.speaker && '| ' + item.speaker + ' 토론자'}
               </h3>
@@ -104,14 +104,14 @@ export default function NormalTimer({
 
       {/* Timer display */}
       <div
-        className={`flex h-[220px] w-[600px] items-center justify-center bg-white text-[120px] font-bold text-neutral-900 shadow-inner`}
+        className={`flex h-[190px] w-[520px] items-center justify-center bg-white text-[110px] font-bold text-neutral-900 shadow-inner xl:h-[220px] xl:w-[600px] xl:text-[120px]`}
       >
         {timer < 0 && '-'}
         {minute} : {second}
       </div>
 
       {/* Timer controller and additional timer controller */}
-      <div className="my-[30px] flex w-full items-center justify-center">
+      <div className="my-[25px] flex w-full items-center justify-center xl:my-[30px]">
         {!isAdditionalTimerOn && (
           <TimerController
             isRunning={isRunning}

--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -61,17 +61,17 @@ export default function NormalTimer({
   return (
     <div
       data-testid="timer"
-      className={`flex min-h-[300px] w-[600px] flex-col items-center rounded-[45px] bg-neutral-200 duration-100 ${boxShadow} xl:w-[720px]`}
+      className={`flex min-h-[300px] w-[460px] flex-col items-center rounded-[45px] bg-neutral-200 duration-100 lg:w-[600px] ${boxShadow} xl:w-[720px]`}
     >
       {/* Title of timer */}
       <div
-        className={`flex h-[105px] w-full items-center justify-center rounded-t-[45px] xl:h-[139px] ${bgColorClass} relative font-bold text-neutral-50`}
+        className={`flex h-[80px] w-full items-center justify-center rounded-t-[45px] lg:h-[105px] xl:h-[139px] ${bgColorClass} relative font-bold text-neutral-50`}
       >
         {/* Title text  
         <h1 className="absolute left-1/2 w-max -translate-x-1/2 transform">
           {titleText}
         </h1> */}
-        <p className="w-full items-center text-center text-[60px] font-bold xl:text-[75px]">
+        <p className="w-full items-center text-center text-[45px] font-semibold lg:text-[60px] lg:font-bold xl:text-[75px]">
           {titleText}
         </p>
 
@@ -82,18 +82,18 @@ export default function NormalTimer({
             className="absolute right-10 top-1/2 -translate-y-1/2"
             onClick={() => onChangingTimer()}
           >
-            <IoCloseOutline className="size-[35px] hover:text-neutral-300 xl:size-[40px]" />
+            <IoCloseOutline className="size-[30px] hover:text-neutral-300 lg:size-[35px] xl:size-[40px]" />
           </button>
         )}
       </div>
 
       {/* Speaker's number, if necessary */}
-      <div className="my-[17px] h-[30px] xl:my-[20px] xl:h-[40px]">
+      <div className="my-[12px] h-[25px] lg:my-[17px] lg:h-[30px] xl:my-[20px] xl:h-[40px]">
         <div className="flex w-full flex-row items-center justify-center space-x-2 text-neutral-900">
           {item.stance !== 'NEUTRAL' && !isAdditionalTimerOn && (
             <>
-              <MdRecordVoiceOver className="size-[35px] xl:size-[40px]" />
-              <h3 className="text-[24px] font-bold xl:text-[28px]">
+              <MdRecordVoiceOver className="size-[30px] lg:size-[35px] xl:size-[40px]" />
+              <h3 className="text-[18px] font-semibold lg:text-[24px] xl:text-[28px]">
                 {teamName && teamName + '  팀 '}
                 {item.speaker && '| ' + item.speaker + ' 토론자'}
               </h3>
@@ -104,14 +104,14 @@ export default function NormalTimer({
 
       {/* Timer display */}
       <div
-        className={`flex h-[190px] w-[520px] items-center justify-center bg-white text-[110px] font-bold text-neutral-900 shadow-inner xl:h-[220px] xl:w-[600px] xl:text-[120px]`}
+        className={`flex h-[140px] w-[400px] items-center justify-center bg-white text-[80px] font-bold text-neutral-900 shadow-inner lg:h-[190px] lg:w-[520px] lg:text-[110px] xl:h-[220px] xl:w-[600px] xl:text-[120px]`}
       >
         {timer < 0 && '-'}
         {minute} : {second}
       </div>
 
       {/* Timer controller and additional timer controller */}
-      <div className="my-[25px] flex w-full items-center justify-center xl:my-[30px]">
+      <div className="my-[20px] flex w-full items-center justify-center lg:my-[25px] xl:my-[30px]">
         {!isAdditionalTimerOn && (
           <TimerController
             isRunning={isRunning}

--- a/src/page/CustomizeTimerPage/components/NormalTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/NormalTimer.tsx
@@ -61,7 +61,7 @@ export default function NormalTimer({
   return (
     <div
       data-testid="timer"
-      className={`flex w-[600px] flex-col items-center rounded-[45px] bg-neutral-200 duration-100 ${boxShadow} xl:w-[720px]`}
+      className={`flex min-h-[300px] w-[600px] flex-col items-center rounded-[45px] bg-neutral-200 duration-100 ${boxShadow} xl:w-[720px]`}
     >
       {/* Title of timer */}
       <div

--- a/src/page/CustomizeTimerPage/components/TimeBasedTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/TimeBasedTimer.tsx
@@ -67,37 +67,37 @@ export default function TimeBasedTimer({
     >
       <div
         data-testid="timer"
-        className={`flex min-h-[300px] w-[720px] flex-col items-center rounded-[45px] bg-neutral-200 transition-all duration-300 ${
+        className={`flex min-h-[300px] w-[460px] flex-col items-center rounded-[45px] bg-neutral-200 transition-all duration-300 lg:w-[600px] xl:w-[720px] ${
           isSelected ? '' : 'pointer-events-none opacity-50 grayscale'
         }`}
       >
         {/* Timer Header */}
         <div
-          className={`flex h-[139px] w-full items-center justify-between rounded-t-[45px] ${bgColorClass} relative text-[75px] font-bold text-neutral-50`}
+          className={`flex h-[80px] w-full items-center justify-between rounded-t-[45px] lg:h-[105px] xl:h-[139px] ${bgColorClass} relative text-[45px] font-semibold  text-neutral-50 lg:text-[60px] lg:font-bold xl:text-[75px]`}
         >
           <h2 className="absolute left-1/2 flex w-max -translate-x-1/2 transform items-center justify-center gap-2">
             {teamName}
             <img
               src={prosCons === 'pros' ? KeyboardKeyA : KeyboardKeyL}
               alt={prosCons === 'pros' ? 'A키' : 'ㅣ키'}
-              className="h-[56px] w-[56px]"
+              className="h-[35px] w-[35px] lg:h-[50px] lg:w-[50px] xl:h-[56px] xl:w-[56px]"
             />
           </h2>
         </div>
         {speakingTimer !== null ? (
-          <div className="h-10" />
+          <div className="h-7 lg:h-10" />
         ) : (
-          <div className="h-20" />
+          <div className="h-12 lg:h-14 xl:h-20" />
         )}
         {/* 🚩 Timer 영역 */}
-        <div className="flex flex-col items-center space-y-[20px]">
+        <div className="flex flex-col items-center space-y-[10px] lg:space-y-[15px] xl:space-y-[20px]">
           {speakingTimer !== null ? (
             <>
               {/* 전체시간 타이머 (상단 작게 표시) */}
               <div
-                className={`relative flex h-[80px] w-[600px] items-center justify-center text-[80px] font-bold text-neutral-900`}
+                className={`relative flex h-[60px] w-[400px] items-center justify-center  text-[58px] font-semibold text-neutral-900 lg:h-[70px] lg:w-[520px] lg:text-[68px] lg:font-bold xl:h-[80px] xl:w-[600px] xl:text-[80px]`}
               >
-                <div className="absolute left-3 top-2 text-sm font-semibold">
+                <div className="absolute left-3 top-2 text-xs font-normal lg:text-sm lg:font-semibold">
                   전체 시간
                 </div>
                 {minute} : {second}
@@ -105,9 +105,9 @@ export default function TimeBasedTimer({
 
               {/* 현재시간 타이머 (크게 표시) */}
               <div
-                className={`relative flex h-[160px] w-[600px] items-center justify-center bg-white text-[100px] font-bold text-neutral-900 shadow-inner`}
+                className={`relative flex h-[110px] w-[400px] items-center justify-center bg-white text-[75px] font-semibold lg:h-[130px] lg:w-[520px] lg:text-[90px] lg:font-bold xl:h-[160px] xl:w-[600px] xl:text-[100px]`}
               >
-                <div className="absolute left-3 top-2 text-sm font-semibold">
+                <div className="absolute left-3 top-2 text-xs font-normal lg:text-sm lg:font-semibold">
                   현재 시간
                 </div>
                 {speakingMinute} : {speakingSecond}
@@ -117,7 +117,7 @@ export default function TimeBasedTimer({
             <>
               {/* 타이머가 하나일 때 (크게 표시) */}
               <div
-                className={`flex h-[220px] w-[600px] items-center justify-center bg-white text-[120px] font-bold text-neutral-900 shadow-inner`}
+                className={`flex h-[160px] w-[400px] items-center justify-center bg-white text-[75px] font-semibold text-neutral-900 shadow-inner lg:h-[200px] lg:w-[520px] lg:text-[100px] lg:font-bold xl:h-[220px] xl:w-[600px] xl:text-[120px]`}
               >
                 {minute} : {second}
               </div>
@@ -126,7 +126,7 @@ export default function TimeBasedTimer({
         </div>
 
         {/* Timer controller 유지 */}
-        <div className="my-[30px]">
+        <div className="my-[15px] lg:my-[25px] xl:my-[30px]">
           <TimerController
             isRunning={isRunning}
             isTimerChangeable={false}

--- a/src/page/CustomizeTimerPage/components/TimeBasedTimer.tsx
+++ b/src/page/CustomizeTimerPage/components/TimeBasedTimer.tsx
@@ -117,7 +117,7 @@ export default function TimeBasedTimer({
             <>
               {/* 타이머가 하나일 때 (크게 표시) */}
               <div
-                className={`flex h-[160px] w-[400px] items-center justify-center bg-white text-[75px] font-semibold text-neutral-900 shadow-inner lg:h-[200px] lg:w-[520px] lg:text-[100px] lg:font-bold xl:h-[220px] xl:w-[600px] xl:text-[120px]`}
+                className={`flex h-[160px] w-[400px] items-center justify-center bg-white text-[75px] font-semibold text-neutral-900 shadow-inner lg:h-[199px] lg:w-[520px] lg:text-[100px] lg:font-bold xl:h-[220px] xl:w-[600px] xl:text-[120px]`}
               >
                 {minute} : {second}
               </div>

--- a/src/page/CustomizeTimerPage/components/TimerController.tsx
+++ b/src/page/CustomizeTimerPage/components/TimerController.tsx
@@ -22,11 +22,11 @@ export default function TimerController({
   return (
     <div
       data-testid="timer-controller"
-      className="flex h-[140px] w-[620px] flex-row xl:h-[180px] xl:w-[730px]"
+      className="lex-row flex h-[120px] w-[480px] lg:h-[140px] lg:w-[620px] xl:h-[180px] xl:w-[730px]"
     >
       <div className="flex size-full flex-1 items-center justify-end ">
         <button
-          className="size-[70px] rounded-full bg-neutral-900 p-[18px] hover:bg-brand-main xl:size-[82px]"
+          className="size-[60px] rounded-full bg-neutral-900 p-[15px] hover:bg-brand-main lg:size-[70px] lg:p-[18px] xl:size-[82px]"
           onClick={() => onReset()}
         >
           <FiRefreshCcw className="size-full justify-center text-slate-50" />
@@ -34,7 +34,7 @@ export default function TimerController({
       </div>
       <div className="flex size-full flex-1 items-center justify-center ">
         <button
-          className="size-[130px] rounded-full bg-neutral-900 p-[40px] hover:bg-brand-main xl:size-[152px] xl:p-[45px]"
+          className="size-[100px] rounded-full bg-neutral-900 p-[30px] hover:bg-brand-main lg:size-[130px] lg:p-[40px] xl:size-[152px] xl:p-[45px]"
           onClick={() => {
             if (isRunning) {
               onPause();

--- a/src/page/CustomizeTimerPage/components/TimerController.tsx
+++ b/src/page/CustomizeTimerPage/components/TimerController.tsx
@@ -55,7 +55,7 @@ export default function TimerController({
         {isTimerChangeable && (
           <button
             data-testid="additional-timer-button"
-            className="h-[120px] w-[150px] flex-col items-center space-y-1 rounded-[23px] border-[3px] border-neutral-900 bg-neutral-50 text-[27px] font-bold leading-[37px] hover:bg-neutral-200 xl:h-[133px] xl:w-[165px] xl:space-y-2 xl:text-[30px]"
+            className="h-[90px] w-[110px] flex-col items-center space-y-1 rounded-[18px] border-[3px] border-neutral-900 bg-neutral-50 text-[20px] font-bold leading-[27px] hover:bg-neutral-200 lg:h-[120px] lg:w-[150px] lg:rounded-[23px] lg:text-[27px] lg:leading-[37px] xl:h-[133px] xl:w-[165px] xl:space-y-2 xl:text-[30px]"
             onClick={() => onChangingTimer()}
           >
             <p>작전 시간</p>

--- a/src/page/CustomizeTimerPage/components/TimerController.tsx
+++ b/src/page/CustomizeTimerPage/components/TimerController.tsx
@@ -22,11 +22,11 @@ export default function TimerController({
   return (
     <div
       data-testid="timer-controller"
-      className="flex h-[180px] w-[730px] flex-row"
+      className="flex h-[140px] w-[730px] flex-row xl:h-[180px]"
     >
       <div className="flex size-full flex-1 items-center justify-end ">
         <button
-          className="size-[82px] rounded-full bg-neutral-900 p-[18px] hover:bg-brand-main"
+          className="size-[70px] rounded-full bg-neutral-900 p-[18px] hover:bg-brand-main xl:size-[82px]"
           onClick={() => onReset()}
         >
           <FiRefreshCcw className="size-full justify-center text-slate-50" />
@@ -34,7 +34,7 @@ export default function TimerController({
       </div>
       <div className="flex size-full flex-1 items-center justify-center ">
         <button
-          className="size-[140px] rounded-full bg-neutral-900 p-[45px] hover:bg-brand-main"
+          className="size-[130px] rounded-full bg-neutral-900 p-[40px] hover:bg-brand-main xl:size-[140px] xl:p-[45px]"
           onClick={() => {
             if (isRunning) {
               onPause();
@@ -55,7 +55,7 @@ export default function TimerController({
         {isTimerChangeable && (
           <button
             data-testid="additional-timer-button"
-            className="h-[133px] w-[165px] flex-col items-center space-y-2 rounded-[23px] border-[3px] border-neutral-900 bg-neutral-50 text-[30px] font-bold leading-[37px] hover:bg-neutral-200"
+            className="h-[120px] w-[150px] flex-col items-center space-y-1 rounded-[23px] border-[3px] border-neutral-900 bg-neutral-50 text-[27px] font-bold leading-[37px] hover:bg-neutral-200 xl:h-[133px] xl:w-[165px] xl:space-y-2 xl:text-[30px]"
             onClick={() => onChangingTimer()}
           >
             <p>작전 시간</p>

--- a/src/page/CustomizeTimerPage/components/TimerController.tsx
+++ b/src/page/CustomizeTimerPage/components/TimerController.tsx
@@ -22,7 +22,7 @@ export default function TimerController({
   return (
     <div
       data-testid="timer-controller"
-      className="flex h-[140px] w-[730px] flex-row xl:h-[180px]"
+      className="flex h-[140px] w-[620px] flex-row xl:h-[180px] xl:w-[730px]"
     >
       <div className="flex size-full flex-1 items-center justify-end ">
         <button
@@ -34,7 +34,7 @@ export default function TimerController({
       </div>
       <div className="flex size-full flex-1 items-center justify-center ">
         <button
-          className="size-[130px] rounded-full bg-neutral-900 p-[40px] hover:bg-brand-main xl:size-[140px] xl:p-[45px]"
+          className="size-[130px] rounded-full bg-neutral-900 p-[40px] hover:bg-brand-main xl:size-[152px] xl:p-[45px]"
           onClick={() => {
             if (isRunning) {
               onPause();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -58,7 +58,7 @@ export default {
       boxShadow: {
         'camp-blue': `0 0 30px #FF3B2F`,
         'camp-red': `0 0 30px #007AFF`,
-        'camp-neutral': `0 0 30px #737373`
+        'camp-neutral': `0 0 30px #737373`,
       },
       colors: {
         brand: {
@@ -70,8 +70,7 @@ export default {
 
           sub1: '#FF5622',
           sub2: '#028391',
-          sub3 :'#FF8B87'
-          
+          sub3: '#FF8B87',
         },
         neutral: {
           1000: '#000000',
@@ -93,6 +92,9 @@ export default {
         },
       },
     },
+    screens: {
+      lg: '1100px',
+      xl: '1400px',
+    },
   },
-  plugins: [],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -93,8 +93,8 @@ export default {
       },
     },
     screens: {
-      lg: '1100px',
-      xl: '1400px',
+      lg: '1280px',
+      xl: '1450px',
     },
   },
 };


### PR DESCRIPTION
# 🚩 연관 이슈

closed #250 

# 📝 작업 내용
### 일반타이머 확인용 Storybook 페이지 추가
- 기존 storybook 에서는 자유토론타이머 페이지만 전체화면으로 확인 가능
- 따라서 별도의 일반타이머용 전체화면 테스트 페이지 추가
### 데스크탑 뷰 breakpoint 설정
- 작은화면: 1280px 미만
- 중간화면: 1280px ~ 1450px
- 큰화면: 1450px 이상
### 화면 크기에 따른 타이머 크기 변화
- 각 breakpoint에 맞춰 고정된 크기 적용
- 차례 버튼(이전, 다음)도 함께 변화

# 🏞️ 스크린샷 (선택)

### 큰화면 (기존 크기 그대로)
<img width="803" alt="스크린샷 2025-05-21 오후 1 32 29" src="https://github.com/user-attachments/assets/29289aa8-7658-4097-ac9e-8927e9f7e735" />
<img width="794" alt="스크린샷 2025-05-21 오후 1 32 57" src="https://github.com/user-attachments/assets/81e5d40f-5d5d-40d6-8abc-845ba8da434c" />


### 중간화면
<img width="779" alt="스크린샷 2025-05-21 오후 1 33 10" src="https://github.com/user-attachments/assets/ca599df1-799f-44a6-b3bf-801efa4d4bde" />
<img width="778" alt="스크린샷 2025-05-21 오후 1 33 18" src="https://github.com/user-attachments/assets/1e3fdf29-8fa5-48c3-a72b-0c9dd17a307e" />


### 작은화면
<img width="775" alt="스크린샷 2025-05-21 오후 1 33 30" src="https://github.com/user-attachments/assets/00d024d0-177d-40af-8d5c-07d53115c2ce" />
<img width="766" alt="스크린샷 2025-05-21 오후 1 33 38" src="https://github.com/user-attachments/assets/144ba3bc-8c77-4995-9454-ecce5d3ef783" />



# 🗣️ 리뷰 요구사항 (선택)
storybook 또는 preview 로 테스트 부탁드립니다
