### PR TITLE
[DESIGN] 시간표 및 타임박스 수정 기능 개선

### DIFF
--- a/src/components/ErrorBoundary/ErrorPage.tsx
+++ b/src/components/ErrorBoundary/ErrorPage.tsx
@@ -26,7 +26,7 @@ export default function ErrorPage({ message, stack, onReset }: ErrorPageProps) {
         <div className="flex w-full flex-col items-start justify-start px-8 py-10">
           <div className="mb-20 flex flex-col font-bold">
             <h1 className="mb-5 text-[120px]">😭</h1>
-            <h1 className="text-4xl md:text-5xl">오류가 발생했어요...</h1>
+            <h1 className="md:text-5xl text-4xl">오류가 발생했어요...</h1>
           </div>
 
           <div className="mb-10 flex flex-col space-y-2">

--- a/src/components/ErrorBoundary/NotFoundPage.tsx
+++ b/src/components/ErrorBoundary/NotFoundPage.tsx
@@ -17,7 +17,7 @@ export default function NotFoundPage() {
         <div className="flex w-full flex-col items-start justify-start px-8 py-10">
           <div className="mb-20 flex flex-col font-bold">
             <h1 className="mb-5 text-[120px]">🤔</h1>
-            <h1 className="text-4xl md:text-5xl">페이지를 찾을 수 없어요...</h1>
+            <h1 className="md:text-5xl text-4xl">페이지를 찾을 수 없어요...</h1>
           </div>
 
           <div className="mb-10 flex flex-col space-y-2">

--- a/src/components/LabledCheckBox/LabeledCheckbox.tsx
+++ b/src/components/LabledCheckBox/LabeledCheckbox.tsx
@@ -15,7 +15,7 @@ export default function LabeledCheckbox({
 
   return (
     <label
-      className={`flex cursor-pointer items-center gap-2 text-sm md:text-base ${labelColorClass}`}
+      className={`md:text-base flex cursor-pointer items-center gap-2 text-sm ${labelColorClass}`}
     >
       <input
         {...rest}

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -13,7 +13,7 @@ export default function useFunnel<Step extends string | number | symbol>(
     navigate(-1);
   };
 
-  const goNextStep = (nextStep: Step) => {
+  const goToStep = (nextStep: Step) => {
     navigate(`${location.pathname}${location.search}`, {
       state: { step: nextStep },
     });
@@ -31,5 +31,5 @@ export default function useFunnel<Step extends string | number | symbol>(
     [currentStep],
   );
 
-  return { currentStep, goBack, goNextStep, Funnel };
+  return { currentStep, goBack, goNextStep: goToStep, Funnel };
 }

--- a/src/hooks/useFunnel.tsx
+++ b/src/hooks/useFunnel.tsx
@@ -31,5 +31,5 @@ export default function useFunnel<Step extends string | number | symbol>(
     [currentStep],
   );
 
-  return { currentStep, goBack, goNextStep: goToStep, Funnel };
+  return { currentStep, goBack, goToStep, Funnel };
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,13 @@ import './index.css';
 import { setupGoogleAnalytics } from './util/setupGoogleAnalytics.tsx';
 
 // console.log(`# URL = ${import.meta.env.VITE_API_BASE_URL}`);
+if (import.meta.env.DEV && !localStorage.getItem('accessToken')) {
+  localStorage.setItem('accessToken', 'mock-token');
+  console.log(
+    '# Fake access token has set to %{}',
+    localStorage.getItem('accessToken'),
+  );
+}
 
 // Functions that calls msw mocking worker
 if (import.meta.env.VITE_MOCK_API === 'true') {

--- a/src/page/LoginPage/LoginPage.tsx
+++ b/src/page/LoginPage/LoginPage.tsx
@@ -26,7 +26,7 @@ export default function LoginPage() {
     <DefaultLayout>
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left>
-          <div className="flex flex-wrap items-center text-2xl font-bold md:text-3xl">
+          <div className="md:text-3xl flex flex-wrap items-center text-2xl font-bold">
             <h1 className="mr-2">로그인 페이지</h1>
           </div>
         </DefaultLayout.Header.Left>

--- a/src/page/TableComposition/TableComposition.test.tsx
+++ b/src/page/TableComposition/TableComposition.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -37,87 +37,80 @@ function TestWrapper({
   );
 }
 
+vi.mock('./components/DebatePanel/DebatePanel', () => {
+  const DebatePanel = ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="timebox">{children}</div>
+  );
+
+  return {
+    default: DebatePanel,
+  };
+});
+
+/**
+ * # Test list
+ * - (add) Cration flow
+ * - (edit) Modification flow
+ */
+
 describe('TableComposition', () => {
   beforeEach(() => {
     // 세션스토리지 초기화 등 필요한 작업
     sessionStorage.clear();
   });
 
-  it('기본 레이아웃과 "이름타입입력" 첫 단계가 렌더링된다 (mode=add)', async () => {
+  it('Creation flow and timebox functionality test', async () => {
     render(
       <TestWrapper initialEntries={['/composition?mode=add']}>
         <TableComposition />
       </TestWrapper>,
     );
 
-    expect(
-      screen.findByRole('heading', {
-        name: '토론 정보를 설정해주세요',
-      }),
-    );
-    expect(screen.getByRole('button', { name: '다음' })).toBeInTheDocument();
-  });
+    // Check header title is exist to verify whether TablenameAndType is correctly rendered
+    expect(screen.findByRole('heading', { name: '토론 정보를 설정해주세요' }));
 
-  it('mode=edit일 때 서버에서 가져온 초기값이 반영된다 (tableId=1)', async () => {
-    render(
-      <TestWrapper initialEntries={['/composition?mode=edit&tableId=1']}>
-        <TableComposition />
-      </TestWrapper>,
-    );
+    // Go to next step - TimeBoxStep
+    await userEvent.click(await screen.findByRole('button', { name: '다음' }));
+    expect(screen.findByRole('heading', { name: '주제 없음' }));
 
-    expect(
-      screen.findByRole('heading', {
-        name: '토론 정보를 수정해주세요',
-      }),
-    );
-    const nameInput = await screen.findByPlaceholderText('시간표 1');
-
-    expect((nameInput as HTMLInputElement).value).toBe('');
-  });
-
-  it('다음 버튼 클릭 시 "타임박스입력" 단계로 이동한다', async () => {
-    render(
-      <TestWrapper initialEntries={['/composition?mode=add']}>
-        <TableComposition />
-      </TestWrapper>,
-    );
-
-    const nextButton = screen.getByText('다음');
-    await userEvent.click(nextButton);
-
-    // TimeBoxStep 컴포넌트가 표시된다고 가정
-    // 예: TimeBoxStep에 data-testid="time-box-step"가 있다면:
-    expect(screen.getByText('주제 없음')).toBeInTheDocument();
-  });
-
-  it('타임박스 단계에서 "완료" 버튼 클릭 시, overview 페이지로 이동한다 (mode=add)', async () => {
-    // 1. 초기 단계
-    render(
-      <TestWrapper initialEntries={['/composition?mode=add']}>
-        <TableComposition />
-      </TestWrapper>,
-    );
-
-    const nextButton = screen.getByText('다음');
-    await userEvent.click(nextButton);
-
-    // 3. TimeBoxStep 노출 확인
-    expect(screen.getByText('주제 없음')).toBeInTheDocument();
-
-    // 4. "완료" (혹은 "제출") 버튼 클릭
-    const submitButton = screen.getByText('시간표 추가 완료');
-    expect(submitButton).toBeDisabled();
-
-    const addButton = screen.getAllByText('+')[0]; // 첫 번째 "+" 버튼 (왼쪽 버튼)
-    await userEvent.click(addButton);
-
-    const confirmButton = screen.getByRole('button', { name: '설정 완료' });
-    await userEvent.click(confirmButton);
-
-    await userEvent.click(submitButton);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('overview-page')).toBeInTheDocument();
+    // Check whether finish button is disabled
+    const finishButton = await screen.findByRole('button', {
+      name: '추가하기',
     });
+    expect(finishButton).toBeDisabled();
+
+    // Add a new timebox
+    await userEvent.click(await screen.findByRole('button', { name: '+' }));
+    await userEvent.click(
+      await screen.findByRole('button', { name: '설정 완료' }),
+    );
+    expect(screen.getByTestId('timebox')).toBeInTheDocument();
+
+    // Finish creation flow
+    await userEvent.click(finishButton);
+    expect(screen.getByTestId('overview-page')).toBeInTheDocument();
+  });
+
+  it('Modification flow test', async () => {
+    render(
+      <TestWrapper
+        initialEntries={['/composition?mode=edit&tableId=1&mode=CUSTOMIZE']}
+      >
+        <TableComposition />
+      </TestWrapper>,
+    );
+
+    // Check whether user sees TimeBoxStep not TableNameAndType
+    expect(screen.findByRole('button', { name: '토론 정보 수정하기' }));
+
+    // Check whether timeboxes are correctly displayed
+    const timeboxItems = await screen.findAllByTestId('timebox');
+    expect(timeboxItems.length).toBeGreaterThan(0);
+
+    // Check whether table info change button works well
+    await userEvent.click(
+      await screen.findByRole('button', { name: '토론 정보 수정하기' }),
+    );
+    expect(screen.getByText('토론 정보를 수정해주세요')).toBeInTheDocument();
   });
 });

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -12,13 +12,16 @@ export type TableCompositionStep = 'NameAndType' | 'TimeBox';
 type Mode = 'edit' | 'add';
 
 export default function TableComposition() {
-  const { Funnel, currentStep, goNextStep } =
-    useFunnel<TableCompositionStep>('NameAndType');
-
-  // 1) URL 등으로부터 "editMode"와 "tableId"를 추출
+  // URL 등으로부터 "editMode"와 "tableId"를 추출
   const [searchParams] = useSearchParams();
   const mode = searchParams.get('mode') as Mode;
   const tableId = Number(searchParams.get('tableId') || 0);
+
+  // Print different funnel page by mode (edit a existing table or add a new table)
+  const initialMode: TableCompositionStep =
+    mode !== 'edit' ? 'NameAndType' : 'TimeBox';
+  const { Funnel, currentStep, goNextStep } =
+    useFunnel<TableCompositionStep>(initialMode);
 
   // (2) edit 모드일 때만 서버에서 initData를 가져옴
   // 테이블 데이터 패칭 분기

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -75,7 +75,8 @@ export default function TableComposition() {
               initData={formData}
               isEdit={mode === 'edit'}
               onTimeBoxChange={updateTable}
-              onButtonClick={handleButtonClick}
+              onFinishButtonClick={handleButtonClick}
+              onEditTableInfoButtonClick={() => goNextStep('NameAndType')}
             />
           ),
         }}

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -7,7 +7,6 @@ import { useGetDebateTableData } from '../../hooks/query/useGetDebateTableData';
 import { useSearchParams } from 'react-router-dom';
 import { useMemo } from 'react';
 import { DebateInfo, TimeBoxInfo } from '../../type/type';
-import LoadingSpinner from '../../components/LoadingSpinner';
 
 export type TableCompositionStep = 'NameAndType' | 'TimeBox';
 type Mode = 'edit' | 'add';

--- a/src/page/TableComposition/TableComposition.tsx
+++ b/src/page/TableComposition/TableComposition.tsx
@@ -7,6 +7,7 @@ import { useGetDebateTableData } from '../../hooks/query/useGetDebateTableData';
 import { useSearchParams } from 'react-router-dom';
 import { useMemo } from 'react';
 import { DebateInfo, TimeBoxInfo } from '../../type/type';
+import LoadingSpinner from '../../components/LoadingSpinner';
 
 export type TableCompositionStep = 'NameAndType' | 'TimeBox';
 type Mode = 'edit' | 'add';
@@ -20,10 +21,10 @@ export default function TableComposition() {
   // Print different funnel page by mode (edit a existing table or add a new table)
   const initialMode: TableCompositionStep =
     mode !== 'edit' ? 'NameAndType' : 'TimeBox';
-  const { Funnel, currentStep, goNextStep } =
+  const { Funnel, currentStep, goToStep } =
     useFunnel<TableCompositionStep>(initialMode);
 
-  // (2) edit 모드일 때만 서버에서 initData를 가져옴
+  // edit 모드일 때만 서버에서 initData를 가져옴
   // 테이블 데이터 패칭 분기
   const { data } = useGetDebateTableData(tableId, mode === 'edit');
 
@@ -67,7 +68,7 @@ export default function TableComposition() {
               info={formData.info}
               isEdit={mode === 'edit'}
               onInfoChange={updateInfo}
-              onButtonClick={() => goNextStep('TimeBox')}
+              onButtonClick={() => goToStep('TimeBox')}
             />
           ),
           TimeBox: (
@@ -76,7 +77,7 @@ export default function TableComposition() {
               isEdit={mode === 'edit'}
               onTimeBoxChange={updateTable}
               onFinishButtonClick={handleButtonClick}
-              onEditTableInfoButtonClick={() => goNextStep('NameAndType')}
+              onEditTableInfoButtonClick={() => goToStep('NameAndType')}
             />
           ),
         }}

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -51,8 +51,8 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
       </DefaultLayout.Header>
 
       <DefaultLayout.ContentContainer>
-        <section className="mx-auto grid w-full max-w-4xl grid-cols-[180px_1fr] gap-x-4 gap-y-12 p-6 md:p-8">
-          <label className="flex items-center text-base font-semibold md:text-2xl">
+        <section className="md:p-8 mx-auto grid w-full max-w-4xl grid-cols-[180px_1fr] gap-x-4 gap-y-12 p-6">
+          <label className="md:text-2xl flex items-center text-base font-semibold">
             토론 시간표 이름
           </label>
           <ClearableInput
@@ -62,7 +62,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
             placeholder="시간표 1"
           />
 
-          <label className="flex items-center text-base font-semibold md:text-2xl">
+          <label className="md:text-2xl flex items-center text-base font-semibold">
             토론 주제
           </label>
           <ClearableInput
@@ -72,7 +72,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
             placeholder="토론 주제를 입력해주세요"
           />
           <>
-            <label className="flex items-center text-base font-semibold md:text-2xl">
+            <label className="md:text-2xl flex items-center text-base font-semibold">
               팀명
             </label>
             <div className="flex items-center gap-8">
@@ -102,7 +102,7 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
             </div>
           </>
 
-          <label className="text-base font-semibold md:text-2xl">
+          <label className="md:text-2xl text-base font-semibold">
             종소리 설정
           </label>
           <div className="flex flex-col gap-3">

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -90,7 +90,12 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       </DefaultLayout.ContentContainer>
 
       <DefaultLayout.StickyFooterWrapper>
-        <div className="mx-auto mb-8 w-full max-w-4xl">
+        <div className="mx-auto mb-8 flex w-full max-w-4xl items-center justify-between gap-2">
+          {/* TODO: Need to add a function here */}
+          <button onClick={() => {}} className="button enabled h-16 w-full">
+            토론 정보 수정하기
+          </button>
+
           <button
             onClick={onButtonClick}
             className={`h-16 w-full ${
@@ -98,7 +103,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
             }`}
             disabled={!isAbledSummitButton}
           >
-            {isEdit ? '시간표 수정 완료' : '시간표 추가 완료'}
+            {isEdit ? '수정 완료' : '추가하기'}
           </button>
         </div>
       </DefaultLayout.StickyFooterWrapper>

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -12,12 +12,19 @@ import { DebateTableData, TimeBoxInfo } from '../../../../type/type';
 interface TimeBoxStepProps {
   initData: DebateTableData;
   onTimeBoxChange: React.Dispatch<React.SetStateAction<TimeBoxInfo[]>>;
-  onButtonClick: () => void;
+  onFinishButtonClick: () => void;
+  onEditTableInfoButtonClick: () => void;
   isEdit?: boolean;
 }
 
 export default function TimeBoxStep(props: TimeBoxStepProps) {
-  const { initData, onTimeBoxChange, onButtonClick, isEdit = false } = props;
+  const {
+    initData,
+    onTimeBoxChange,
+    onFinishButtonClick,
+    onEditTableInfoButtonClick,
+    isEdit = false,
+  } = props;
   const initTimeBox = initData.table;
   const { openModal, closeModal, ModalWrapper } = useModal();
 
@@ -92,12 +99,15 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       <DefaultLayout.StickyFooterWrapper>
         <div className="mx-auto mb-8 flex w-full max-w-4xl items-center justify-between gap-2">
           {/* TODO: Need to add a function here */}
-          <button onClick={() => {}} className="button enabled h-16 w-full">
+          <button
+            onClick={onEditTableInfoButtonClick}
+            className="button enabled h-16 w-full"
+          >
             토론 정보 수정하기
           </button>
 
           <button
-            onClick={onButtonClick}
+            onClick={onFinishButtonClick}
             className={`h-16 w-full ${
               isAbledSummitButton ? 'button enabled' : 'button disabled'
             }`}

--- a/src/page/TableComposition/hook/useTableFrom.tsx
+++ b/src/page/TableComposition/hook/useTableFrom.tsx
@@ -45,12 +45,6 @@ const useTableFrom = (
     // Originaly here was exhaustive-deps
   }, [initData, setFormData]);
 
-  useEffect(() => {
-    if (currentStep === 'TimeBox' && navigationType === 'POP') {
-      navigate('/');
-    }
-  }, [currentStep, navigationType, navigate]);
-
   const updateInfo: React.Dispatch<
     React.SetStateAction<DebateTableData['info']>
   > = (action) => {

--- a/src/page/TableListPage/TableListPage.tsx
+++ b/src/page/TableListPage/TableListPage.tsx
@@ -26,7 +26,7 @@ export default function TableListPage() {
       <DefaultLayout.Header>
         <DefaultLayout.Header.Left></DefaultLayout.Header.Left>
         <DefaultLayout.Header.Center>
-          <div className="flex flex-wrap items-center justify-center px-2 text-2xl font-bold md:text-3xl">
+          <div className="md:text-3xl flex flex-wrap items-center justify-center px-2 text-2xl font-bold">
             <h1>토론 시간표를 선택해주세요</h1>
           </div>
         </DefaultLayout.Header.Center>

--- a/src/page/TimerPage/components/FirstUseToolTip.tsx
+++ b/src/page/TimerPage/components/FirstUseToolTip.tsx
@@ -21,7 +21,7 @@ export default function FirstUseToolTip({ onClose }: FirstUseToolTipProps) {
           <h2 className="text-xl font-bold">자유토론 타이머 조작</h2>
         </div>
 
-        <div className="text-m flex flex-col space-y-1 md:text-lg">
+        <div className="text-m md:text-lg flex flex-col space-y-1">
           <ListItem>재생 버튼을 눌러 타이머를 시작</ListItem>
           <ListItem>
             타이머가 동작 중일 때, 일시정지 버튼을 눌러 타이머를 일시정지
@@ -41,7 +41,7 @@ export default function FirstUseToolTip({ onClose }: FirstUseToolTipProps) {
           <h2 className="text-xl font-bold">일반 토론 타이머 조작</h2>
         </div>
 
-        <div className="text-m flex flex-col space-y-1 md:text-lg">
+        <div className="text-m md:text-lg flex flex-col space-y-1">
           <ListItem>재생 버튼을 눌러 타이머를 시작</ListItem>
           <ListItem>
             타이머가 동작 중일 때, 일시정지 버튼을 눌러 타이머를 일시정지
@@ -59,7 +59,7 @@ export default function FirstUseToolTip({ onClose }: FirstUseToolTipProps) {
           <h1 className="text-xl font-bold">키보드 조작</h1>
         </div>
 
-        <div className="text-m flex flex-col space-y-1 md:text-lg">
+        <div className="text-m md:text-lg flex flex-col space-y-1">
           <ListItem>스페이스 바로 타이머를 시작 및 일시정지</ListItem>
           <ListItem>R 키로 타이머 초기화</ListItem>
           <ListItem>좌우 방향키로 이전/다음 차례로 이동</ListItem>

--- a/src/repositories/ApiDebateTableRepository.ts
+++ b/src/repositories/ApiDebateTableRepository.ts
@@ -16,10 +16,12 @@ export class ApiDebateTableRepository implements DebateTableRepository {
   async getTable(tableId: number): Promise<GetDebateTableResponseType> {
     return await getDebateTableData(tableId);
   }
+
   async addTable(data: DebateTableData): Promise<PostDebateTableResponseType> {
     const { info, table } = data;
     return await postDebateTableData({ info, table });
   }
+
   async editTable(
     data: PutDebateTableRequestType,
   ): Promise<PutDebateTableResponseType> {

--- a/src/repositories/DebateTableRepository.ts
+++ b/src/repositories/DebateTableRepository.ts
@@ -8,6 +8,7 @@ import { DebateTableData } from '../type/type';
 import { isGuestFlow } from '../util/sessionStorage';
 import { ApiDebateTableRepository } from './ApiDebateTableRepository';
 import { SessionDebateTableRepository } from './SessionDebateTableRepository';
+
 export interface DebateTableRepository {
   getTable(tableId?: number): Promise<GetDebateTableResponseType>;
   addTable(data: DebateTableData): Promise<PostDebateTableResponseType>;
@@ -18,6 +19,7 @@ export interface DebateTableRepository {
 
 export function getRepository(): DebateTableRepository {
   console.log(isGuestFlow());
+
   if (isGuestFlow()) return new SessionDebateTableRepository();
   return new ApiDebateTableRepository();
 }


### PR DESCRIPTION
# 🚩 연관 이슈

closed #236 

# 📝 작업 내용
## 문제점
- 현재 수정 플로우는 토론 정보 수정 화면 `NameAndType` → 타임박스 수정 화면 `TimeBoxStep`의 플로우로 진행
- 이 플로우에서는 테이블 수정 버튼 클릭 시, 토론 정보 수정 화면 `NameAndType`에서 시작함
- 이는 테이블 데이터가 아닌 타임박스만 수정하고 싶은 사용자에게 불필요한 동작을 더 수행하도록 강제하는 플로우였음

## 개선 사항
### 새로운 수정 플로우 구현
- 테이블 수정 버튼 클릭 시, 토론 정보 수정 화면 `NameAndType`이 아닌 타임박스 수정 화면 `TimeBoxStep`이 출력되게 개선
- '토론 정보 수정하기' 버튼을 타임박스 수정 화면 `TimeBoxStep`에 추가
- '토론 정보 수정하기' 버튼 클릭 시, 토론 정보 수정 화면 `NameAndType`이 출력되게 개선
- 새로운 수정 플로우 구현에 따른 테스트 코드도 전면 수정

### 훅 `useFunnel`의 반환 중 하나인 함수 `goNextStep`의 이름 변경
함수 `goNextStep`의 이름을 `goToStep`으로 변경하였습니다.

기존 함수 이름이었던 `goNextStep`은 다음 스텝으로 넘어간다는 의미를 내포하고 있으나, 그 의미와는 다르게 이 함수는 특정 스텝을 인수로 받아 그 스텝으로 진행하는 기능을 가지고 있습니다.
```tsx
const goNextStep = (nextStep: Step) => {
  navigate(`${location.pathname}${location.search}`, {
    state: { step: nextStep },
  });
};
```

따라서 특정 스텝을 인수로 받고 그 스텝으로 넘어간다는 함수 기능을 더 엄격하게 반영하여, 함수 이름을 `goNextStep`에서 `goToStep`으로 변경하였습니다.

### 오류 해결
```tsx
useEffect(() => {
  if (currentStep === 'TimeBox' && navigationType === 'POP') {
    navigate('/');
  }
}, [currentStep, navigationType, navigate]);
```

간단히 말씀드리면 이상의 코드 때문에 Vitest를 활용한 UI 테스트 및 수정 플로우로의 접근이 원천 차단되는 문제가 있어, 이를 삭제하였습니다.


## 사용자 입장에서의 변경 사항
새로운 테이블 수정 플로우는 아래와 같이 진행됩니다:
- 테이블 미리보기 화면 `TableOverviewPage`에서 '수정하기' 버튼 클릭
- 타임박스 수정 화면 `TimeBoxStep`으로 이동 및 '토론 정보 수정하기' 버튼 클릭
- 토론 정보 수정 화면 `TableNameAndType`으로 이동하여 토론 정보(주제, 팀명 등) 수정 가능

# 🏞️ 스크린샷 (선택)
## '토론 정보 수정하기' 버튼이 추가된 `TimeBoxStep` 화면
![image](https://github.com/user-attachments/assets/3c5dd86c-3233-4f76-a65e-38af34a0f1da)

# 🗣️ 리뷰 요구사항 (선택)
없음