### PR TITLE
[HOTFIX] 배포 워크플로가 환경 변수를 읽지 못하는 오류 수정

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     environment: DEPLOY_DEV
 
     steps:
@@ -22,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .env
-        run: echo "${{secrets.ENV}}" > .env
+        run: echo "${{vars.ENV}}" > .env
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
     environment: DEPLOY_PROD
 
     steps:
@@ -22,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup .env
-        run: echo "${{secrets.ENV}}" > .env
+        run: echo "${{vars.ENV}}" > .env
 
       - name: Install Dependencies
         run: npm ci


### PR DESCRIPTION
# 🚩 연관 이슈

closed #288 

# 📝 작업 내용
## 배포 워크플로(dev, prod 모두)가 환경 변수를 읽지 못하는 오류 수정
이 문제는 GitHub Actions 스크립트에서 환경 변수를 `vars.ENV`가 아니라 `secrets.ENV`로 참고하고 있었기 때문에 발생했습니다. dev 배포 스크립트와 prod 배포 스크립트 모두 `vars.ENV`로 수정하였습니다.

## 배포 워크플로 실행 조건 완화
기존 배포 워크플로는 오직 PR이 병합될 때에만 실행 가능했습니다. 원래 GitHub Actions는 스크립트를 기본(default) 브랜치가 아닌 하위 브랜치에서도 실행 가능하지만, 이 조건에 의해 하위 브랜치에서 스크립트를 개선한 후 테스트할 수 없었습니다. 이 제한을 풀어 워크플로 개선 시 하위 브랜치에서도 테스트를 해 보고 문제를 조기에 식별할 수 있게 개선합니다.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음
