### PR TITLE
[CHORE] 팀 구성원 변경에 따른 Auto PR 스크립트 수정

### DIFF
--- a/.github/workflows/Auto_PR_Setting.yml
+++ b/.github/workflows/Auto_PR_Setting.yml
@@ -45,6 +45,7 @@ jobs:
           LABELS=$(echo "${ISSUE_DATA}" | jq -r '.labels | join(",")')
 
           # 팀 멤버 목록을 정의하고, 할당되지 않은 멤버를 리뷰어로 추가.
+          # 단, 현재 활동하지 않는 멤버는 제외. (현재 비활성 멤버 = 엘, 케이티)
           TEAM_MEMBERS=("jaeml06" "i-meant-to-be" "useon")
           IFS=', ' read -r -a ASSIGNEE_ARRAY <<< "${ASSIGNEES}"
           REVIEWERS=()

--- a/.github/workflows/Auto_PR_Setting.yml
+++ b/.github/workflows/Auto_PR_Setting.yml
@@ -45,7 +45,7 @@ jobs:
           LABELS=$(echo "${ISSUE_DATA}" | jq -r '.labels | join(",")')
 
           # 팀 멤버 목록을 정의하고, 할당되지 않은 멤버를 리뷰어로 추가.
-          TEAM_MEMBERS=("jaeml06" "i-meant-to-be" "eunwoo-levi" "katie424")
+          TEAM_MEMBERS=("jaeml06" "i-meant-to-be" "useon")
           IFS=', ' read -r -a ASSIGNEE_ARRAY <<< "${ASSIGNEES}"
           REVIEWERS=()
           for MEMBER in "${TEAM_MEMBERS[@]}"; do


### PR DESCRIPTION
# 🚩 연관 이슈

closed #298 

# 📝 작업 내용
## 문제점
- 썬데이의 합류가 Auto PR 스크립트에 반영되지 않음
- 현재 비활성 멤버인 엘과 케이티가 Auto PR 스크립트에서 제외되지 않음

## 변경 사항
- 썬데이를 Auto PR 스크립트에 추가
- 엘과 케이티를 Auto PR 스크립트에서 제거

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 자동 PR 리뷰어 할당 팀원 목록이 업데이트되었습니다. (비활성 멤버 제외, 신규 멤버 추가)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->