### PR TITLE
[DESIGN] 로그인/로그아웃 버튼 디자인 변경

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,5 +1,9 @@
 import axios from 'axios';
-import { getAccessToken, setAccessToken } from '../util/accessToken';
+import {
+  getAccessToken,
+  removeAccessToken,
+  setAccessToken,
+} from '../util/accessToken';
 
 axios.defaults.withCredentials = true;
 export const axiosInstance = axios.create({
@@ -57,6 +61,7 @@ axiosInstance.interceptors.response.use(
         console.error('Refresh Token is invalid or expired', refreshError);
         // 재발급도 실패하면 -> 로그인 페이지 이동
         window.location.href = '/home';
+        removeAccessToken();
         return Promise.reject(refreshError);
       }
     }

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -12,6 +12,9 @@ import { oAuthLogin } from '../../../util/googleAuth';
 import { useModal } from '../../../hooks/useModal';
 import DialogModal from '../../../components/DialogModal/DialogModal';
 
+// The type of header icons will be declared here.
+type HeaderIcons = 'home';
+
 function StickyTriSectionHeader(props: PropsWithChildren) {
   const { children } = props;
 
@@ -24,24 +27,37 @@ function StickyTriSectionHeader(props: PropsWithChildren) {
   );
 }
 
+/**
+ * Header의 좌측 부 제목 영역
+ * @param props 부 제목에 해당하는 JSX 컴포넌트
+ * @returns JSX.Element
+ */
 StickyTriSectionHeader.Left = function Left(props: PropsWithChildren) {
   const { children } = props;
   return <div className="flex-1 items-start text-start">{children}</div>;
 };
 
+/**
+ * Header의 중앙 주 제목 영역
+ * @param props 주 제목에 해당하는 JSX 컴포넌트
+ * @returns JSX.Element
+ */
 StickyTriSectionHeader.Center = function Center(props: PropsWithChildren) {
   const { children } = props;
   return <div className="flex-1 items-center text-center">{children}</div>;
 };
 
-type HeaderIcons = 'home';
-
+/**
+ * Header의 우측 버튼 영역
+ * @param props Header에 추가할 기본 아이콘 외의 커스텀 아이콘
+ * @returns JSX.Element
+ */
 StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
   const { children } = props;
   const navigate = useNavigate();
   const { mutate: logoutMutate } = useLogout(() => navigate('/home'));
   const { openModal, closeModal, ModalWrapper } = useModal({});
-  const defaultIcons: HeaderIcons[] = ['home'];
+  const defaultIcons: HeaderIcons[] = ['home']; // Icons that will be displayed on all pages are added here
 
   return (
     <>
@@ -49,7 +65,7 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
         {/* Auth related header items */}
         <>
           {/* Guest mode indicator */}
-          {!isGuestFlow() && (
+          {isGuestFlow() && (
             <div className="animate-pulse rounded-full bg-neutral-300 px-4 py-2 font-semibold">
               비회원 모드
             </div>
@@ -58,7 +74,7 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
           {/* Login and logout button */}
           {isLoggedIn() && (
             <button
-              className="rounded-full px-4 py-2 text-[20px] font-bold hover:bg-neutral-400"
+              className="rounded-full px-4 py-2 font-bold hover:bg-neutral-300"
               onClick={() => logoutMutate()}
             >
               로그아웃
@@ -66,7 +82,7 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
           )}
           {!isLoggedIn() && (
             <button
-              className="rounded-full px-4 py-2 font-bold hover:bg-neutral-400"
+              className="rounded-full px-4 py-2 font-bold hover:bg-neutral-300"
               onClick={() => openModal()}
             >
               로그인

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -27,33 +27,18 @@ function StickyTriSectionHeader(props: PropsWithChildren) {
   );
 }
 
-/**
- * Header의 좌측 부 제목 영역
- * @param props 부 제목에 해당하는 JSX 컴포넌트
- * @returns JSX.Element
- */
 StickyTriSectionHeader.Left = function Left(props: PropsWithChildren) {
   const { children } = props;
   return <div className="flex-1 items-start text-start">{children}</div>;
 };
 
-/**
- * Header의 중앙 주 제목 영역
- * @param props 주 제목에 해당하는 JSX 컴포넌트
- * @returns JSX.Element
- */
 StickyTriSectionHeader.Center = function Center(props: PropsWithChildren) {
   const { children } = props;
   return <div className="flex-1 items-center text-center">{children}</div>;
 };
 
-/**
- * Header의 우측 버튼 영역
- * @param props Header에 추가할 기본 아이콘 외의 커스텀 아이콘
- * @returns JSX.Element
- */
 StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
-  const { children } = props;
+  const { children: buttons } = props;
   const navigate = useNavigate();
   const { mutate: logoutMutate } = useLogout(() => navigate('/home'));
   const { openModal, closeModal, ModalWrapper } = useModal({});
@@ -93,7 +78,7 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
         </>
 
         {/* Buttons given as an argument */}
-        {children}
+        {buttons}
 
         {/* Normal buttons */}
         {defaultIcons.map((iconName, index) => {

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -2,7 +2,6 @@ import { PropsWithChildren } from 'react';
 import { IoMdHome } from 'react-icons/io';
 import { useNavigate } from 'react-router-dom';
 import useLogout from '../../../hooks/mutations/useLogout';
-import { IoLogIn, IoLogOut } from 'react-icons/io5';
 import IconButton from '../../../components/IconButton/IconButton';
 import { isLoggedIn } from '../../../util/accessToken';
 import {
@@ -35,45 +34,54 @@ StickyTriSectionHeader.Center = function Center(props: PropsWithChildren) {
   return <div className="flex-1 items-center text-center">{children}</div>;
 };
 
-type HeaderIcons = 'home' | 'logout' | 'guest' | 'auth';
+type HeaderIcons = 'home';
 
 StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
   const { children } = props;
   const navigate = useNavigate();
   const { mutate: logoutMutate } = useLogout(() => navigate('/home'));
   const { openModal, closeModal, ModalWrapper } = useModal({});
-  const defaultIcons: HeaderIcons[] = [];
-
-  if (isGuestFlow()) {
-    defaultIcons.push('guest');
-  }
-
-  if (isLoggedIn()) {
-    defaultIcons.push('home', 'auth');
-  } else {
-    defaultIcons.push('auth');
-  }
+  const defaultIcons: HeaderIcons[] = ['home'];
 
   return (
     <>
       <div className="flex flex-1 items-stretch justify-end gap-2 text-right">
-        {children && (
-          <>
-            {children}
-            <div className="w-[1px] self-stretch bg-neutral-500" />
-          </>
-        )}
+        {/* Auth related header items */}
+        <>
+          {/* Guest mode indicator */}
+          {!isGuestFlow() && (
+            <div className="animate-pulse rounded-full bg-neutral-300 px-4 py-2 font-semibold">
+              비회원 모드
+            </div>
+          )}
 
+          {/* Login and logout button */}
+          {isLoggedIn() && (
+            <button
+              className="rounded-full px-4 py-2 text-[20px] font-bold hover:bg-neutral-400"
+              onClick={() => logoutMutate()}
+            >
+              로그아웃
+            </button>
+          )}
+          {!isLoggedIn() && (
+            <button
+              className="rounded-full px-4 py-2 font-bold hover:bg-neutral-400"
+              onClick={() => openModal()}
+            >
+              로그인
+            </button>
+          )}
+
+          <div className="w-[1px] self-stretch bg-neutral-500" />
+        </>
+
+        {/* Buttons given as an argument */}
+        {children}
+
+        {/* Normal buttons */}
         {defaultIcons.map((iconName, index) => {
           switch (iconName) {
-            case 'guest':
-              return (
-                <div key={`${iconName}-${index}`}>
-                  <div className="animate-pulse rounded-full bg-neutral-300 px-4 py-2 font-semibold">
-                    비회원 모드
-                  </div>
-                </div>
-              );
             case 'home':
               return (
                 <div key={`${iconName}-${index}`}>
@@ -83,33 +91,11 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
                       if (isGuestFlow()) {
                         deleteSessionCustomizeTableData();
                       }
-                      navigate('/');
+                      navigate('/home');
                     }}
                   />
                 </div>
               );
-            case 'auth':
-              if (isLoggedIn()) {
-                return (
-                  <div key={`${iconName}-${index}`}>
-                    <IconButton
-                      icon={<IoLogOut size={24} />}
-                      onClick={() => logoutMutate()}
-                      title="로그아웃"
-                    />
-                  </div>
-                );
-              } else {
-                return (
-                  <div key={`${iconName}-${index}`}>
-                    <IconButton
-                      icon={<IoLogIn size={24} />}
-                      onClick={() => openModal()}
-                      title="로그인"
-                    />
-                  </div>
-                );
-              }
             default:
               return null;
           }

--- a/src/page/LandingPage/LandingPage.tsx
+++ b/src/page/LandingPage/LandingPage.tsx
@@ -25,18 +25,25 @@ export default function LandingPage() {
   const handleDashboardButtonClick = () => {
     navigate('/');
   };
-  const onLoginButtonClick = () => {
+  const onHeaderLoginClicked = () => {
     if (!isLoggedIn()) {
       oAuthLogin();
     } else {
       logoutMutate();
     }
   };
+  const onTableSectionLoginClicked = () => {
+    if (!isLoggedIn()) {
+      oAuthLogin();
+    } else {
+      handleDashboardButtonClick();
+    }
+  };
 
   return (
     <div className="flex h-full w-full items-center justify-center bg-neutral-0">
       {/* 헤더 */}
-      <Header onLoginButtonClicked={() => onLoginButtonClick()} />
+      <Header onLoginButtonClicked={onHeaderLoginClicked} />
 
       <main className="flex w-full flex-col items-center">
         {/* 흰색 배경 */}
@@ -59,7 +66,7 @@ export default function LandingPage() {
         {/* 흰색 배경 */}
         <div className="flex w-[95%] max-w-[1226px] flex-col gap-96 py-48 md:w-[64%]">
           {/* 홈 설정 */}
-          <TableSection onLogin={() => onLoginButtonClick()} />
+          <TableSection onLogin={onTableSectionLoginClicked} />
           {/* 리뷰 */}
           <ReviewSection onStartWithoutLogin={handleStartWithoutLogin} />
           {/* 버그 및 불편사항 제보 */}

--- a/src/page/LandingPage/LandingPage.tsx
+++ b/src/page/LandingPage/LandingPage.tsx
@@ -8,8 +8,13 @@ import ReportSection from './components/ReportSection';
 import { oAuthLogin } from '../../util/googleAuth';
 import { createTableShareUrl } from '../../util/arrayEncoding';
 import { SAMPLE_TABLE_DATA } from '../../constants/sample_table';
+import { isLoggedIn } from '../../util/accessToken';
+import { useNavigate } from 'react-router-dom';
+import useLogout from '../../hooks/mutations/useLogout';
 
 export default function LandingPage() {
+  const navigate = useNavigate();
+  const { mutate: logoutMutate } = useLogout(() => navigate('/home'));
   const handleStartWithoutLogin = () => {
     // window.location.href = LANDING_URLS.START_WITHOUT_LOGIN_URL;
     window.location.href = createTableShareUrl(
@@ -17,17 +22,30 @@ export default function LandingPage() {
       SAMPLE_TABLE_DATA,
     );
   };
+  const handleDashboardButtonClick = () => {
+    navigate('/');
+  };
+  const onLoginButtonClick = () => {
+    if (!isLoggedIn()) {
+      oAuthLogin();
+    } else {
+      logoutMutate();
+    }
+  };
 
   return (
     <div className="flex h-full w-full items-center justify-center bg-neutral-0">
       {/* 헤더 */}
-      <Header onLogin={() => oAuthLogin()} />
+      <Header onLoginButtonClicked={() => onLoginButtonClick()} />
 
       <main className="flex w-full flex-col items-center">
         {/* 흰색 배경 */}
         <div className="flex w-[95%] max-w-[1226px] flex-col gap-96 pb-48 pt-20 md:w-[64%]">
           {/* 메인 화면 */}
-          <MainSection onStartWithoutLogin={handleStartWithoutLogin} />
+          <MainSection
+            onStartWithoutLogin={handleStartWithoutLogin}
+            onDashboardButtonClicked={handleDashboardButtonClick}
+          />
           {/* 시간표 설정화면 */}
           <TimeTableSection />
         </div>
@@ -41,7 +59,7 @@ export default function LandingPage() {
         {/* 흰색 배경 */}
         <div className="flex w-[95%] max-w-[1226px] flex-col gap-96 py-48 md:w-[64%]">
           {/* 홈 설정 */}
-          <TableSection onLogin={() => oAuthLogin()} />
+          <TableSection onLogin={() => onLoginButtonClick()} />
           {/* 리뷰 */}
           <ReviewSection onStartWithoutLogin={handleStartWithoutLogin} />
           {/* 버그 및 불편사항 제보 */}

--- a/src/page/LandingPage/LandingPage.tsx
+++ b/src/page/LandingPage/LandingPage.tsx
@@ -5,20 +5,20 @@ import TimerSection from './components/TimerSection';
 import TableSection from './components/TableSection';
 import ReviewSection from './components/ReviewSection';
 import ReportSection from './components/ReportSection';
-import useLandingPageLogics from './hooks/useLandingPageLogics';
+import useLandingPageHandlers from './hooks/useLandingPageHandlers';
 
 export default function LandingPage() {
-  const [
+  const {
     handleStartWithoutLogin,
-    onTableSectionLoginClicked,
-    onDashboardButtonClicked,
-    onHeaderLoginClicked,
-  ] = useLandingPageLogics();
+    handleDashboardButtonClick,
+    handleHeaderLoginButtonClick,
+    handleTableSectionLoginButtonClick,
+  } = useLandingPageHandlers();
 
   return (
     <div className="flex h-full w-full items-center justify-center bg-neutral-0">
       {/* 헤더 */}
-      <Header onLoginButtonClicked={onHeaderLoginClicked} />
+      <Header onLoginButtonClicked={handleHeaderLoginButtonClick} />
 
       <main className="flex w-full flex-col items-center">
         {/* 흰색 배경 */}
@@ -26,7 +26,7 @@ export default function LandingPage() {
           {/* 메인 화면 */}
           <MainSection
             onStartWithoutLogin={handleStartWithoutLogin}
-            onDashboardButtonClicked={onDashboardButtonClicked}
+            onDashboardButtonClicked={handleDashboardButtonClick}
           />
           {/* 시간표 설정화면 */}
           <TimeTableSection />
@@ -41,7 +41,7 @@ export default function LandingPage() {
         {/* 흰색 배경 */}
         <div className="flex w-[95%] max-w-[1226px] flex-col gap-96 py-48 md:w-[64%]">
           {/* 홈 설정 */}
-          <TableSection onLogin={onTableSectionLoginClicked} />
+          <TableSection onLogin={handleTableSectionLoginButtonClick} />
           {/* 리뷰 */}
           <ReviewSection onStartWithoutLogin={handleStartWithoutLogin} />
           {/* 버그 및 불편사항 제보 */}

--- a/src/page/LandingPage/LandingPage.tsx
+++ b/src/page/LandingPage/LandingPage.tsx
@@ -5,40 +5,15 @@ import TimerSection from './components/TimerSection';
 import TableSection from './components/TableSection';
 import ReviewSection from './components/ReviewSection';
 import ReportSection from './components/ReportSection';
-import { oAuthLogin } from '../../util/googleAuth';
-import { createTableShareUrl } from '../../util/arrayEncoding';
-import { SAMPLE_TABLE_DATA } from '../../constants/sample_table';
-import { isLoggedIn } from '../../util/accessToken';
-import { useNavigate } from 'react-router-dom';
-import useLogout from '../../hooks/mutations/useLogout';
+import useLandingPageLogics from './hooks/useLandingPageLogics';
 
 export default function LandingPage() {
-  const navigate = useNavigate();
-  const { mutate: logoutMutate } = useLogout(() => navigate('/home'));
-  const handleStartWithoutLogin = () => {
-    // window.location.href = LANDING_URLS.START_WITHOUT_LOGIN_URL;
-    window.location.href = createTableShareUrl(
-      import.meta.env.VITE_SHARE_BASE_URL,
-      SAMPLE_TABLE_DATA,
-    );
-  };
-  const handleDashboardButtonClick = () => {
-    navigate('/');
-  };
-  const onHeaderLoginClicked = () => {
-    if (!isLoggedIn()) {
-      oAuthLogin();
-    } else {
-      logoutMutate();
-    }
-  };
-  const onTableSectionLoginClicked = () => {
-    if (!isLoggedIn()) {
-      oAuthLogin();
-    } else {
-      handleDashboardButtonClick();
-    }
-  };
+  const [
+    handleStartWithoutLogin,
+    onTableSectionLoginClicked,
+    onDashboardButtonClicked,
+    onHeaderLoginClicked,
+  ] = useLandingPageLogics();
 
   return (
     <div className="flex h-full w-full items-center justify-center bg-neutral-0">
@@ -51,7 +26,7 @@ export default function LandingPage() {
           {/* 메인 화면 */}
           <MainSection
             onStartWithoutLogin={handleStartWithoutLogin}
-            onDashboardButtonClicked={handleDashboardButtonClick}
+            onDashboardButtonClicked={onDashboardButtonClicked}
           />
           {/* 시간표 설정화면 */}
           <TimeTableSection />

--- a/src/page/LandingPage/components/Header.tsx
+++ b/src/page/LandingPage/components/Header.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
+import { isLoggedIn } from '../../../util/accessToken';
 
 interface HeaderProps {
-  onLogin: () => void;
+  onLoginButtonClicked: () => void;
 }
 
-export default function Header({ onLogin }: HeaderProps) {
+export default function Header({ onLoginButtonClicked }: HeaderProps) {
   const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {
@@ -28,9 +29,9 @@ export default function Header({ onLogin }: HeaderProps) {
         </div>
         <button
           className="text-[min(max(0.875rem,1.25vw),1.2rem)]"
-          onClick={onLogin}
+          onClick={() => onLoginButtonClicked()}
         >
-          3초 로그인
+          {!isLoggedIn() ? '3초 로그인' : '로그아웃'}
         </button>
       </div>
     </header>

--- a/src/page/LandingPage/components/Header.tsx
+++ b/src/page/LandingPage/components/Header.tsx
@@ -29,7 +29,7 @@ export default function Header({ onLoginButtonClicked }: HeaderProps) {
         </div>
         <button
           className="text-[min(max(0.875rem,1.25vw),1.2rem)]"
-          onClick={() => onLoginButtonClicked()}
+          onClick={onLoginButtonClicked}
         >
           {!isLoggedIn() ? '3초 로그인' : '로그아웃'}
         </button>

--- a/src/page/LandingPage/components/MainSection.tsx
+++ b/src/page/LandingPage/components/MainSection.tsx
@@ -21,22 +21,12 @@ export default function MainSection({
       <h1 className="text-[min(max(1.5rem,3.5vw),3rem)] font-bold">
         토론 진행을 더 쉽고 빠르게
       </h1>
-      {isLoggedIn() && (
-        <button
-          onClick={onDashboardButtonClicked}
-          className="rounded-full border border-neutral-300 bg-brand-main px-5 py-2 text-[min(max(0.875rem,1.25vw),1.2rem)] font-medium text-black transition-all duration-100 hover:bg-brand-sub1 hover:text-neutral-0"
-        >
-          대시보드로 이동
-        </button>
-      )}
-      {!isLoggedIn() && (
-        <button
-          onClick={onStartWithoutLogin}
-          className="rounded-full border border-neutral-300 bg-brand-main px-5 py-2 text-[min(max(0.875rem,1.25vw),1.2rem)] font-medium text-black transition-all duration-100 hover:bg-brand-sub1 hover:text-neutral-0"
-        >
-          비회원으로 시작하기
-        </button>
-      )}
+      <button
+        onClick={isLoggedIn() ? onDashboardButtonClicked : onStartWithoutLogin}
+        className="rounded-full border border-neutral-300 bg-brand-main px-5 py-2 text-[min(max(0.875rem,1.25vw),1.2rem)] font-medium text-black transition-all duration-100 hover:bg-brand-sub1 hover:text-neutral-0"
+      >
+        {isLoggedIn() ? '대시보드로 이동' : '비회원으로 시작하기'}
+      </button>
     </section>
   );
 }

--- a/src/page/LandingPage/components/MainSection.tsx
+++ b/src/page/LandingPage/components/MainSection.tsx
@@ -1,10 +1,15 @@
 import preview from '../../../assets/landing/preview.webm';
+import { isLoggedIn } from '../../../util/accessToken';
 
 interface MainSectionProps {
   onStartWithoutLogin: () => void;
+  onDashboardButtonClicked: () => void;
 }
 
-export default function MainSection({ onStartWithoutLogin }: MainSectionProps) {
+export default function MainSection({
+  onStartWithoutLogin,
+  onDashboardButtonClicked,
+}: MainSectionProps) {
   return (
     <section
       id="main-section"
@@ -16,12 +21,22 @@ export default function MainSection({ onStartWithoutLogin }: MainSectionProps) {
       <h1 className="text-[min(max(1.5rem,3.5vw),3rem)] font-bold">
         토론 진행을 더 쉽고 빠르게
       </h1>
-      <button
-        onClick={onStartWithoutLogin}
-        className="rounded-full border border-neutral-300 bg-brand-main px-5 py-2 text-[min(max(0.875rem,1.25vw),1.2rem)] font-medium text-black transition-all duration-100 hover:bg-brand-sub1 hover:text-neutral-0"
-      >
-        비회원으로 시작하기
-      </button>
+      {isLoggedIn() && (
+        <button
+          onClick={onDashboardButtonClicked}
+          className="rounded-full border border-neutral-300 bg-brand-main px-5 py-2 text-[min(max(0.875rem,1.25vw),1.2rem)] font-medium text-black transition-all duration-100 hover:bg-brand-sub1 hover:text-neutral-0"
+        >
+          대시보드로 이동
+        </button>
+      )}
+      {!isLoggedIn() && (
+        <button
+          onClick={onStartWithoutLogin}
+          className="rounded-full border border-neutral-300 bg-brand-main px-5 py-2 text-[min(max(0.875rem,1.25vw),1.2rem)] font-medium text-black transition-all duration-100 hover:bg-brand-sub1 hover:text-neutral-0"
+        >
+          비회원으로 시작하기
+        </button>
+      )}
     </section>
   );
 }

--- a/src/page/LandingPage/hooks/useLandingPageHandlers.ts
+++ b/src/page/LandingPage/hooks/useLandingPageHandlers.ts
@@ -6,7 +6,7 @@ import { createTableShareUrl } from '../../../util/arrayEncoding';
 import { SAMPLE_TABLE_DATA } from '../../../constants/sample_table';
 import { useCallback } from 'react';
 
-const useLandingPageLogics = () => {
+const useLandingPageHandlers = () => {
   // Prepare dependencies
   const navigate = useNavigate();
   const { mutate: logoutMutate } = useLogout(() => navigate('/home'));
@@ -19,17 +19,17 @@ const useLandingPageLogics = () => {
       SAMPLE_TABLE_DATA,
     );
   }, []);
-  const onTableSectionLoginButtonClicked = useCallback(() => {
+  const handleTableSectionLoginButtonClick = useCallback(() => {
     if (!isLoggedIn()) {
       oAuthLogin();
     } else {
       navigate('/');
     }
   }, [navigate]);
-  const onDashboardButtonClicked = useCallback(() => {
+  const handleDashboardButtonClick = useCallback(() => {
     navigate('/');
   }, [navigate]);
-  const onHeaderLoginButtonClicked = useCallback(() => {
+  const handleHeaderLoginButtonClick = useCallback(() => {
     if (!isLoggedIn()) {
       oAuthLogin();
     } else {
@@ -37,12 +37,12 @@ const useLandingPageLogics = () => {
     }
   }, [logoutMutate]);
 
-  return [
+  return {
     handleStartWithoutLogin,
-    onTableSectionLoginButtonClicked,
-    onDashboardButtonClicked,
-    onHeaderLoginButtonClicked,
-  ];
+    handleTableSectionLoginButtonClick,
+    handleDashboardButtonClick,
+    handleHeaderLoginButtonClick,
+  };
 };
 
-export default useLandingPageLogics;
+export default useLandingPageHandlers;

--- a/src/page/LandingPage/hooks/useLandingPageLogics.ts
+++ b/src/page/LandingPage/hooks/useLandingPageLogics.ts
@@ -4,6 +4,7 @@ import { oAuthLogin } from '../../../util/googleAuth';
 import useLogout from '../../../hooks/mutations/useLogout';
 import { createTableShareUrl } from '../../../util/arrayEncoding';
 import { SAMPLE_TABLE_DATA } from '../../../constants/sample_table';
+import { useCallback } from 'react';
 
 const useLandingPageLogics = () => {
   // Prepare dependencies
@@ -11,30 +12,30 @@ const useLandingPageLogics = () => {
   const { mutate: logoutMutate } = useLogout(() => navigate('/home'));
 
   // Declare functions that represent business logics
-  const handleStartWithoutLogin = () => {
+  const handleStartWithoutLogin = useCallback(() => {
     // window.location.href = LANDING_URLS.START_WITHOUT_LOGIN_URL;
     window.location.href = createTableShareUrl(
       import.meta.env.VITE_SHARE_BASE_URL,
       SAMPLE_TABLE_DATA,
     );
-  };
-  const onTableSectionLoginButtonClicked = () => {
+  }, []);
+  const onTableSectionLoginButtonClicked = useCallback(() => {
     if (!isLoggedIn()) {
       oAuthLogin();
     } else {
       navigate('/');
     }
-  };
-  const onDashboardButtonClicked = () => {
+  }, [navigate]);
+  const onDashboardButtonClicked = useCallback(() => {
     navigate('/');
-  };
-  const onHeaderLoginButtonClicked = () => {
+  }, [navigate]);
+  const onHeaderLoginButtonClicked = useCallback(() => {
     if (!isLoggedIn()) {
       oAuthLogin();
     } else {
       logoutMutate();
     }
-  };
+  }, [logoutMutate]);
 
   return [
     handleStartWithoutLogin,

--- a/src/page/LandingPage/hooks/useLandingPageLogics.ts
+++ b/src/page/LandingPage/hooks/useLandingPageLogics.ts
@@ -1,0 +1,47 @@
+import { useNavigate } from 'react-router-dom';
+import { isLoggedIn } from '../../../util/accessToken';
+import { oAuthLogin } from '../../../util/googleAuth';
+import useLogout from '../../../hooks/mutations/useLogout';
+import { createTableShareUrl } from '../../../util/arrayEncoding';
+import { SAMPLE_TABLE_DATA } from '../../../constants/sample_table';
+
+const useLandingPageLogics = () => {
+  // Prepare dependencies
+  const navigate = useNavigate();
+  const { mutate: logoutMutate } = useLogout(() => navigate('/home'));
+
+  // Declare functions that represent business logics
+  const handleStartWithoutLogin = () => {
+    // window.location.href = LANDING_URLS.START_WITHOUT_LOGIN_URL;
+    window.location.href = createTableShareUrl(
+      import.meta.env.VITE_SHARE_BASE_URL,
+      SAMPLE_TABLE_DATA,
+    );
+  };
+  const onTableSectionLoginButtonClicked = () => {
+    if (!isLoggedIn()) {
+      oAuthLogin();
+    } else {
+      navigate('/');
+    }
+  };
+  const onDashboardButtonClicked = () => {
+    navigate('/');
+  };
+  const onHeaderLoginButtonClicked = () => {
+    if (!isLoggedIn()) {
+      oAuthLogin();
+    } else {
+      logoutMutate();
+    }
+  };
+
+  return [
+    handleStartWithoutLogin,
+    onTableSectionLoginButtonClicked,
+    onDashboardButtonClicked,
+    onHeaderLoginButtonClicked,
+  ];
+};
+
+export default useLandingPageLogics;


### PR DESCRIPTION
# 🚩 연관 이슈

closed #284 

# 📝 작업 내용
## 요구 사항
- (이전 페이즈) 헤더의 로그인/로그아웃 버튼 디자인을 써니 시안대로 변경해야 함
- (이번 페이즈 기획 회의) 홈 버튼이 `TableListPage`가 아닌 `LandingPage`로 이동하게 수정해야 함

## 변경 사항
### 헤더의 로그인/로그아웃 버튼 관련
- 헤더의 로그인/로그아웃 버튼 디자인을 써니 시안대로 변경

### 헤더의 홈 버튼 관련
- 헤더의 홈 버튼이 모든 페이지에서 나타나게 수정
- 헤더의 홈 버튼이 `TableListPage`가 아닌 `LandingPage`로 이동하게 수정

### `LandingPage` 관련
헤더의 홈 버튼이 `LandingPage`로 이동하는 것으로 바뀌었지만, `LandingPage`는 여전히 로그인 상태에서 '3초 로그인' 버튼과 '비회원으로 이용하기' 버튼을 표시합니다. 이는 이미 로그인한 회원 입장에서는 다소 적절하지 않은 플로우입니다. 따라서 비회원을 전제로 개발된 기존 플로우를, 로그인한 회원의 경우도 대응할 수 있게 아래와 같이 개선하였습니다:
- `LandingPage`의 '3초 로그인' 버튼이 로그인 상태일 경우 '로그아웃' 버튼으로 대체되도록 개선
- `LandingPage`의 '비회원으로 시작하기' 버튼이 로그인 상태일 경우 '대시보드로 이동' (`TableListPage`) 버튼으로 대체되도록 개선

## 보충
기존 `LandingPage`가 루트(`LandingPage`)에서 필요한 함수를 선언하고 이를 하위 컴포넌트에 내리는 식으로 구현하고 있었습니다. 따라서, 이 PR에서도 해당 원칙을 계승하여, 새로운 함수를 모두 루트에 선언하여 구현하였음을 알립니다.

# 🏞️ 스크린샷 (선택)
## 로그인 상태에서의 헤더 버튼
![image](https://github.com/user-attachments/assets/f4888757-1ccd-4902-8021-cb933fc76db1)

## 비회원 상태에서의 헤더 버튼
![image](https://github.com/user-attachments/assets/a8257017-e1aa-490c-874c-a49ba7bef7cd)

## 로그인 상태에서의 변경 사항이 적용된 `LandingPage`
![image](https://github.com/user-attachments/assets/b7f2cd12-da06-4074-a1c0-f98b32d8dae9)

# 🗣️ 리뷰 요구사항 (선택)
별도 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 랜딩 페이지에서 로그인 상태에 따라 버튼이 "대시보드로 이동" 또는 "비회원으로 시작하기"로 동적으로 표시됩니다.
  * 랜딩 페이지의 버튼 및 헤더 동작이 개선되어, 로그인/로그아웃 및 대시보드 이동이 더욱 직관적으로 작동합니다.

* **버그 수정**
  * 토큰 만료 시, 액세스 토큰이 올바르게 삭제되어 보안이 강화되었습니다.

* **리팩터링**
  * 랜딩 페이지의 이벤트 핸들러 로직이 커스텀 훅으로 분리되어 코드 구조가 개선되었습니다.
  * 헤더 우측 영역의 로그인/로그아웃 및 게스트 표시 방식이 명확하게 변경되었습니다.

* **문서화**
  * 컴포넌트 prop 명칭 및 인터페이스가 명확하게 정리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->