### PR TITLE
[CHORE] GitHub 저장소 이슈 목록을 Notion으로 동기화

### DIFF
--- a/.github/workflows/Notion_Sync.yml
+++ b/.github/workflows/Notion_Sync.yml
@@ -29,4 +29,4 @@ jobs:
           NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
           NOTION_USER_UUID_MAP: ${{ secrets.NOTION_USER_UUID_MAP }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
-        run: python notion_sync.py
+        run: python ./notion_sync.py

--- a/.github/workflows/Notion_Sync.yml
+++ b/.github/workflows/Notion_Sync.yml
@@ -30,4 +30,4 @@ jobs:
           NOTION_USER_UUID_MAP: ${{ secrets.NOTION_USER_UUID_MAP }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
-        run: python src/notion_sync.py
+        run: python notion_sync.py

--- a/.github/workflows/Notion_Sync.yml
+++ b/.github/workflows/Notion_Sync.yml
@@ -1,0 +1,33 @@
+name: Notion Sync
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, reopened, closed]
+  pull_request_target: # For accessing secrets from forked repos
+    types: [opened, reopened, closed]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: pip install requests pytz
+
+      - name: Run Notion Sync Script
+        env:
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
+          NOTION_USER_UUID_MAP: ${{ secrets.NOTION_USER_UUID_MAP }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: python src/notion_sync.py

--- a/.github/workflows/Notion_Sync.yml
+++ b/.github/workflows/Notion_Sync.yml
@@ -28,6 +28,5 @@ jobs:
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
           NOTION_DATABASE_ID: ${{ secrets.NOTION_DATABASE_ID }}
           NOTION_USER_UUID_MAP: ${{ secrets.NOTION_USER_UUID_MAP }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_EVENT_PATH: ${{ github.event_path }}
         run: python notion_sync.py

--- a/notion_sync.py
+++ b/notion_sync.py
@@ -1,0 +1,227 @@
+import os
+import json
+import re
+import datetime
+import requests
+import pytz
+
+# De
+
+# Import envs
+NOTION_TOKEN = os.getenv("NOTION_TOKEN")
+NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
+NOTION_USER_UUID_MAP_STR = os.getenv("NOTION_USER_UUID_MAP")
+NOTION_API_URL = "https://api.notion.com/v1"
+
+if NOTION_USER_UUID_MAP_STR:
+    NOTION_USER_UUID_MAP = json.loads(NOTION_USER_UUID_MAP_STR)
+else:
+    print("NOTION_USER_UUID_MAP secret not found or empty.")
+    NOTION_USER_UUID_MAP = {}
+
+# Set header for HTTP request
+HEADERS = {
+    "Authorization": f"Bearer {NOTION_TOKEN}",
+    "Notion-Version": "2022-06-28",
+    "Content-Type": "application/json",
+}
+
+# Load GitHub event payload
+def get_github_event_payload():
+    event_path = os.getenv("GITHUB_EVENT_PATH")
+    if not event_path:
+        print("GITHUB_EVENT_PATH is not valid.")
+        return None
+    with open(event_path, "r") as f:
+        return json.load(f)
+
+# Find Notion DB item by GitHub issue id
+def find_notion_page_by_github_id(github_id):
+    query_url = f"{NOTION_API_URL}/databases/{NOTION_DATABASE_ID}/query"
+    payload = {
+        "filter": {
+            "property": "ID",
+            "number": {
+                "equals": github_id
+            }
+        }
+    }
+    response = requests.post(query_url, headers=HEADERS, json=payload)
+    response.raise_for_status()
+    results = response.json().get("results")
+    return results[0] if results else None
+
+# Create new Notion DB item
+def create_notion_page(title, status, github_assignee_id, github_url, github_id):
+    create_url = f"{NOTION_API_URL}/pages"
+
+    # Parse Notion user id
+    notion_user_id = NOTION_USER_UUID_MAP.get(github_assignee_id, "") if github_assignee_id else ""
+
+    # Parse current time (KST)
+    korea_timezone = pytz.timezone('Asia/Seoul')
+    current_datetime = datetime.datetime.now(korea_timezone)
+    current_datetime_str = current_datetime.isoformat()
+
+    data = {
+        "parent": {"database_id": NOTION_DATABASE_ID},
+        "properties": {
+            "이름": {
+                "title": [
+                    {
+                        "text": {
+                            "content": title
+                        }
+                    }
+                ]
+            },
+            "URL": {
+                "url": github_url
+            },
+            "상태": {
+                "select": {
+                    "name": status
+                }
+            },
+            "ID": {
+                "number": github_id
+            },
+            "생성 날짜": {
+                "date": {
+                    "start": current_datetime_str
+                }
+            }
+        }
+    }
+    if (notion_user_id):
+        data["properties"]["작업자"] = {
+                "people": [
+                    {
+                        "id": notion_user_id
+                    }
+                ]
+            }
+
+    response = requests.post(create_url, headers=HEADERS, json=data)
+    response.raise_for_status()
+    print(f"Notion item created / Title: '{title}', Status: '{status}'")
+    return response.json()
+
+# Patch Notion DB item
+def update_notion_page_status(page_id, status):
+    update_url = f"{NOTION_API_URL}/pages/{page_id}"
+    data = {
+        "properties": {
+            "상태": {
+                "select": {
+                    "name": status
+                }
+            }
+        }
+    }
+    response = requests.patch(update_url, headers=HEADERS, json=data)
+    response.raise_for_status()
+    print(f"Updated status of Notion page '{page_id}' as '{status}'")
+    return response.json()
+
+# Handle issue-related event
+def handle_issue_event(payload):
+    issue = payload.get("issue")
+    if not issue:
+        print("Issue data is not in payload.")
+        return
+
+    action = payload.get("action")
+    issue_title = issue.get("title")
+    issue_url = issue.get("html_url")
+    issue_number = issue.get("number")
+    issue_assignees = issue.get("assignees", [])
+    issue_assignee_id = issue_assignees[0].get("id") if issue_assignees else None
+
+    if action == "opened":
+        print(f"Issue opened: #{issue_number} - {issue_title}")
+        # Check duplication
+        notion_page = find_notion_page_by_github_id(issue_number)
+        if not notion_page:
+            create_notion_page(issue_title, "열림", issue_assignee_id, issue_url, issue_number)
+        else:
+            print(f"Issue #{issue_number} is already in Notion DB. This task will be skipped.")
+    else:
+        print(f"Not supported action: {action}")
+
+# Handle PR event
+def handle_pull_request_event(payload):
+    pr = payload.get("pull_request")
+    if not pr:
+        print("PR data is not in payload.")
+        return
+
+    action = payload.get("action")
+    pr_title = pr.get("title")
+    pr_number = pr.get("number")
+    pr_url = pr.get("html_url")
+    pr_assignees = pr.get("assignees", [])
+    pr_assignee_id = pr_assignees[0].get("id") if pr_assignees else None
+
+    # Find all related issue ID
+    body = pr.get("body", "")
+    issue_ids = re.findall(r"(?:close|closes|closed|fix|fixes|fixed)\s+#(\d+)", body, re.IGNORECASE)
+    issue_ids = [int(num) for num in issue_ids]
+
+    # If no specified issue, create Notion DB item with PR id 
+    if not issue_ids:
+        print(f"Cannot find related issue numbers in PR #{pr_number}. Add PR id itself on the list.")
+        issue_ids = [pr_number]
+
+    for related_issue_number in issue_ids:
+        notion_page = find_notion_page_by_github_id(related_issue_number)
+
+        if not notion_page:
+            # There is no related issue on Notion or have to add PR itself 
+            if related_issue_number == pr_number: # Register PR itself
+                print(f"Add PR #{pr_number} on the Notion DB.")
+                create_notion_page(f"PR: {pr_title}", "병합 요청됨", pr_assignee_id, pr_url, pr_number)
+            else:
+                print(f"Issue #{related_issue_number} is not in Notion DB. Create new one.")
+                create_notion_page(f"이슈 #{related_issue_number} (PR 연동)", "병합 요청됨", pr_assignee_id, pr_url, related_issue_number)
+            continue
+
+        page_id = notion_page["id"]
+
+        if action == "opened" or action == "reopened":
+            print(f"PR opened/reopened: #{pr_number} - {pr_title}. Change status of related issue #{related_issue_number}.")
+            update_notion_page_status(page_id, "병합 요청됨")
+        elif action == "closed":
+            if pr.get("merged"):
+                print(f"PR merged: #{pr_number} - {pr_title}. Change status of related issue #{related_issue_number}.")
+                update_notion_page_status(page_id, "병합됨")
+            else:
+                print(f"PR closed (not merged): #{pr_number} - {pr_title}. Change status of related issue #{related_issue_number}.")
+                update_notion_page_status(page_id, "닫힘")
+        else:
+            print(f"Not supported PR action: {action}")
+
+if __name__ == "__main__":
+    event_payload = get_github_event_payload()
+
+    if not event_payload:
+        print("Cannot read event payload. Terminate.")
+    else:
+        event_name = os.getenv("GITHUB_EVENT_NAME")
+        print(f"GitHub Event Name: {event_name}")
+
+        try:
+            if event_name == "issues":
+                handle_issue_event(event_payload)
+            elif event_name == "pull_request" or event_name == "pull_request_target":
+                handle_pull_request_event(event_payload)
+            else:
+                print(f"Not supported GitHub event: {event_name}")
+        except requests.exceptions.RequestException as e:
+            print(f"Notion API request error: {e}")
+            if e.response:
+                print(f"Failure response: {e.response.text}")
+            exit(1)
+        except Exception as e:
+            print(f"Unpredicted error occured: {e}")
+            exit(1)

--- a/notion_sync.py
+++ b/notion_sync.py
@@ -31,8 +31,12 @@ def get_github_event_payload():
     if not event_path:
         print("GITHUB_EVENT_PATH is not valid.")
         return None
-    with open(event_path, "r") as f:
-        return json.load(f)
+    try:
+        with open(event_path, "r") as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        print(f"Failed to read event payload: {e}")
+        return None
 
 # Find Notion DB item by GitHub issue id
 def find_notion_page_by_github_id(github_id):

--- a/notion_sync.py
+++ b/notion_sync.py
@@ -5,14 +5,13 @@ import datetime
 import requests
 import pytz
 
-# De
-
 # Import envs
 NOTION_TOKEN = os.getenv("NOTION_TOKEN")
 NOTION_DATABASE_ID = os.getenv("NOTION_DATABASE_ID")
 NOTION_USER_UUID_MAP_STR = os.getenv("NOTION_USER_UUID_MAP")
 NOTION_API_URL = "https://api.notion.com/v1"
 
+# Parse GitHub ID-Notion UUID map
 if NOTION_USER_UUID_MAP_STR:
     NOTION_USER_UUID_MAP = json.loads(NOTION_USER_UUID_MAP_STR)
 else:


### PR DESCRIPTION
# 🚩 연관 이슈

closed #301 

# 📝 작업 내용
이슈 생성, PR 오픈 및 재오픈, PR 병합 및 닫힘 발생 시, 해당 사항을 Debate Timer Notion 페이지로 발송합니다.

특히, 이슈에 할당된 작업자(assignee)의 GitHub ID를 Notion의 실제 사용자 UUID와 매핑하여, GitHub 상 작업자와 Notion의 사용자가 동일하게 표시될 수 있게 구현하였습니다. 예를 들어, 이 이슈의 경우는 저(i-meant-to-be)가 작업자이므로, 스크립트가 제 GitHub ID에 해당하는 Notion UUID를 찾아 Notion 데이터베이스에 저를 작업자로 기록하게 됩니다. 우리 프론트 팀원들의 Notion UUID는 아무래도 비밀로 관리하는 것이 좋을 것 같아, 저장소 수준 비밀로 저장하였다는 점도 같이 알립니다.

일단 이 PR 닫고 재오픈했을 땐 잘 동작하는 거 확인했습니다.

### 새로 추가된 저장소 수준 Secrets
다음 링크에서 확인 가능합니다: [Actions Secrets](https://github.com/debate-timer/debate-timer-fe/settings/secrets/actions)
- NOTION_DATABASE_ID | 이슈 정보가 담길 Notion 데이터베이스의 ID
- NOTION_TOKEN | Notion API의 개인 키
- NOTION_USER_UUID_MAP | GitHub ID와 Notion의 사용자 UUID가 매핑된 데이터

# 🏞️ 스크린샷 (선택)
## Notion 내 스크린샷
Notion 메인 페이지 하단의 'FE 태스크 대시보드`에서 확인 가능합니다.
![image](https://github.com/user-attachments/assets/7b94cb8b-a94b-4465-a728-0b74519cdd5d)

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub 이슈 및 풀 리퀘스트를 Notion 데이터베이스와 자동으로 동기화하는 기능이 추가되었습니다.  
  * 이슈 생성, PR 오픈/재오픈/종료 시 관련 정보가 Notion에 자동 반영됩니다.  
  * PR 상태에 따라 Notion 내 상태도 자동 업데이트됩니다.  
  * 이슈 및 PR 이벤트 발생 시 자동으로 동기화 작업이 실행되도록 GitHub Actions 워크플로우가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->