### PR TITLE
[Windows-FEAT] 파일 시스템 입출력 구현

### DIFF
--- a/electron/api.test.ts
+++ b/electron/api.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import path from 'path';
+import fs from 'fs/promises';
+import os from 'os';
+import { getItem, getAllItems, deleteItem, patchItem, postItem } from './api';
+import { DebateTableData } from './type';
+
+// --- 테스트 환경 설정 ---
+const TEST_DIR = path.join(os.tmpdir(), 'electron-db-test');
+const testDbPath = path.join(TEST_DIR, 'test-db.json');
+const ORIGINAL_SAMPLE_DATA: DebateTableData = {
+  info: {
+    id: '1-1-1-1-1',
+    agenda: '나의 토론 주제',
+    name: '나의 시간표',
+    prosTeamName: '찬성',
+    consTeamName: '반대',
+    finishBell: true,
+    warningBell: false,
+  },
+  table: [
+    {
+      boxType: 'NORMAL',
+      stance: 'PROS',
+      speechType: '입론',
+      time: 180,
+      timePerSpeaking: null,
+      timePerTeam: null,
+      speaker: '1번',
+    },
+    {
+      boxType: 'NORMAL',
+      stance: 'CONS',
+      speechType: '입론',
+      time: 180,
+      timePerSpeaking: null,
+      timePerTeam: null,
+      speaker: '1번',
+    },
+    {
+      boxType: 'NORMAL',
+      stance: 'PROS',
+      speechType: '반론',
+      time: 180,
+      timePerSpeaking: null,
+      timePerTeam: null,
+      speaker: '2번',
+    },
+    {
+      boxType: 'NORMAL',
+      stance: 'CONS',
+      speechType: '반론',
+      time: 180,
+      timePerSpeaking: null,
+      timePerTeam: null,
+      speaker: '2번',
+    },
+    {
+      boxType: 'TIME_BASED',
+      stance: 'NEUTRAL',
+      speechType: '자유토론',
+      time: null,
+      timePerSpeaking: 120,
+      timePerTeam: 420,
+      speaker: '2번',
+    },
+    {
+      boxType: 'NORMAL',
+      stance: 'PROS',
+      speechType: '최종 발언',
+      time: 180,
+      timePerSpeaking: null,
+      timePerTeam: null,
+      speaker: '3번',
+    },
+    {
+      boxType: 'NORMAL',
+      stance: 'CONS',
+      speechType: '최종 발언',
+      time: 180,
+      timePerSpeaking: null,
+      timePerTeam: null,
+      speaker: '3번',
+    },
+  ],
+} as const;
+const SAMPLE_UUID_1 = '79800bb7-70a1-4564-b790-e2148967af7e';
+const SAMPLE_UUID_2 = 'bd818b12-fbb0-405a-8fab-d22d63884e82';
+
+// 테스트용 초기 데이터 (Seed Data)
+let SEED_DATA: DebateTableData[];
+
+beforeAll(async () => {
+  // 테스트를 위한 임시 디렉토리 생성
+  await fs.mkdir(TEST_DIR, { recursive: true });
+});
+
+beforeEach(async () => {
+  // 각 테스트가 실행되기 전에 항상 동일한 초기 데이터로 파일을 덮어씀
+  const SAMPLE_DATA_1 = JSON.parse(JSON.stringify(ORIGINAL_SAMPLE_DATA));
+  const SAMPLE_DATA_2 = JSON.parse(JSON.stringify(ORIGINAL_SAMPLE_DATA));
+  SAMPLE_DATA_1.info.id = SAMPLE_UUID_1;
+  SAMPLE_DATA_2.info.id = SAMPLE_UUID_2;
+  SEED_DATA = [SAMPLE_DATA_1, SAMPLE_DATA_2];
+  await fs.writeFile(testDbPath, JSON.stringify(SEED_DATA, null, 2));
+});
+
+afterAll(async () => {
+  // 모든 테스트가 끝난 후 임시 디렉토리와 파일 삭제
+  await fs.rm(TEST_DIR, { recursive: true, force: true });
+});
+
+// --- 테스트 스위트 ---
+describe('Database Handlers', () => {
+  it('✅ getAllItems: should return all items from the database', async () => {
+    const items = await getAllItems(testDbPath);
+    expect(items).toHaveLength(2);
+    expect(items).toEqual(SEED_DATA);
+  });
+
+  describe('getItem', () => {
+    it('✅ should return a single item for a valid ID', async () => {
+      const item = await getItem(testDbPath, SAMPLE_UUID_1);
+      expect(item.info.id).toBe(SAMPLE_UUID_1);
+      expect(item.info.agenda).toBe('나의 토론 주제');
+    });
+
+    it('❌ should throw an error for a non-existent ID', async () => {
+      // 존재하지 않는 ID로 요청했을 때 에러가 발생하는지 확인
+      await expect(getItem(testDbPath, '9-2-3-1-2')).rejects.toThrow(
+        'Failed to find item.',
+      );
+    });
+  });
+
+  it('✅ postItem: should add a new item and return it', async () => {
+    const newItem = JSON.parse(JSON.stringify(ORIGINAL_SAMPLE_DATA));
+
+    const createdItem = await postItem(testDbPath, newItem as DebateTableData);
+
+    expect(createdItem.info.agenda).toBe('나의 토론 주제');
+    expect(createdItem.info.id).toBeDefined(); // 새 UUID가 할당되었는지 확인
+
+    // 파일의 실제 상태도 확인
+    const db = JSON.parse(await fs.readFile(testDbPath, 'utf-8'));
+    expect(db).toHaveLength(3);
+    expect(db[2].info.agenda).toBe('나의 토론 주제');
+  });
+
+  it('✅ deleteItem: should remove an item and return the updated list', async () => {
+    const updatedDb = await deleteItem(testDbPath, SAMPLE_UUID_1);
+
+    expect(updatedDb).toHaveLength(1);
+    expect(
+      updatedDb.find((item) => item.info.id === SAMPLE_UUID_1),
+    ).toBeUndefined();
+
+    // 파일의 실제 상태도 확인
+    const db = JSON.parse(await fs.readFile(testDbPath, 'utf-8'));
+    expect(db).toHaveLength(1);
+  });
+
+  it('✅ patchItem: should update an existing item and return it', async () => {
+    const itemToUpdate = JSON.parse(JSON.stringify(ORIGINAL_SAMPLE_DATA));
+    itemToUpdate.info.id = SAMPLE_UUID_1;
+    itemToUpdate.info.agenda = '새로운 토론 주제';
+
+    const updatedItem = await patchItem(testDbPath, itemToUpdate);
+
+    expect(updatedItem.info.agenda).toBe('새로운 토론 주제');
+
+    // 파일의 실제 상태도 확인
+    const db = JSON.parse(await fs.readFile(testDbPath, 'utf-8'));
+    const itemInDb = db.find((item) => item.info.id === SAMPLE_UUID_1);
+
+    expect(db).toHaveLength(2); // 전체 길이는 그대로인지 확인
+    expect(itemInDb.info.agenda).toBe('새로운 토론 주제');
+  });
+});

--- a/electron/api.ts
+++ b/electron/api.ts
@@ -1,0 +1,68 @@
+import { randomUUID, UUID } from 'crypto';
+import { DebateTableData } from './type';
+import fs from 'fs/promises';
+
+// Read database (helper function for API requests)
+async function readDb(dbPath: string) {
+  const data = await fs.readFile(dbPath, 'utf-8');
+  const parsedData = JSON.parse(data);
+  return Array.isArray(parsedData) ? parsedData : [];
+}
+
+// Named DB API functions
+// GET 1 item
+export async function getItem(
+  dbPath: string,
+  id: UUID,
+): Promise<DebateTableData> {
+  const db = await readDb(dbPath);
+  const target = db.find((record: DebateTableData) => record.info.id === id);
+  if (target) {
+    return target;
+  } else {
+    throw new Error('Failed to find item.');
+  }
+}
+
+// GET all items
+export async function getAllItems(dbPath: string): Promise<DebateTableData[]> {
+  return readDb(dbPath);
+}
+
+// POST
+export async function postItem(
+  dbPath: string,
+  item: DebateTableData,
+): Promise<DebateTableData> {
+  const db = await readDb(dbPath);
+  item.info.id = randomUUID();
+  db.push(item);
+  await fs.writeFile(dbPath, JSON.stringify(db, null, 2));
+  return item;
+}
+
+// DELETE
+export async function deleteItem(
+  dbPath: string,
+  item: DebateTableData,
+): Promise<DebateTableData[]> {
+  const db = await readDb(dbPath);
+  const updatedDb = db.filter(
+    (record: DebateTableData) => record.info.id !== item.info.id,
+  );
+  await fs.writeFile(dbPath, JSON.stringify(updatedDb, null, 2));
+  return updatedDb;
+}
+
+// PATCH
+export async function patchItem(
+  dbPath: string,
+  item: DebateTableData,
+): Promise<DebateTableData> {
+  const db = await readDb(dbPath);
+  const updatedDb = db.map((record: DebateTableData) =>
+    record.info.id === item.info.id ? item : record,
+  );
+  await fs.writeFile(dbPath, JSON.stringify(updatedDb, null, 2));
+  return item;
+}

--- a/electron/api.ts
+++ b/electron/api.ts
@@ -54,12 +54,12 @@ export async function postItem(
 // DELETE
 export async function deleteItem(
   dbPath: string,
-  item: DebateTableData,
+  id: UUID,
 ): Promise<DebateTableData[]> {
   return await dbMutex.runExclusive(async () => {
     const db = await readDb(dbPath);
     const updatedDb = db.filter(
-      (record: DebateTableData) => record.info.id !== item.info.id,
+      (record: DebateTableData) => record.info.id !== id,
     );
     await fs.writeFile(dbPath, JSON.stringify(updatedDb, null, 2));
     return updatedDb;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -61,9 +61,7 @@ ipcMain.handle('db-post', async (_event, item: DebateTableData) =>
 );
 
 // DELETE
-ipcMain.handle('db-delete', async (_event, item: DebateTableData) =>
-  deleteItem(dbPath, item),
-);
+ipcMain.handle('db-delete', async (_event, id: UUID) => deleteItem(dbPath, id));
 
 // PATCH
 ipcMain.handle('db-patch', async (_event, item: DebateTableData) =>

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,9 +1,13 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, ipcMain } from 'electron';
+import { randomUUID, UUID } from 'crypto';
 import path from 'path';
+import fs from 'fs/promises';
+import { DebateTableData } from './type';
 
 // Vite 개발 서버 URL. process.env.VITE_DEV_SERVER_URL는 vite-plugin-electron이 자동으로 설정해줍니다.
 const VITE_DEV_SERVER_URL = process.env['VITE_DEV_SERVER_URL'];
 
+// Window setting
 function createWindow() {
   const mainWindow = new BrowserWindow({
     width: 800,
@@ -28,7 +32,73 @@ function createWindow() {
   }
 }
 
-app.whenReady().then(createWindow);
+// Database related codes
+const dbPath = path.join(app.getPath('userData'), 'db.json');
+
+// Initialize database
+async function initDb() {
+  try {
+    await fs.access(dbPath);
+  } catch {
+    await fs.writeFile(dbPath, JSON.stringify([]));
+  }
+}
+
+// Read database (helper function used on API requests)
+async function readDb() {
+  const data = await fs.readFile(dbPath, 'utf-8');
+  const parsedData = JSON.parse(data);
+  return Array.isArray(parsedData) ? parsedData : [];
+}
+
+// GET
+ipcMain.handle('db-get', async (_event, id: UUID): Promise<DebateTableData> => {
+  const db = await readDb();
+  const target = db.find((record: DebateTableData) => record.info.id === id);
+  if (target) {
+    return target;
+  } else {
+    throw new Error('Failed to find item.');
+  }
+});
+
+// GET ALL
+ipcMain.handle('db-get-all', async () => readDb());
+
+// POST
+ipcMain.handle('db-post', async (_event, item: DebateTableData) => {
+  const db = await readDb();
+  item.info.id = randomUUID();
+  db.push(item);
+  await fs.writeFile(dbPath, JSON.stringify(db, null, 2));
+  return item;
+});
+
+// DELETE
+ipcMain.handle('db-delete', async (_event, id: UUID) => {
+  const db = await readDb();
+  const updatedDb = db.filter(
+    (record: DebateTableData) => record.info.id !== id,
+  );
+  await fs.writeFile(dbPath, JSON.stringify(updatedDb, null, 2));
+  return updatedDb;
+});
+
+// PATCH
+ipcMain.handle('db-patch', async (_event, item: DebateTableData) => {
+  const db = await readDb();
+  const updatedDb = db.map((record: DebateTableData) =>
+    record.info.id === item.info.id ? item : record,
+  );
+  await fs.writeFile(dbPath, JSON.stringify(updatedDb, null, 2));
+  return item;
+});
+
+// Launch app
+app.whenReady().then(() => {
+  initDb();
+  createWindow();
+});
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron';
 import { DebateTableData } from './type';
 import { UUID } from 'crypto';
 
+// Only expose under items to the renderer
 interface DB_API {
   get: (id: UUID) => Promise<DebateTableData>;
   getAll: () => Promise<DebateTableData[]>;

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,0 +1,25 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import { DebateTableData } from './type';
+import { UUID } from 'crypto';
+
+interface DB_API {
+  get: (id: UUID) => Promise<DebateTableData>;
+  getAll: () => Promise<DebateTableData[]>;
+  post: (item: DebateTableData) => Promise<DebateTableData>;
+  delete: (id: UUID) => Promise<DebateTableData[]>;
+  patch: (item: DebateTableData) => Promise<DebateTableData>;
+}
+
+declare global {
+  interface Window {
+    db: DB_API;
+  }
+}
+
+contextBridge.exposeInMainWorld('db', {
+  get: (id: UUID) => ipcRenderer.invoke('db-get', id),
+  getAll: () => ipcRenderer.invoke('db-get-all'),
+  post: (item: DebateTableData) => ipcRenderer.invoke('db-post', item),
+  delete: (id: UUID) => ipcRenderer.invoke('db-delete', id),
+  patch: (item: DebateTableData) => ipcRenderer.invoke('db-patch', item),
+});

--- a/electron/type.ts
+++ b/electron/type.ts
@@ -1,0 +1,36 @@
+import { UUID } from 'crypto';
+
+// Types
+export type Stance = 'PROS' | 'CONS' | 'NEUTRAL';
+export type TimeBoxType = 'NORMAL' | 'TIME_BASED';
+
+export interface TimeBoxInfo {
+  stance: Stance;
+  speechType: string;
+  boxType: TimeBoxType;
+  time: number | null;
+  timePerTeam: number | null;
+  timePerSpeaking: number | null;
+  speaker: string | null;
+}
+
+export interface DebateInfo {
+  id: UUID;
+  name: string;
+  agenda: string;
+  prosTeamName: string;
+  consTeamName: string;
+  warningBell: boolean;
+  finishBell: boolean;
+}
+
+export interface DebateTable {
+  id: number;
+  name: string;
+  agenda: string;
+}
+
+export interface DebateTableData {
+  info: DebateInfo;
+  table: TimeBoxInfo[];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@tanstack/eslint-plugin-query": "^5.62.9",
         "@tanstack/react-query": "^5.62.12",
+        "async-mutex": "^0.5.0",
         "axios": "^1.7.9",
         "pako": "^2.1.0",
         "qrcode.react": "^4.2.0",
@@ -4691,6 +4692,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/asynckit": {
@@ -13736,7 +13746,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tween-functions": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@tanstack/eslint-plugin-query": "^5.62.9",
     "@tanstack/react-query": "^5.62.12",
+    "async-mutex": "^0.5.0",
     "axios": "^1.7.9",
     "pako": "^2.1.0",
     "qrcode.react": "^4.2.0",

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -1,6 +1,8 @@
 import { UUID } from 'crypto';
 import { DebateTableData } from './type/type';
 
+// Declared same types from electron/preload.ts
+// to keep type consistency between the renderer side and the main side
 export interface DB_API {
   get: (id: UUID) => Promise<DebateTableData>;
   getAll: () => Promise<DebateTableData[]>;

--- a/src/renderer.d.ts
+++ b/src/renderer.d.ts
@@ -1,0 +1,16 @@
+import { UUID } from 'crypto';
+import { DebateTableData } from './type/type';
+
+export interface DB_API {
+  get: (id: UUID) => Promise<DebateTableData>;
+  getAll: () => Promise<DebateTableData[]>;
+  post: (item: DebateTableData) => Promise<DebateTableData>;
+  delete: (id: UUID) => Promise<DebateTableData[]>;
+  patch: (item: DebateTableData) => Promise<DebateTableData>;
+}
+
+declare global {
+  interface Window {
+    db: DB_API;
+  }
+}

--- a/src/repositories/FileDebateTableRepository.ts
+++ b/src/repositories/FileDebateTableRepository.ts
@@ -1,0 +1,27 @@
+import { DebateTableData } from '../type/type';
+import { UUID } from 'crypto';
+
+class FileDebateTableRepository {
+  async getTable(id: UUID): Promise<DebateTableData> {
+    return await window.db.get(id);
+  }
+
+  async getAllTables(): Promise<DebateTableData[]> {
+    return await window.db.getAll();
+  }
+
+  async postTable(item: DebateTableData): Promise<DebateTableData> {
+    return await window.db.post(item);
+  }
+
+  async deleteTable(id: UUID): Promise<DebateTableData[]> {
+    return await window.db.delete(id);
+  }
+
+  async patchTable(item: DebateTableData): Promise<DebateTableData> {
+    return await window.db.post(item);
+  }
+}
+
+const fileDebateTableRepository = new FileDebateTableRepository();
+export default fileDebateTableRepository;

--- a/src/repositories/IPCDebateTableRepository.ts
+++ b/src/repositories/IPCDebateTableRepository.ts
@@ -1,27 +1,34 @@
 import { DebateTableData } from '../type/type';
 import { UUID } from 'crypto';
 
-class FileDebateTableRepository {
+// Interface for IPC-based repository
+class IPCDebateTableRepository {
+  // Get 1 item
   async getTable(id: UUID): Promise<DebateTableData> {
     return await window.db.get(id);
   }
 
+  // Get all items
   async getAllTables(): Promise<DebateTableData[]> {
     return await window.db.getAll();
   }
 
+  // Create a new item
   async postTable(item: DebateTableData): Promise<DebateTableData> {
     return await window.db.post(item);
   }
 
+  // Delete the item
   async deleteTable(id: UUID): Promise<DebateTableData[]> {
     return await window.db.delete(id);
   }
 
+  // Modify the existing item
   async patchTable(item: DebateTableData): Promise<DebateTableData> {
     return await window.db.post(item);
   }
 }
 
-const fileDebateTableRepository = new FileDebateTableRepository();
+// Create singleton instance and expose it only
+const fileDebateTableRepository = new IPCDebateTableRepository();
 export default fileDebateTableRepository;

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -1,3 +1,5 @@
+import { UUID } from 'crypto';
+
 // Types
 export type Stance = 'PROS' | 'CONS' | 'NEUTRAL';
 export type TimeBoxType = 'NORMAL' | 'TIME_BASED';
@@ -31,18 +33,13 @@ export interface TimeBoxInfo {
 }
 
 export interface DebateInfo {
+  id: UUID;
   name: string;
   agenda: string;
   prosTeamName: string;
   consTeamName: string;
   warningBell: boolean;
   finishBell: boolean;
-}
-
-export interface DebateTable {
-  id: number;
-  name: string;
-  agenda: string;
 }
 
 export interface DebateTableData {


### PR DESCRIPTION
# 🚩 연관 이슈

closed #308

# 📝 작업 내용
## Electron에 관한 사전 지식
- Electron은 다음 구조로 구성됨: 렌더러(React) - 메인(Electron)
- 렌더러는 우리가 이미 개발해 둔 Debate Timer 프로젝트로서 화면에 컨텐츠를 표시하고, 메인은 일렉트론의 실행을 담당
- 두 프로세스 간 연결은 IPC(Inter-process communication)으로 이루어짐
- 기본적으로 두 프로세스는 보안을 위해 서로의 소스 코드를 공유하지 않고, 따라서 메인에서 렌더러로 개방할 함수를 직접 지정해주어야 하는데, 그것이 preload.ts 파일에서 정의됨
- 메인 측 코드는 /electron에, 렌더러 측 코드는 원래대로 /src에 존재

## 목적
기존 웹 기반 앱에서는 서버에서 데이터를 요청하고 받았지만, 선관위 환경은 오프라인 단독망이기 때문에, API 요청이 오프라인에서 이루어질 수 있게 개선해야 함

## 요약
- [메인] 저수준 파일 입출력 함수 구현
- [렌더러] 고수준 API 리포지토리 구현 
- [메인 & 렌더러] 프리로드 코드 추가

## 주요 파일 설명
- electron/api.ts 메인 측의 저수준 파일 입출력 함수
- electron/main.ts Electron의 진입점이자 메인 소스 코드
- electron/preload.ts 렌더러-메인 측 간 공유할 함수가 정의된 파일
- electron/type.ts 렌더러의 자료형을 그대로 사용하기 위해 가져옴
- src/repositories/IPCCustomizeTableRepository.ts 렌더러 측의 API 저장소 코드

## [메인] 저수준 파일 입출력 함수 구현
파일 입출력을 직접적으로 수행하는 코드를 메인 측에 구현하였습니다. 구조는 아래와 같이 이루어져 있습니다:
- electron/api.ts 실제 API 구현은 여기서 이루어짐
- electron/main.ts 구현된 API를 활용

테스트 코드에서도 동일한 함수를 사용하기 위해서, API 함수들을 별도 파일로 빼게 되었습니다. 또한, electron/api.ts 내에 상호 배제(mutex)를 설정하여, 파일 입출력 시 의도하지 않은 동시성 문제가 발생하지 않도록 차단하였습니다.

## [렌더러] 고수준 API 리포지토리 구현
메인 측의 API를 활용할 수 있도록, 렌더러 측에도 저장소 패턴을 적용하여 고수준 API를 사용할 수 있는 환경을 마련했습니다.

다만, 기존에 작업해두었던 저장소 패턴에서 정의되지 않은 다른 함수도 필요로 해서, 기존 리포지토리(src\repositories\DebateTableRepository.ts)를 상속하지 않고 따로 만들었다는 점을 알립니다. 또한, (이미 동시성 문제는 메인 측에서 처리하긴 했으나) 이쪽 저장소에도 다른 저장소와 마찬가지로 싱글톤 패턴을 적용해, 하나의 인스턴스만 존재할 수 있게 제한하였습니다.

## [메인 & 렌더러] 프리로드 코드 추가
electron\preload.ts 코드에, 메인에서 렌더러로 개방할 함수를 정의하여, 두 프로세스가 원활히 협력할 수 있게 준비해 두었습니다.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
코드 리뷰가 어려울까 싶어 Electron 관련 배경 지식을 적어놓긴 했는데요... 그래도 잘 이해가 안 가는 부분이 있으시다면 편하게 질문해주세요!