### PR TITLE
[FIX] 타이머 키보드 오류 수정

### DIFF
--- a/src/page/TimerPage/TimerPage.tsx
+++ b/src/page/TimerPage/TimerPage.tsx
@@ -87,10 +87,14 @@ export default function TimerPage() {
           </div>
         </DefaultLayout.ContentContainer>
       </DefaultLayout>
+
+      {/* Modal for users who have not used this timer */}
       <FirstUseToolTipModal
         Wrapper={UseToolTipWrapper}
         onClose={closeUseTooltipModal}
       />
+
+      {/* Modal that asks users whether they want to store the timetable in their account */}
       <LoginAndStoreModal
         Wrapper={LoginAndStoreModalWrapper}
         onClose={closeLoginAndStoreModal}

--- a/src/page/TimerPage/hooks/useTimerHotkey.ts
+++ b/src/page/TimerPage/hooks/useTimerHotkey.ts
@@ -100,7 +100,7 @@ export function useTimerHotkey(state: TimerPageLogics) {
         case 'KeyA':
           // 찬성 진영 선택 및 반대 타이머 정지
           if (!timer1.isDone) {
-            setProsConsSelected('CONS');
+            setProsConsSelected('PROS');
             if (timer2.isRunning) timer2.pauseTimer();
           }
           break;


### PR DESCRIPTION
# 🚩 연관 이슈

closed #314 

# 📝 작업 내용
다소 중요도가 높은 항목 같아서, 바로 처리하여 PR 올립니다.

## 문제 상황
```ts
case 'KeyA':
  // 찬성 진영 선택 및 반대 타이머 정지
  if (!timer1.isDone) {
    setProsConsSelected('CONS'); // 여기가 문제였음
    if (timer2.isRunning) timer2.pauseTimer();
  }
  break;
```
자유토론 타이머에서 A 키가 찬성 측 타이머가 아니라 반대 측 타이머를 활성화하는 오류 수정

## 해결책
```ts
case 'KeyA':
  // 찬성 진영 선택 및 반대 타이머 정지
  if (!timer1.isDone) {
    setProsConsSelected('PROS'); // 이렇게 수정
    if (timer2.isRunning) timer2.pauseTimer();
  }
  break;
```
의도된 동작에 맞게 코드 수정

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 'A' 키보드 단축키를 사용할 때 찬성(Pros) 진영이 올바르게 선택되도록 동작을 수정했습니다.

* **문서화**
  * 타이머 페이지의 두 모달 컴포넌트에 대해 설명하는 주석을 추가하여 코드 가독성을 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->