### PR TITLE
[FEAT] 타임박스 복사 기능 구현

### DIFF
--- a/src/page/TableComposition/TableComposition.test.tsx
+++ b/src/page/TableComposition/TableComposition.test.tsx
@@ -37,7 +37,7 @@ function TestWrapper({
   );
 }
 
-vi.mock('./components/DebatePanel/DebatePanel', () => {
+vi.mock('./components/TimeBox/TimeBox', () => {
   const DebatePanel = ({ children }: { children: React.ReactNode }) => (
     <div data-testid="timebox">{children}</div>
   );

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -1,5 +1,5 @@
 import { HTMLAttributes } from 'react';
-import EditDeleteButtons from '../EditDeleteButtons/EditDeleteButtons';
+import TimeBoxManageButtons from '../TimeBoxManageButtons/TimeBoxManageButtons';
 import { TimeBoxInfo } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 import { LuArrowUpDown } from 'react-icons/lu';
@@ -80,7 +80,7 @@ export default function DebatePanel(props: DebatePanelProps) {
           {isPros ? (
             <>
               <div className="absolute left-2 top-2">
-                <EditDeleteButtons
+                <TimeBoxManageButtons
                   info={props.info}
                   prosTeamName={props.prosTeamName}
                   consTeamName={props.consTeamName}
@@ -95,7 +95,7 @@ export default function DebatePanel(props: DebatePanelProps) {
             <>
               {renderDragHandle()}
               <div className="absolute right-2 top-2">
-                <EditDeleteButtons
+                <TimeBoxManageButtons
                   info={props.info}
                   prosTeamName={props.prosTeamName}
                   consTeamName={props.consTeamName}
@@ -121,7 +121,7 @@ export default function DebatePanel(props: DebatePanelProps) {
         <>
           {renderDragHandle()}
           <div className="absolute right-2 top-2">
-            <EditDeleteButtons
+            <TimeBoxManageButtons
               info={props.info}
               prosTeamName={props.prosTeamName}
               consTeamName={props.consTeamName}
@@ -143,7 +143,7 @@ export default function DebatePanel(props: DebatePanelProps) {
         <>
           {renderDragHandle()}
           <div className="absolute right-2 top-2">
-            <EditDeleteButtons
+            <TimeBoxManageButtons
               info={props.info}
               prosTeamName={props.prosTeamName}
               consTeamName={props.consTeamName}

--- a/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
+++ b/src/page/TableComposition/components/DebatePanel/DebatePanel.tsx
@@ -10,6 +10,7 @@ interface DebatePanelProps extends HTMLAttributes<HTMLDivElement> {
   consTeamName: string;
   onSubmitEdit?: (updatedInfo: TimeBoxInfo) => void;
   onSubmitDelete?: () => void;
+  onSubmitCopy?: () => void;
 }
 
 export default function DebatePanel(props: DebatePanelProps) {
@@ -22,7 +23,7 @@ export default function DebatePanel(props: DebatePanelProps) {
     timePerSpeaking,
     speaker,
   } = props.info;
-  const { onSubmitEdit, onSubmitDelete, onMouseDown } = props;
+  const { onSubmitEdit, onSubmitDelete, onSubmitCopy, onMouseDown } = props;
 
   // 타이머 시간 문자열 처리
   let timeStr = '';
@@ -74,7 +75,7 @@ export default function DebatePanel(props: DebatePanelProps) {
         isPros ? 'bg-camp-blue' : 'bg-camp-red'
       } h-20 select-none p-2 font-bold text-neutral-0`}
     >
-      {onSubmitEdit && onSubmitDelete && (
+      {onSubmitEdit && onSubmitDelete && onSubmitCopy && (
         <>
           {isPros ? (
             <>
@@ -85,6 +86,7 @@ export default function DebatePanel(props: DebatePanelProps) {
                   consTeamName={props.consTeamName}
                   onSubmitEdit={onSubmitEdit}
                   onSubmitDelete={onSubmitDelete}
+                  onSubmitCopy={onSubmitCopy}
                 />
               </div>
               {renderDragHandle()}
@@ -99,6 +101,7 @@ export default function DebatePanel(props: DebatePanelProps) {
                   consTeamName={props.consTeamName}
                   onSubmitEdit={onSubmitEdit}
                   onSubmitDelete={onSubmitDelete}
+                  onSubmitCopy={onSubmitCopy}
                 />
               </div>
             </>
@@ -114,7 +117,7 @@ export default function DebatePanel(props: DebatePanelProps) {
 
   const renderNeutralTimeoutPanel = () => (
     <div className="relative flex h-20 w-full flex-col items-center justify-center rounded-md bg-neutral-400 p-2 font-medium ">
-      {onSubmitEdit && onSubmitDelete && (
+      {onSubmitEdit && onSubmitDelete && onSubmitCopy && (
         <>
           {renderDragHandle()}
           <div className="absolute right-2 top-2">
@@ -124,6 +127,7 @@ export default function DebatePanel(props: DebatePanelProps) {
               consTeamName={props.consTeamName}
               onSubmitEdit={onSubmitEdit}
               onSubmitDelete={onSubmitDelete}
+              onSubmitCopy={onSubmitCopy}
             />
           </div>
         </>
@@ -135,7 +139,7 @@ export default function DebatePanel(props: DebatePanelProps) {
 
   const renderNeutralCustomPanel = () => (
     <div className="relative flex h-20 w-full flex-col items-center justify-center rounded-md bg-brand-main p-2 font-medium ">
-      {onSubmitEdit && onSubmitDelete && (
+      {onSubmitEdit && onSubmitDelete && onSubmitCopy && (
         <>
           {renderDragHandle()}
           <div className="absolute right-2 top-2">
@@ -145,6 +149,7 @@ export default function DebatePanel(props: DebatePanelProps) {
               consTeamName={props.consTeamName}
               onSubmitEdit={onSubmitEdit}
               onSubmitDelete={onSubmitDelete}
+              onSubmitCopy={onSubmitCopy}
             />
           </div>
         </>

--- a/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
+++ b/src/page/TableComposition/components/EditDeleteButtons/EditDeleteButtons.tsx
@@ -3,6 +3,7 @@ import { TimeBoxInfo } from '../../../../type/type';
 import { useModal } from '../../../../hooks/useModal';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 import DialogModal from '../../../../components/DialogModal/DialogModal';
+import { FaPaste } from 'react-icons/fa';
 
 interface EditDeleteButtonsProps {
   info: TimeBoxInfo;
@@ -10,6 +11,7 @@ interface EditDeleteButtonsProps {
   consTeamName?: string;
   onSubmitEdit: (updatedInfo: TimeBoxInfo) => void;
   onSubmitDelete: () => void;
+  onSubmitCopy: () => void;
 }
 
 export default function EditDeleteButtons(props: EditDeleteButtonsProps) {
@@ -23,11 +25,18 @@ export default function EditDeleteButtons(props: EditDeleteButtonsProps) {
     closeModal: closeDeleteModal,
     ModalWrapper: DeleteModalWrapper,
   } = useModal({ isCloseButtonExist: false });
-  const { info, onSubmitEdit, onSubmitDelete } = props;
+  const { info, onSubmitEdit, onSubmitDelete, onSubmitCopy } = props;
 
   return (
     <>
       <div className="flex justify-end gap-2">
+        <button
+          onClick={onSubmitCopy}
+          className="rounded-sm bg-neutral-0 p-[2px]"
+          aria-label="복사하기"
+        >
+          <FaPaste className="text-neutral-900" />
+        </button>
         <button
           onClick={openEditModal}
           className="rounded-sm bg-neutral-0 p-[2px]"

--- a/src/page/TableComposition/components/TimeBox/TimeBox.stories.tsx
+++ b/src/page/TableComposition/components/TimeBox/TimeBox.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
-import DebatePanel from './DebatePanel';
+import TimeBox from './TimeBox';
 
-const meta: Meta<typeof DebatePanel> = {
-  title: 'page/TableSetup/Components/DebatePanel',
-  component: DebatePanel,
+const meta: Meta<typeof TimeBox> = {
+  title: 'page/TableSetup/Components/TimeBox',
+  component: TimeBox,
   tags: ['autodocs'],
   args: {
     info: {
@@ -19,7 +19,7 @@ const meta: Meta<typeof DebatePanel> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof DebatePanel>;
+type Story = StoryObj<typeof TimeBox>;
 
 // 찬성 입론
 export const ProsOpening: Story = {

--- a/src/page/TableComposition/components/TimeBox/TimeBox.tsx
+++ b/src/page/TableComposition/components/TimeBox/TimeBox.tsx
@@ -4,7 +4,7 @@ import { TimeBoxInfo } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 import { LuArrowUpDown } from 'react-icons/lu';
 
-interface DebatePanelProps extends HTMLAttributes<HTMLDivElement> {
+interface TimeBoxProps extends HTMLAttributes<HTMLDivElement> {
   info: TimeBoxInfo;
   prosTeamName: string;
   consTeamName: string;
@@ -13,7 +13,7 @@ interface DebatePanelProps extends HTMLAttributes<HTMLDivElement> {
   onSubmitCopy?: () => void;
 }
 
-export default function DebatePanel(props: DebatePanelProps) {
+export default function TimeBox(props: TimeBoxProps) {
   const {
     stance,
     speechType,

--- a/src/page/TableComposition/components/TimeBox/TimeBox.tsx
+++ b/src/page/TableComposition/components/TimeBox/TimeBox.tsx
@@ -75,37 +75,33 @@ export default function TimeBox(props: TimeBoxProps) {
         isPros ? 'bg-camp-blue' : 'bg-camp-red'
       } h-20 select-none p-2 font-bold text-neutral-0`}
     >
-      {onSubmitEdit && onSubmitDelete && onSubmitCopy && (
+      {isPros ? (
         <>
-          {isPros ? (
-            <>
-              <div className="absolute left-2 top-2">
-                <TimeBoxManageButtons
-                  info={props.info}
-                  prosTeamName={props.prosTeamName}
-                  consTeamName={props.consTeamName}
-                  onSubmitEdit={onSubmitEdit}
-                  onSubmitDelete={onSubmitDelete}
-                  onSubmitCopy={onSubmitCopy}
-                />
-              </div>
-              {renderDragHandle()}
-            </>
-          ) : (
-            <>
-              {renderDragHandle()}
-              <div className="absolute right-2 top-2">
-                <TimeBoxManageButtons
-                  info={props.info}
-                  prosTeamName={props.prosTeamName}
-                  consTeamName={props.consTeamName}
-                  onSubmitEdit={onSubmitEdit}
-                  onSubmitDelete={onSubmitDelete}
-                  onSubmitCopy={onSubmitCopy}
-                />
-              </div>
-            </>
-          )}
+          <div className="absolute left-2 top-2">
+            <TimeBoxManageButtons
+              info={props.info}
+              prosTeamName={props.prosTeamName}
+              consTeamName={props.consTeamName}
+              onSubmitEdit={onSubmitEdit}
+              onSubmitDelete={onSubmitDelete}
+              onSubmitCopy={onSubmitCopy}
+            />
+          </div>
+          {renderDragHandle()}
+        </>
+      ) : (
+        <>
+          {renderDragHandle()}
+          <div className="absolute right-2 top-2">
+            <TimeBoxManageButtons
+              info={props.info}
+              prosTeamName={props.prosTeamName}
+              consTeamName={props.consTeamName}
+              onSubmitEdit={onSubmitEdit}
+              onSubmitDelete={onSubmitDelete}
+              onSubmitCopy={onSubmitCopy}
+            />
+          </div>
         </>
       )}
       <div className="font-semibold">
@@ -117,21 +113,17 @@ export default function TimeBox(props: TimeBoxProps) {
 
   const renderNeutralTimeoutPanel = () => (
     <div className="relative flex h-20 w-full flex-col items-center justify-center rounded-md bg-neutral-400 p-2 font-medium ">
-      {onSubmitEdit && onSubmitDelete && onSubmitCopy && (
-        <>
-          {renderDragHandle()}
-          <div className="absolute right-2 top-2">
-            <TimeBoxManageButtons
-              info={props.info}
-              prosTeamName={props.prosTeamName}
-              consTeamName={props.consTeamName}
-              onSubmitEdit={onSubmitEdit}
-              onSubmitDelete={onSubmitDelete}
-              onSubmitCopy={onSubmitCopy}
-            />
-          </div>
-        </>
-      )}
+      {renderDragHandle()}
+      <div className="absolute right-2 top-2">
+        <TimeBoxManageButtons
+          info={props.info}
+          prosTeamName={props.prosTeamName}
+          consTeamName={props.consTeamName}
+          onSubmitEdit={onSubmitEdit}
+          onSubmitDelete={onSubmitDelete}
+          onSubmitCopy={onSubmitCopy}
+        />
+      </div>
       <span className="font-semibold">{speechType}</span>
       <span className="text-2xl font-semibold">{timeStr}</span>
     </div>
@@ -139,21 +131,17 @@ export default function TimeBox(props: TimeBoxProps) {
 
   const renderNeutralCustomPanel = () => (
     <div className="relative flex h-20 w-full flex-col items-center justify-center rounded-md bg-brand-main p-2 font-medium ">
-      {onSubmitEdit && onSubmitDelete && onSubmitCopy && (
-        <>
-          {renderDragHandle()}
-          <div className="absolute right-2 top-2">
-            <TimeBoxManageButtons
-              info={props.info}
-              prosTeamName={props.prosTeamName}
-              consTeamName={props.consTeamName}
-              onSubmitEdit={onSubmitEdit}
-              onSubmitDelete={onSubmitDelete}
-              onSubmitCopy={onSubmitCopy}
-            />
-          </div>
-        </>
-      )}
+      {renderDragHandle()}
+      <div className="absolute right-2 top-2">
+        <TimeBoxManageButtons
+          info={props.info}
+          prosTeamName={props.prosTeamName}
+          consTeamName={props.consTeamName}
+          onSubmitEdit={onSubmitEdit}
+          onSubmitDelete={onSubmitDelete}
+          onSubmitCopy={onSubmitCopy}
+        />
+      </div>
       <span className="font-semibold">{speechType}</span>
       <span className="text-2xl font-semibold">{fullTimeStr}</span>
     </div>

--- a/src/page/TableComposition/components/TimeBox/TimeBox.tsx
+++ b/src/page/TableComposition/components/TimeBox/TimeBox.tsx
@@ -4,13 +4,17 @@ import { TimeBoxInfo } from '../../../../type/type';
 import { Formatting } from '../../../../util/formatting';
 import { LuArrowUpDown } from 'react-icons/lu';
 
+interface TimeBoxEventHandlers {
+  onSubmitEdit?: (updatedInfo: TimeBoxInfo) => void;
+  onSubmitDelete?: () => void;
+  onSubmitCopy?: () => void;
+  onMouseDown?: () => void;
+}
 interface TimeBoxProps extends HTMLAttributes<HTMLDivElement> {
   info: TimeBoxInfo;
   prosTeamName: string;
   consTeamName: string;
-  onSubmitEdit?: (updatedInfo: TimeBoxInfo) => void;
-  onSubmitDelete?: () => void;
-  onSubmitCopy?: () => void;
+  eventHandlers?: TimeBoxEventHandlers;
 }
 
 export default function TimeBox(props: TimeBoxProps) {
@@ -23,9 +27,12 @@ export default function TimeBox(props: TimeBoxProps) {
     timePerSpeaking,
     speaker,
   } = props.info;
-  const { onSubmitEdit, onSubmitDelete, onSubmitCopy, onMouseDown } = props;
-
-  // 타이머 시간 문자열 처리
+  const { eventHandlers } = props;
+  const onSubmitEdit = eventHandlers?.onSubmitEdit;
+  const onSubmitDelete = eventHandlers?.onSubmitDelete;
+  const onSubmitCopy = eventHandlers?.onSubmitCopy;
+  const onMouseDown = eventHandlers?.onMouseDown;
+  const isModifiable = !!eventHandlers;
   let timeStr = '';
   let timePerSpeakingStr = '';
 
@@ -75,35 +82,41 @@ export default function TimeBox(props: TimeBoxProps) {
         isPros ? 'bg-camp-blue' : 'bg-camp-red'
       } h-20 select-none p-2 font-bold text-neutral-0`}
     >
-      {isPros ? (
-        <>
-          <div className="absolute left-2 top-2">
-            <TimeBoxManageButtons
-              info={props.info}
-              prosTeamName={props.prosTeamName}
-              consTeamName={props.consTeamName}
-              onSubmitEdit={onSubmitEdit}
-              onSubmitDelete={onSubmitDelete}
-              onSubmitCopy={onSubmitCopy}
-            />
-          </div>
-          {renderDragHandle()}
-        </>
-      ) : (
-        <>
-          {renderDragHandle()}
-          <div className="absolute right-2 top-2">
-            <TimeBoxManageButtons
-              info={props.info}
-              prosTeamName={props.prosTeamName}
-              consTeamName={props.consTeamName}
-              onSubmitEdit={onSubmitEdit}
-              onSubmitDelete={onSubmitDelete}
-              onSubmitCopy={onSubmitCopy}
-            />
-          </div>
-        </>
-      )}
+      {isPros
+        ? isModifiable && (
+            <>
+              <div className="absolute left-2 top-2">
+                <TimeBoxManageButtons
+                  info={props.info}
+                  prosTeamName={props.prosTeamName}
+                  consTeamName={props.consTeamName}
+                  eventHandlers={{
+                    onSubmitEdit,
+                    onSubmitDelete,
+                    onSubmitCopy,
+                  }}
+                />
+              </div>
+              {renderDragHandle()}
+            </>
+          )
+        : isModifiable && (
+            <>
+              {renderDragHandle()}
+              <div className="absolute right-2 top-2">
+                <TimeBoxManageButtons
+                  info={props.info}
+                  prosTeamName={props.prosTeamName}
+                  consTeamName={props.consTeamName}
+                  eventHandlers={{
+                    onSubmitEdit,
+                    onSubmitDelete,
+                    onSubmitCopy,
+                  }}
+                />
+              </div>
+            </>
+          )}
       <div className="font-semibold">
         {speechType} {speaker && `| ${speaker} 토론자`}
       </div>
@@ -119,9 +132,11 @@ export default function TimeBox(props: TimeBoxProps) {
           info={props.info}
           prosTeamName={props.prosTeamName}
           consTeamName={props.consTeamName}
-          onSubmitEdit={onSubmitEdit}
-          onSubmitDelete={onSubmitDelete}
-          onSubmitCopy={onSubmitCopy}
+          eventHandlers={{
+            onSubmitEdit,
+            onSubmitDelete,
+            onSubmitCopy,
+          }}
         />
       </div>
       <span className="font-semibold">{speechType}</span>
@@ -131,17 +146,23 @@ export default function TimeBox(props: TimeBoxProps) {
 
   const renderNeutralCustomPanel = () => (
     <div className="relative flex h-20 w-full flex-col items-center justify-center rounded-md bg-brand-main p-2 font-medium ">
-      {renderDragHandle()}
-      <div className="absolute right-2 top-2">
-        <TimeBoxManageButtons
-          info={props.info}
-          prosTeamName={props.prosTeamName}
-          consTeamName={props.consTeamName}
-          onSubmitEdit={onSubmitEdit}
-          onSubmitDelete={onSubmitDelete}
-          onSubmitCopy={onSubmitCopy}
-        />
-      </div>
+      {isModifiable && (
+        <>
+          {renderDragHandle()}
+          <div className="absolute right-2 top-2">
+            <TimeBoxManageButtons
+              info={props.info}
+              prosTeamName={props.prosTeamName}
+              consTeamName={props.consTeamName}
+              eventHandlers={{
+                onSubmitEdit,
+                onSubmitDelete,
+                onSubmitCopy,
+              }}
+            />
+          </div>
+        </>
+      )}
       <span className="font-semibold">{speechType}</span>
       <span className="text-2xl font-semibold">{fullTimeStr}</span>
     </div>

--- a/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.stories.tsx
+++ b/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.stories.tsx
@@ -1,16 +1,16 @@
 import { Meta, StoryObj } from '@storybook/react';
-import EditDeleteButtons from './EditDeleteButtons';
+import TimeBoxManageButtons from './TimeBoxManageButtons';
 import { TimeBoxInfo } from '../../../../type/type';
 
-const meta: Meta<typeof EditDeleteButtons> = {
-  title: 'page/TableSetup/components/EditDeleteButtons',
-  component: EditDeleteButtons,
+const meta: Meta<typeof TimeBoxManageButtons> = {
+  title: 'page/TableSetup/components/TimeBoxManageButtons',
+  component: TimeBoxManageButtons,
   tags: ['autodocs'],
 };
 
 export default meta;
 
-type Story = StoryObj<typeof EditDeleteButtons>;
+type Story = StoryObj<typeof TimeBoxManageButtons>;
 
 const normalTimeBoxInfo: TimeBoxInfo = {
   stance: 'PROS',
@@ -27,6 +27,7 @@ export const NormalTimeBox: Story = {
     info: normalTimeBoxInfo,
     onSubmitEdit: () => {},
     onSubmitDelete: () => {},
+    onSubmitCopy: () => {},
   },
 };
 

--- a/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.stories.tsx
+++ b/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.stories.tsx
@@ -25,9 +25,11 @@ const normalTimeBoxInfo: TimeBoxInfo = {
 export const NormalTimeBox: Story = {
   args: {
     info: normalTimeBoxInfo,
-    onSubmitEdit: () => {},
-    onSubmitDelete: () => {},
-    onSubmitCopy: () => {},
+    eventHandlers: {
+      onSubmitEdit: () => {},
+      onSubmitDelete: () => {},
+      onSubmitCopy: () => {},
+    },
   },
 };
 
@@ -44,7 +46,9 @@ const timeBasedTimeBoxInfo: TimeBoxInfo = {
 export const TimeBasedTimeBox: Story = {
   args: {
     info: timeBasedTimeBoxInfo,
-    onSubmitEdit: () => {},
-    onSubmitDelete: () => {},
+    eventHandlers: {
+      onSubmitEdit: () => {},
+      onSubmitDelete: () => {},
+    },
   },
 };

--- a/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.tsx
+++ b/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.tsx
@@ -4,14 +4,16 @@ import { useModal } from '../../../../hooks/useModal';
 import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 import DialogModal from '../../../../components/DialogModal/DialogModal';
 import { FaPaste } from 'react-icons/fa';
-
-interface TimeBoxManageButtonsProps {
-  info: TimeBoxInfo;
-  prosTeamName?: string;
-  consTeamName?: string;
+interface TimeBoxManageButtonsEventHandlers {
   onSubmitEdit?: (updatedInfo: TimeBoxInfo) => void;
   onSubmitDelete?: () => void;
   onSubmitCopy?: () => void;
+}
+interface TimeBoxManageButtonsProps {
+  info: TimeBoxInfo;
+  prosTeamName: string;
+  consTeamName: string;
+  eventHandlers?: TimeBoxManageButtonsEventHandlers;
 }
 
 export default function TimeBoxManageButtons(props: TimeBoxManageButtonsProps) {
@@ -25,7 +27,10 @@ export default function TimeBoxManageButtons(props: TimeBoxManageButtonsProps) {
     closeModal: closeDeleteModal,
     ModalWrapper: DeleteModalWrapper,
   } = useModal({ isCloseButtonExist: false });
-  const { info, onSubmitEdit, onSubmitDelete, onSubmitCopy } = props;
+  const { info, eventHandlers } = props;
+  const onSubmitEdit = eventHandlers?.onSubmitEdit;
+  const onSubmitDelete = eventHandlers?.onSubmitDelete;
+  const onSubmitCopy = eventHandlers?.onSubmitCopy;
 
   return (
     <>
@@ -62,8 +67,8 @@ export default function TimeBoxManageButtons(props: TimeBoxManageButtonsProps) {
         <EditModalWrapper>
           <TimerCreationContent
             initData={info}
-            prosTeamName={props.prosTeamName as string}
-            consTeamName={props.consTeamName as string}
+            prosTeamName={props.prosTeamName}
+            consTeamName={props.consTeamName}
             onSubmit={(newInfo) => {
               onSubmitEdit(newInfo);
             }}

--- a/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.tsx
+++ b/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.tsx
@@ -9,9 +9,9 @@ interface TimeBoxManageButtonsProps {
   info: TimeBoxInfo;
   prosTeamName?: string;
   consTeamName?: string;
-  onSubmitEdit: (updatedInfo: TimeBoxInfo) => void;
-  onSubmitDelete: () => void;
-  onSubmitCopy: () => void;
+  onSubmitEdit?: (updatedInfo: TimeBoxInfo) => void;
+  onSubmitDelete?: () => void;
+  onSubmitCopy?: () => void;
 }
 
 export default function TimeBoxManageButtons(props: TimeBoxManageButtonsProps) {
@@ -30,57 +30,67 @@ export default function TimeBoxManageButtons(props: TimeBoxManageButtonsProps) {
   return (
     <>
       <div className="flex justify-end gap-2">
-        <button
-          onClick={onSubmitCopy}
-          className="rounded-sm bg-neutral-0 p-[2px]"
-          aria-label="복사하기"
-        >
-          <FaPaste className="text-neutral-900" />
-        </button>
-        <button
-          onClick={openEditModal}
-          className="rounded-sm bg-neutral-0 p-[2px]"
-          aria-label="수정하기"
-        >
-          <RiEditFill className="text-neutral-900" />
-        </button>
-        <button
-          onClick={openDeleteModal}
-          className="rounded-sm bg-neutral-0 p-[2px]"
-          aria-label="삭제하기"
-        >
-          <RiDeleteBinFill className="text-neutral-900" />
-        </button>
+        {onSubmitCopy && (
+          <button
+            onClick={onSubmitCopy}
+            className="rounded-sm bg-neutral-0 p-[2px]"
+            aria-label="복사하기"
+          >
+            <FaPaste className="text-neutral-900" />
+          </button>
+        )}
+        {onSubmitEdit && (
+          <button
+            onClick={openEditModal}
+            className="rounded-sm bg-neutral-0 p-[2px]"
+            aria-label="수정하기"
+          >
+            <RiEditFill className="text-neutral-900" />
+          </button>
+        )}
+        {onSubmitDelete && (
+          <button
+            onClick={openDeleteModal}
+            className="rounded-sm bg-neutral-0 p-[2px]"
+            aria-label="삭제하기"
+          >
+            <RiDeleteBinFill className="text-neutral-900" />
+          </button>
+        )}
       </div>
-      <EditModalWrapper>
-        <TimerCreationContent
-          initData={info}
-          prosTeamName={props.prosTeamName as string}
-          consTeamName={props.consTeamName as string}
-          onSubmit={(newInfo) => {
-            onSubmitEdit(newInfo);
-          }}
-          onClose={closeEditModal}
-        />
-      </EditModalWrapper>
+      {onSubmitEdit && (
+        <EditModalWrapper>
+          <TimerCreationContent
+            initData={info}
+            prosTeamName={props.prosTeamName as string}
+            consTeamName={props.consTeamName as string}
+            onSubmit={(newInfo) => {
+              onSubmitEdit(newInfo);
+            }}
+            onClose={closeEditModal}
+          />
+        </EditModalWrapper>
+      )}
 
-      <DeleteModalWrapper>
-        <DialogModal
-          left={{ text: '취소', onClick: () => closeDeleteModal() }}
-          right={{
-            text: '삭제',
-            onClick: () => {
-              onSubmitDelete();
-              closeDeleteModal();
-            },
-            isBold: true,
-          }}
-        >
-          <h1 className="px-20 py-10 text-xl font-bold">
-            이 타이머를 삭제하시겠습니까?
-          </h1>
-        </DialogModal>
-      </DeleteModalWrapper>
+      {onSubmitDelete && (
+        <DeleteModalWrapper>
+          <DialogModal
+            left={{ text: '취소', onClick: () => closeDeleteModal() }}
+            right={{
+              text: '삭제',
+              onClick: () => {
+                onSubmitDelete();
+                closeDeleteModal();
+              },
+              isBold: true,
+            }}
+          >
+            <h1 className="px-20 py-10 text-xl font-bold">
+              이 타이머를 삭제하시겠습니까?
+            </h1>
+          </DialogModal>
+        </DeleteModalWrapper>
+      )}
     </>
   );
 }

--- a/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.tsx
+++ b/src/page/TableComposition/components/TimeBoxManageButtons/TimeBoxManageButtons.tsx
@@ -5,7 +5,7 @@ import TimerCreationContent from '../TimerCreationContent/TimerCreationContent';
 import DialogModal from '../../../../components/DialogModal/DialogModal';
 import { FaPaste } from 'react-icons/fa';
 
-interface EditDeleteButtonsProps {
+interface TimeBoxManageButtonsProps {
   info: TimeBoxInfo;
   prosTeamName?: string;
   consTeamName?: string;
@@ -14,7 +14,7 @@ interface EditDeleteButtonsProps {
   onSubmitCopy: () => void;
 }
 
-export default function EditDeleteButtons(props: EditDeleteButtonsProps) {
+export default function TimeBoxManageButtons(props: TimeBoxManageButtonsProps) {
   const {
     openModal: openEditModal,
     closeModal: closeEditModal,

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -1,4 +1,4 @@
-import DebatePanel from '../DebatePanel/DebatePanel';
+import TimeBox from '../TimeBox/TimeBox';
 import TimerCreationButton from '../TimerCreationButton/TimerCreationButton';
 import { useModal } from '../../../../hooks/useModal';
 import { useDragAndDrop } from '../../../../hooks/useDragAndDrop';
@@ -62,7 +62,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
 
   const renderTimeBoxItem = (info: TimeBoxInfo, index: number) => {
     return (
-      <DebatePanel
+      <TimeBox
         key={index}
         info={info as TimeBoxInfo}
         onSubmitEdit={(updatedInfo) => handleSubmitEdit(index, updatedInfo)}

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -65,12 +65,15 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
       <TimeBox
         key={index}
         info={info as TimeBoxInfo}
-        onSubmitEdit={(updatedInfo) => handleSubmitEdit(index, updatedInfo)}
         prosTeamName={initData.info.prosTeamName}
         consTeamName={initData.info.consTeamName}
-        onSubmitDelete={() => handleSubmitDelete(index)}
-        onSubmitCopy={() => handleCopy(index)}
-        onMouseDown={() => handleMouseDown(index)}
+        eventHandlers={{
+          onSubmitEdit: (updatedInfo: TimeBoxInfo) =>
+            handleSubmitEdit(index, updatedInfo),
+          onSubmitDelete: () => handleSubmitDelete(index),
+          onSubmitCopy: () => handleCopy(index),
+          onMouseDown: () => handleMouseDown(index),
+        }}
       />
     );
   };

--- a/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
+++ b/src/page/TableComposition/components/TimeBoxStep/TimeBoxStep.tsx
@@ -49,6 +49,15 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
     );
   };
 
+  const handleCopy = (indexToCopy: number) => {
+    onTimeBoxChange((prevData) => {
+      const toCopy = prevData[indexToCopy];
+      if (!toCopy) return prevData;
+      const copyItem = { ...toCopy };
+      return [...prevData, copyItem];
+    });
+  };
+
   const isAbledSummitButton = initTimeBox.length !== 0;
 
   const renderTimeBoxItem = (info: TimeBoxInfo, index: number) => {
@@ -60,6 +69,7 @@ export default function TimeBoxStep(props: TimeBoxStepProps) {
         prosTeamName={initData.info.prosTeamName}
         consTeamName={initData.info.consTeamName}
         onSubmitDelete={() => handleSubmitDelete(index)}
+        onSubmitCopy={() => handleCopy(index)}
         onMouseDown={() => handleMouseDown(index)}
       />
     );

--- a/src/page/TableOverviewPage/TableOverview.tsx
+++ b/src/page/TableOverviewPage/TableOverview.tsx
@@ -6,7 +6,7 @@ import HeaderTitle from '../../components/HeaderTitle/HeaderTitle';
 import { RiEditFill, RiSpeakFill } from 'react-icons/ri';
 import usePatchDebateTable from '../../hooks/mutations/usePatchDebateTable';
 import { useGetDebateTableData } from '../../hooks/query/useGetDebateTableData';
-import DebatePanel from '../TableComposition/components/DebatePanel/DebatePanel';
+import TimeBox from '../TableComposition/components/TimeBox/TimeBox';
 import { useTableShare } from '../../hooks/useTableShare';
 import { MdOutlineIosShare } from 'react-icons/md';
 import { StanceToString } from '../../type/type';
@@ -56,7 +56,7 @@ export default function TableOverview() {
 
             <div className="flex w-full flex-col gap-2">
               {data?.table.map((info, index) => (
-                <DebatePanel
+                <TimeBox
                   key={index}
                   info={info}
                   prosTeamName={data.info.prosTeamName}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #313

# 📝 작업 내용
커스텀 타종을 추가하기전, 기존 전역적으로 관리되던 타종이 각각의 타임 박스에서 개별 설정으로 변경됨에 따라, 사용자 편의성을 위해 타임 박스 기능을 추가

## 타임 박스 복사 기능
 
<img width="816" height="399" alt="image" src="https://github.com/user-attachments/assets/b10a5b79-3ed4-4a96-8969-b4082808daf0" />
복사 버튼 클릭 시, 가장 하단에 복사된 타임박스를 생성

## 타임박스 관련 컴포넌트 명 변경
기존에 사용되던 컴포넌트명을 더 이해하기 쉽게 변경하였습니다.
- EditDeleteButtons -> TimeBoxManageButtons
    복사버튼이 추가되어 타임 박스를 관리한다는 네이밍으로 통합

- DebatePanel -> TimeBox
   타임박스라는 이름을 사용하고 있기 때문에 TimeBox로 컴포넌트 명을 변경


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 각 TimeBox 항목에 '복사' 버튼이 추가되어, 사용자가 항목을 손쉽게 복제할 수 있습니다.
  * TimeBox 관리 버튼이 복사, 편집, 삭제 기능을 모두 포함하도록 확장되었습니다.
  * TimeBox 컴포넌트가 이벤트 핸들러를 그룹화하여 관리 버튼과 드래그 핸들러의 일관된 표시를 지원합니다.

* **버그 수정**
  * 기존 DebatePanel 컴포넌트가 TimeBox로 명확하게 교체되어, 일관된 명칭과 기능을 제공합니다.

* **스타일**
  * 복사 버튼이 직관적인 아이콘과 접근성 라벨로 추가되어 사용자 경험이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->