### PR TITLE
[FIX] 타이머에서 숫자 키패드 Enter가 동작하지 않는 문제 수정

### DIFF
--- a/src/page/TimerPage/hooks/useTimerHotkey.ts
+++ b/src/page/TimerPage/hooks/useTimerHotkey.ts
@@ -40,6 +40,7 @@ export function useTimerHotkey(state: TimerPageLogics) {
         'KeyA',
         'KeyL',
         'Enter',
+        'NumpadEnter',
       ];
 
       // 핫키 입력시, 기본 동작(스크롤, 폼 전송 등) 막음

--- a/src/page/TimerPage/hooks/useTimerHotkey.ts
+++ b/src/page/TimerPage/hooks/useTimerHotkey.ts
@@ -113,6 +113,7 @@ export function useTimerHotkey(state: TimerPageLogics) {
           }
           break;
         case 'Enter':
+        case 'NumpadEnter':
           // 진영 전환
           switchCamp();
           break;


### PR DESCRIPTION
# 🚩 연관 이슈

closed #327 

# 📝 작업 내용
## 문제 상황
타이머에서 진영 전환은 Enter 키로 가능하지만, 숫자 키패드의 Enter 키는 인식하지 못하는 문제가 있었음

## 개선 사항
`useTimerHotkey` 훅이 `NumpadEnter`도 인식하도록 개선

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음