### PR TITLE
[FIX] 비회원으로 로그인 하지 않고 뒤로 가기를 눌렀을 때 에러 발생 문제 해결

### DIFF
--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -108,7 +108,7 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
           left={{
             text: '아니오',
             onClick: () => {
-              deleteSessionCustomizeTableData();
+              sessionStorage.setItem('keepGuestTable', 'false');
               closeModal();
               oAuthLogin();
             },
@@ -116,6 +116,7 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
           right={{
             text: '네',
             onClick: () => {
+              sessionStorage.setItem('keepGuestTable', 'true');
               closeModal();
               oAuthLogin();
             },

--- a/src/layout/components/header/StickyTriSectionHeader.tsx
+++ b/src/layout/components/header/StickyTriSectionHeader.tsx
@@ -44,6 +44,12 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
   const { openModal, closeModal, ModalWrapper } = useModal({});
   const defaultIcons: HeaderIcons[] = ['home']; // Icons that will be displayed on all pages are added here
 
+  const handleLoginStart = (keepData: boolean) => {
+    sessionStorage.setItem('keepGuestTable', String(keepData));
+    closeModal();
+    oAuthLogin();
+  };
+
   return (
     <>
       <div className="flex flex-1 items-stretch justify-end gap-2 text-right">
@@ -107,19 +113,11 @@ StickyTriSectionHeader.Right = function Right(props: PropsWithChildren) {
         <DialogModal
           left={{
             text: '아니오',
-            onClick: () => {
-              sessionStorage.setItem('keepGuestTable', 'false');
-              closeModal();
-              oAuthLogin();
-            },
+            onClick: () => handleLoginStart(false),
           }}
           right={{
             text: '네',
-            onClick: () => {
-              sessionStorage.setItem('keepGuestTable', 'true');
-              closeModal();
-              oAuthLogin();
-            },
+            onClick: () => handleLoginStart(true),
             isBold: true,
           }}
         >

--- a/src/page/TimerPage/components/LoginAndStoreModal.tsx
+++ b/src/page/TimerPage/components/LoginAndStoreModal.tsx
@@ -1,6 +1,7 @@
 import { ComponentType, ReactNode } from 'react';
 import DialogModal from '../../../components/DialogModal/DialogModal';
 import { oAuthLogin } from '../../../util/googleAuth';
+import { useNavigate } from 'react-router-dom';
 
 interface LoginAndStoreModalProps {
   Wrapper: ComponentType<{
@@ -14,12 +15,17 @@ export function LoginAndStoreModal({
   Wrapper,
   onClose,
 }: LoginAndStoreModalProps) {
+  const navigate = useNavigate();
+
   return (
     <Wrapper closeButtonColor="text-neutral-1000">
       <DialogModal
         left={{
           text: '아니오',
-          onClick: onClose,
+          onClick: () => {
+            onClose();
+            navigate('/overview/customize/guest');
+          },
         }}
         right={{
           text: '네',


### PR DESCRIPTION
# 🚩 연관 이슈
closed #312 

# 📝 작업 내용
# 문제 발생 플로우
비회원으로 토론 시작 -> 로그인 시도 -> 로그인 안 하고 뒤로가기 -> 에러 발생
# 문제 정의
<img width="1887" height="568" alt="image" src="https://github.com/user-attachments/assets/f2b036a6-bfd8-448c-990c-1a04a5b2df91" />
처음에 접속하면 세션 스토리지에 아무것도 없습니다.


<img width="1883" height="562" alt="image" src="https://github.com/user-attachments/assets/06e70839-98cb-4049-a84a-5849da83ce0c" />
비회원으로 시작하기를 눌러 들어가면 임의로 세션 스토리지에 테이블을 넣어줍니다. 


<img width="1911" height="810" alt="image" src="https://github.com/user-attachments/assets/2adb0b94-d54c-4d8d-8199-147741a0ed1a" />
로그인을 시도하고 이후 로그인을 완료하지 않고 다시 뒤로 넘어오면


<img width="1908" height="712" alt="image" src="https://github.com/user-attachments/assets/a735d08b-80c7-4496-b7ed-82ab545a08ea" />
다시 돌아왔을 때 세션 스토리지에 값이 초기화 되는 것이 문제였습니다. 

코드를 살펴보면
```tsx
        <DialogModal
          left={{
            text: '아니오',
            onClick: () => {
              deleteSessionCustomizeTableData(); // 해당 부분에서 클릭하자마자 삭제해버리는 로직
              closeModal();
              oAuthLogin();
            },
          }}
          right={{
            text: '네',
            onClick: () => {
              closeModal();
              oAuthLogin();
            },
            isBold: true,
          }}
        >
          <div className="break-keep px-20 py-10 text-center text-xl font-bold">
            비회원으로 사용하던 시간표가 있습니다. <br />
            로그인 후에도 이 시간표를 계속 사용하시겠습니까?
          </div>
        </DialogModal>
```
로그인이 완료되지 않았는데 해당 버튼을 누르자마자 바로 세션스토리지에 저장된 값을 삭제하기 때문에 문제가 발생했습니다.

# 문제 해결 과정
1. 예 또는 아니오를 눌렀을 때 시간표 저장 여부를 세션스토리지에 저장하기
2. 로그인이 완료되면 OAuth에서 시간표를 저장하지 않은 경우 기존의 시간표를 삭제한다.

# 🏞️ 스크린샷 (선택)
https://github.com/user-attachments/assets/6b996d55-1ee7-46a3-80e5-fd9a4e951a20

다시 문제 발생 플로우를 따라갔을 때 삭제되지 않는 것을 확인할 수 있습니다 😆😆

# 🗣️ 리뷰 요구사항 (선택)
혹시 놓친 부분이 있거나 더 좋은 방향이 있다면 말씀해 주세용 🫡✨👍

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * OAuth 로그인 시 게스트 테이블 데이터 유지 여부 처리가 개선되어, "아니오" 선택 시 세션 데이터가 올바르게 삭제됩니다.
  * OAuth 로그인 과정에서 중복 처리가 방지됩니다.

* **기능 개선**
  * 로그인 모달에서 "아니오" 선택 시, 사용자가 커스터마이즈 페이지로 자동 이동됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->