### PR TITLE
[FIX] 타이머 좌우 방향키 조작 비활성화

### DIFF
--- a/src/page/TimerPage/hooks/useTimerHotkey.ts
+++ b/src/page/TimerPage/hooks/useTimerHotkey.ts
@@ -34,8 +34,6 @@ export function useTimerHotkey(state: TimerPageLogics) {
       // 핫키로 쓸 키 목록
       const keysToDisable = new Set([
         'Space',
-        'ArrowLeft',
-        'ArrowRight',
         'KeyR',
         'KeyA',
         'KeyL',
@@ -77,14 +75,6 @@ export function useTimerHotkey(state: TimerPageLogics) {
               toggleTimer(timer2);
             }
           }
-          break;
-        case 'ArrowLeft':
-          // 이전 라운드 이동
-          goToOtherItem(true);
-          break;
-        case 'ArrowRight':
-          // 다음 라운드 이동
-          goToOtherItem(false);
           break;
         case 'KeyR':
           // 타이머 리셋

--- a/src/page/TimerPage/hooks/useTimerHotkey.ts
+++ b/src/page/TimerPage/hooks/useTimerHotkey.ts
@@ -4,7 +4,6 @@ import { TimerPageLogics } from './useTimerPageState';
 /**
  * 타이머 페이지에서 키보드 단축키(핫키) 기능을 제공하는 커스텀 훅입니다.
  * - Space: 타이머 시작/일시정지
- * - ArrowLeft/ArrowRight: 이전/다음 라운드 이동
  * - KeyR: 타이머 리셋
  * - KeyA/KeyL: 각각 찬/반 진영 타이머 활성화
  * - Enter, NumpadEnter: 진영 전환


### PR DESCRIPTION
# 🚩 연관 이슈

closed #332 

# 📝 작업 내용
## 문제 상황
타이머에서 이전/다음 차례로 이동하는 좌우 방향키가 실수로 눌리면 현재 진행 중인 토론의 정보가 모두 초기화되는 문제가 있음

## 개선 사항
좌우 방향키를 눌러 이전/다음 차례로 이동할 수 있었던 기능 비활성화

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
이 변경 사항은 [debate-timer-fe-win](https://github.com/debate-timer/debate-timer-fe-win) 저장소에도 완전히 동일하게 적용 예정입니다. 이 PR이 이 저장소에서 승인되고 병합될 경우, [debate-timer-fe-win](https://github.com/debate-timer/debate-timer-fe-win) 저장소에서는 별도 PR 리뷰 없이 병합 예정임을 알립니다.