### PR TITLE
[FIX] 상대팀이 모두 시간 소진, 2회 이상 발언할 시간이 남아있을 때, 1회 발언 이후, 전체시간을 전부 소비할 수 없는 문제 수정

### DIFF
--- a/src/page/TimerPage/hooks/useTimeBasedTimer.ts
+++ b/src/page/TimerPage/hooks/useTimeBasedTimer.ts
@@ -113,33 +113,41 @@ export function useTimeBasedTimer({
    * 발언자 전환 시 타이머 리셋/초기화
    * - 발언 타이머 사용중이면 default값(또는 totalTimer 이하)로 재설정
    * - 전체 타이머는 초기값(defaultTotalTimer)로 리셋
+   * - 상대 진영 전체 시간 소진 시, 남은 전체 시간을 speakingTimer에 전부 반영
    */
-  const resetTimerForNextPhase = useCallback(() => {
-    pauseTimer();
-    if (
-      isSpeakingTimer &&
-      defaultTime.defaultSpeakingTimer !== null &&
-      totalTimer !== null
-    ) {
-      setSpeakingTimer(
-        defaultTime.defaultSpeakingTimer < totalTimer
-          ? defaultTime.defaultSpeakingTimer
-          : totalTimer,
-      );
-      if (totalTimer > 0) {
-        setIsDone(false);
+  const resetTimerForNextPhase = useCallback(
+    (isOpponentDone: boolean) => {
+      pauseTimer();
+      if (
+        isSpeakingTimer &&
+        totalTimer !== null &&
+        defaultTime.defaultSpeakingTimer !== null
+      ) {
+        if (isOpponentDone) {
+          setSpeakingTimer(totalTimer);
+        } else {
+          setSpeakingTimer(
+            defaultTime.defaultSpeakingTimer < totalTimer
+              ? defaultTime.defaultSpeakingTimer
+              : totalTimer,
+          );
+        }
+        if (totalTimer > 0) {
+          setIsDone(false);
+        }
+        return;
       }
-      return;
-    }
-    if (totalTimer === 0) return;
-    setTotalTimer(defaultTime.defaultTotalTimer);
-  }, [
-    defaultTime.defaultSpeakingTimer,
-    defaultTime.defaultTotalTimer,
-    isSpeakingTimer,
-    totalTimer,
-    pauseTimer,
-  ]);
+      if (totalTimer === 0) return;
+      setTotalTimer(defaultTime.defaultTotalTimer);
+    },
+    [
+      defaultTime.defaultSpeakingTimer,
+      defaultTime.defaultTotalTimer,
+      isSpeakingTimer,
+      totalTimer,
+      pauseTimer,
+    ],
+  );
 
   /**
    * 외부에서 전체/발언 타이머를 지정값으로 재설정
@@ -203,7 +211,7 @@ export interface TimeBasedTimerLogics {
   isSpeakingTimer: boolean;
   startTimer: () => void;
   pauseTimer: () => void;
-  resetTimerForNextPhase: () => void;
+  resetTimerForNextPhase: (isOpponentDone: boolean) => void;
   resetCurrentTimer: () => void;
   setTimers: (total: number | null, speaking?: number | null) => void;
   setSavedTime: Dispatch<

--- a/src/page/TimerPage/hooks/useTimerPageState.ts
+++ b/src/page/TimerPage/hooks/useTimerPageState.ts
@@ -166,13 +166,11 @@ export function useTimerPageState(tableId: number): TimerPageLogics {
    * 진영 전환 시, 상대 타이머를 발언 구간에 맞게 초기화
    */
   useEffect(() => {
-    if (prosConsSelected === 'CONS') {
-      if (timer1.speakingTimer === null) return;
-      timer1.resetTimerForNextPhase();
-    } else if (prosConsSelected === 'PROS') {
-      if (timer2.speakingTimer === null) return;
-      timer2.resetTimerForNextPhase();
-    }
+    const isPros = prosConsSelected === 'PROS';
+    const myTimer = isPros ? timer1 : timer2;
+    const opponentTimer = isPros ? timer2 : timer1;
+    if (myTimer.speakingTimer === null) return;
+    myTimer.resetTimerForNextPhase(opponentTimer.isDone);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prosConsSelected]);
 


### PR DESCRIPTION
# 🚩 연관 이슈

closed #331

# 📝 작업 내용
상대팀이 모두 시간 소진, 2회 이상 발언할 시간이 남아있을 때, 1회 발언 이후, 전체시간을 전부 소비할 수 없는 문제 수정했습니다. 
resetTimerForNextPhase함수에 매변수로 상대방 진영의 isDone상태를 받아서 speakingTimer 상태를 변경하는 분기를 추가했습니다.

### 기존

https://github.com/user-attachments/assets/a716e3ce-bc87-4519-81b9-622b0168cb2e

## 변경 후

https://github.com/user-attachments/assets/e097c328-2ddd-4c23-bcda-959d242edf47



# 🗣️ 리뷰 요구사항 (선택)
npm run preview를 통해 확인했을 때, 정상작동하는 것을 확인했습니다. 여러분도 한번 확인해주세요
또한 현재 develop브랜치에서 npm run storybook을 확인한 결과 mock이 이루어지지 않는 것을 확인할 수 있습니다. 아마 최근에 api관련 설정을 건든게 원인 같긴한데 혹시 여러분도 그러신가요? 어디를 수정해야 고쳐질지 모르겠네요