### PR TITLE
[FIX] 발언자 이름 출력 조건이 반대로 되어 있는 문제 수정

### DIFF
--- a/src/page/TimerPage/components/NormalTimer.tsx
+++ b/src/page/TimerPage/components/NormalTimer.tsx
@@ -90,7 +90,7 @@ export default function NormalTimer({
       {/* Speaker's number, if necessary */}
       <div className="my-[12px] h-[25px] lg:my-[17px] lg:h-[30px] xl:my-[20px] xl:h-[40px]">
         <div className="flex w-full flex-row items-center justify-center space-x-2 text-neutral-900">
-          {item.stance !== 'NEUTRAL' && isAdditionalTimerOn && (
+          {item.stance !== 'NEUTRAL' && !isAdditionalTimerOn && (
             <>
               <MdRecordVoiceOver className="size-[30px] lg:size-[35px] xl:size-[40px]" />
               <h3 className="text-[18px] font-semibold lg:text-[24px] xl:text-[28px]">


### PR DESCRIPTION
# 🚩 연관 이슈

closed #337 

# 📝 작업 내용
## 문제 상황
- 일반 타이머 `NormalTimer`에서 발언자 이름이 표기되지 않는 문제가 있었음
- 발언자 이름이 출력되기 위해서는 작전 시간 타이머가 켜져 있지 않아야 하는데, 이 부분 조건문을 반대로 작성해서 - 다시 말하면 반대로 작전 시간 타이머가 켜져 있어야 발언자 이름이 출력되도록 구현되어 있었어서 - 문제가 발생함

## 해결 방안
작전 시간 타이머 관련 조건문에 `!`을 붙여, 작전 시간 타이머가 꺼져 있어야 발언자 이름이 나오도록 조건 정상화

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음