### PR TITLE
[FIX] 타이머 오류 해결

### DIFF
--- a/src/page/TimerPage/components/NormalTimer.tsx
+++ b/src/page/TimerPage/components/NormalTimer.tsx
@@ -133,7 +133,7 @@ export default function NormalTimer({
         >
           <span
             className={clsx(
-              'flex w-full flex-row items-center justify-center p-[16px] text-[70px] font-bold text-default-black xl:text-[110px]',
+              'flex w-full flex-row items-center justify-center p-[16px] text-[70px] font-bold tabular-nums text-default-black xl:text-[110px]',
               { 'space-x-[8px]': totalTime < 0 },
               { 'space-x-[16px]': totalTime >= 0 },
             )}

--- a/src/page/TimerPage/components/TimeBasedTimer.tsx
+++ b/src/page/TimerPage/components/TimeBasedTimer.tsx
@@ -7,6 +7,7 @@ import CircularTimer from './CircularTimer';
 import clsx from 'clsx';
 import useCircularTimerAnimation from '../hooks/useCircularTimerAnimation';
 import useBreakpoint from '../../../hooks/useBreakpoint';
+import { useMemo } from 'react';
 
 type TimeBasedTimerInstance = {
   totalTimer: number | null;
@@ -41,6 +42,7 @@ export default function TimeBasedTimer({
     pauseTimer,
     resetCurrentTimer,
   } = timeBasedTimerInstance;
+
   const minute = Formatting.formatTwoDigits(
     Math.floor(Math.abs(totalTimer ?? 0) / 60),
   );
@@ -55,20 +57,33 @@ export default function TimeBasedTimer({
 
   const initRawProgress = (): number => {
     if (speakingTimer === null) {
-      if (item.timePerTeam && item.timePerTeam > 0 && totalTimer) {
+      // 1회당 발언 시간 X일 때...
+      if (item.timePerTeam && totalTimer && item.timePerTeam > 0) {
+        // 팀당 발언 시간 타이머가 정상 동작 중이고 남은 시간이 있을 경우, 진행도를 계산
         return ((item.timePerTeam - totalTimer) / item.timePerTeam) * 100;
+      } else {
+        // 팀당 발언 시간 타이머가 멈추거나 완료된 경우,
+        // 완료(100%)에 해당하는 진행도를 반환
+        return 100;
       }
-    } else if (
-      item.timePerSpeaking &&
-      item.timePerSpeaking > 0 &&
-      speakingTimer
-    ) {
-      return (
-        ((item.timePerSpeaking - speakingTimer) / item.timePerSpeaking) * 100
-      );
+    } else {
+      // 1회당 발언 시간 O일 때...
+      if (
+        item.timePerSpeaking &&
+        speakingTimer &&
+        totalTimer &&
+        item.timePerSpeaking > 0
+      ) {
+        // 1회당 발언 시간 타이머가 정상 동작 중이고 남은 시간이 있을 경우, 진행도를 계산
+        return (
+          ((item.timePerSpeaking - speakingTimer) / item.timePerSpeaking) * 100
+        );
+      } else {
+        // 1회당 발언 시간 타이머가 멈추거나 완료된 경우,
+        // 완료(100%)에 해당하는 진행도를 반환
+        return 100;
+      }
     }
-
-    return 0;
   };
 
   const rawProgress = initRawProgress();

--- a/src/page/TimerPage/components/TimeBasedTimer.tsx
+++ b/src/page/TimerPage/components/TimeBasedTimer.tsx
@@ -7,7 +7,6 @@ import CircularTimer from './CircularTimer';
 import clsx from 'clsx';
 import useCircularTimerAnimation from '../hooks/useCircularTimerAnimation';
 import useBreakpoint from '../../../hooks/useBreakpoint';
-import { useMemo } from 'react';
 
 type TimeBasedTimerInstance = {
   totalTimer: number | null;
@@ -60,6 +59,9 @@ export default function TimeBasedTimer({
       // 1회당 발언 시간 X일 때...
       if (item.timePerTeam && totalTimer && item.timePerTeam > 0) {
         // 팀당 발언 시간 타이머가 정상 동작 중이고 남은 시간이 있을 경우, 진행도를 계산
+        if (totalTimer <= 0) {
+          return 100;
+        }
         return ((item.timePerTeam - totalTimer) / item.timePerTeam) * 100;
       } else {
         // 팀당 발언 시간 타이머가 멈추거나 완료된 경우,
@@ -68,12 +70,7 @@ export default function TimeBasedTimer({
       }
     } else {
       // 1회당 발언 시간 O일 때...
-      if (
-        item.timePerSpeaking &&
-        speakingTimer &&
-        totalTimer &&
-        item.timePerSpeaking > 0
-      ) {
+      if (item.timePerSpeaking && speakingTimer && item.timePerSpeaking > 0) {
         // 1회당 발언 시간 타이머가 정상 동작 중이고 남은 시간이 있을 경우, 진행도를 계산
         return (
           ((item.timePerSpeaking - speakingTimer) / item.timePerSpeaking) * 100

--- a/src/page/TimerPage/components/TimeBasedTimer.tsx
+++ b/src/page/TimerPage/components/TimeBasedTimer.tsx
@@ -127,7 +127,7 @@ export default function TimeBasedTimer({
       >
         {/* 1회당 발언 시간 X */}
         {speakingTimer === null && (
-          <span className="flex w-full flex-row items-center justify-center p-[16px] text-[90px] font-bold text-default-black xl:text-[110px]">
+          <span className="flex w-full flex-row items-center justify-center p-[16px] text-[90px] font-bold tabular-nums text-default-black xl:text-[110px]">
             <p className="flex flex-1 items-center justify-center">{minute}</p>
             <p className="flex items-center justify-center">:</p>
             <p className="flex flex-1 items-center justify-center">{second}</p>
@@ -140,7 +140,7 @@ export default function TimeBasedTimer({
             <h1 className="w-[88px] rounded-[8px] bg-default-black py-[6px] text-center text-[16px] text-default-white xl:w-[112px] xl:text-[20px]">
               전체 시간
             </h1>
-            <span className="flex flex-row text-[56px] font-semibold text-default-black xl:text-[72px]">
+            <span className="flex flex-row text-[56px] font-semibold tabular-nums text-default-black xl:text-[72px]">
               <p className="flex w-[80px] items-center justify-center xl:w-[120px]">
                 {minute}
               </p>
@@ -161,7 +161,7 @@ export default function TimeBasedTimer({
             >
               현재 시간
             </h1>
-            <span className="flex flex-row text-[70px] font-bold text-default-black lg:text-[90px] xl:text-[110px]">
+            <span className="flex flex-row text-[70px] font-bold tabular-nums text-default-black lg:text-[90px] xl:text-[110px]">
               <p className="flex w-[108px] items-center justify-center xl:w-[180px]">
                 {speakingMinute}
               </p>

--- a/src/page/TimerPage/components/TimeBasedTimer.tsx
+++ b/src/page/TimerPage/components/TimeBasedTimer.tsx
@@ -115,7 +115,7 @@ export default function TimeBasedTimer({
       >
         {/* 1회당 발언 시간 X */}
         {speakingTimer === null && (
-          <span className="flex w-full flex-row items-center justify-center space-x-[16px] p-[16px] text-[110px] font-bold text-default-black">
+          <span className="flex w-full flex-row items-center justify-center p-[16px] text-[90px] font-bold text-default-black xl:text-[110px]">
             <p className="flex flex-1 items-center justify-center">{minute}</p>
             <p className="flex items-center justify-center">:</p>
             <p className="flex flex-1 items-center justify-center">{second}</p>


### PR DESCRIPTION
# 🚩 연관 이슈

closed #348 

# 📝 작업 내용
## 첫 번째 오류
### 🐞 상세 내용
<img width="1075" height="862" alt="image" src="https://github.com/user-attachments/assets/e7ecbad5-0402-4ea8-a96b-d40ba413863c" />

1회당 발언 시간이 없는 시간 총량제 타이머의 남은 시간 텍스트 크기가, 작은 적응형 화면에서 비정상적으로 커 보였던 문제

### 🔍 원인
다른 타이머 UI 요소와는 다르게, 1회당 발언 시간 없는 시간 총량제 타이머의 텍스트에만 적응형이 적용되지 않았었음

### ⚒️ 해결
<img width="1056" height="864" alt="image" src="https://github.com/user-attachments/assets/dff07e0e-a3a8-4f16-b220-416dc9c0663c" />

적응형 적용하여 큰 화면에서는 110 px(써니가 넘겨준 원래 규격), 작은 화면에서는 90 px로 렌더링되도록 수정

## 두 번째 오류
### 🐞 상세 내용
시간 총량제 타이머 발언 시간이 끝난 상태여도, 프로그레스 바가 원래대로 복원되었던 문제

### 🔍 원인
- 타이머 애니메이션 진행도(단위 %)는 시작할 때에는 0%이고, 완료될 때에는 100%임
- 그러나 현재 로직은 완료 시 100%가 아닌 0%로 초기화하도록 짜여져 있었음 (나의 실수 😢)

### ⚒️ 해결
https://github.com/user-attachments/assets/40c08f2d-30aa-4280-ade3-2ca23c104adf

타이머가 종료됐을 때, 타이머 애니메이션 진행도가 0%가 아닌 100%로 초기화되도록 수정

## 그 외 변경 사항
TailwindCSS의 [`tabular-nums`](https://tailwindcss.com/docs/font-variant-numeric#using-tabular-figures) 태그를 두 타이머 - 시간 총량제 타이머와 일반 타이머 - 모두에 적용하여, 숫자가 동일한 너비를 차지하게 해 UI가 튀는 상황을 방지할 수 있게 했어요.

# 🏞️ 스크린샷 (선택)
위에 첨부하였으므로 생략

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 타이머 진행률 계산 로직 개선으로 팀별/발언별 기준에 따른 진행률이 더 정확히 표시됩니다.
- 스타일
  - CircularTimer의 “1회당 발언 시간 X” 글자 크기와 패딩 조정으로 가독성 향상.
  - 숫자 표시 전반에 tabular-nums 적용으로 자릿수 정렬이 일관되게 개선되었습니다.
- 버그 수정
  - 총 타이머 또는 발언 타이머가 없거나 0일 때의 진행률 처리 문제 수정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->