### PR TITLE
[DESIGN] 종소리 설정에 아코디언 UI 적용

### DIFF
--- a/src/components/NotificationBadge/NotificationBadge.stories.tsx
+++ b/src/components/NotificationBadge/NotificationBadge.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from '@storybook/react';
+import NotificationBadge from './NotificationBadge';
+
+const meta: Meta<typeof NotificationBadge> = {
+  title: 'Components/NotificationBadge',
+  component: NotificationBadge,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NotificationBadge>;
+
+export const WhenNoNotification: Story = {
+  args: {
+    count: 0,
+  },
+};
+export const When1Notification: Story = {
+  args: {
+    count: 1,
+  },
+};
+export const WhenMoreThan99Notification: Story = {
+  args: {
+    count: 100,
+  },
+};
+export const Default: Story = {
+  args: {
+    count: 14,
+  },
+};

--- a/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/src/components/NotificationBadge/NotificationBadge.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx';
+
+interface NotificationBadgeProps {
+  count: number;
+  className?: string;
+}
+
+export default function NotificationBadge({
+  count,
+  className = '',
+}: NotificationBadgeProps) {
+  if (count === 0) {
+    return null;
+  }
+
+  const displayCount = count > 99 ? '99+' : count;
+
+  return (
+    <span
+      className={clsx(
+        'inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold leading-none text-white',
+        className,
+      )}
+    >
+      {displayCount}
+    </span>
+  );
+}

--- a/src/components/NotificationBadge/NotificationBadge.tsx
+++ b/src/components/NotificationBadge/NotificationBadge.tsx
@@ -9,16 +9,20 @@ export default function NotificationBadge({
   count,
   className = '',
 }: NotificationBadgeProps) {
-  if (count === 0) {
+  // 음수, NaN 등 의도하지 않은 값 확인
+  const safeCount = Number.isFinite(count) ? Math.max(0, count) : 0;
+  if (safeCount === 0) {
     return null;
   }
 
-  const displayCount = count > 99 ? '99+' : count;
+  const displayCount = safeCount > 99 ? '99+' : safeCount;
 
   return (
     <span
+      role="status"
+      aria-label={`알림 ${displayCount}개`}
       className={clsx(
-        'inline-flex h-4 min-w-[16px] items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-bold leading-none text-white',
+        'inline-flex h-[16px] min-w-[16px] items-center justify-center rounded-full bg-semantic-error px-[4px] text-[10px] font-bold leading-none text-default-white',
         className,
       )}
     >

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -680,7 +680,7 @@ export default function TimerCreationContent({
                             ? '종소리 설정 접기'
                             : '종소리 설정 펼치기'
                         }
-                        onClick={() => handleBellExpandButtonClick()}
+                        onClick={handleBellExpandButtonClick}
                       >
                         <DTExpand
                           className={clsx(

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -674,6 +674,12 @@ export default function TimerCreationContent({
 
                       <button
                         className="h-full"
+                        type="button"
+                        aria-label={
+                          isBellExpanded
+                            ? '종소리 설정 접기'
+                            : '종소리 설정 펼치기'
+                        }
                         onClick={() => handleBellExpandButtonClick()}
                       >
                         <DTExpand className="h-full rounded-full p-[8px] text-default-black transition-colors duration-300 hover:bg-default-disabled/hover" />

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -701,7 +701,6 @@ export default function TimerCreationContent({
                         <span className="flex w-full flex-row items-center space-x-[4px]">
                           {/* 벨 유형 */}
                           <DropdownMenu
-                            className=""
                             options={bellOptions}
                             selectedValue={bellInput.type}
                             onSelect={(value: BellType) => {

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -433,8 +433,8 @@ export default function TimerCreationContent({
   );
 
   const handleBellExpandButtonClick = useCallback(() => {
-    setIsBellExpanded(!isBellExpanded);
-  }, [isBellExpanded]);
+    setIsBellExpanded((prev) => !prev);
+  }, []);
 
   return (
     <div className="flex w-[820px] flex-col">

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -682,7 +682,15 @@ export default function TimerCreationContent({
                         }
                         onClick={() => handleBellExpandButtonClick()}
                       >
-                        <DTExpand className="h-full rounded-full p-[8px] text-default-black transition-colors duration-300 hover:bg-default-disabled/hover" />
+                        <DTExpand
+                          className={clsx(
+                            'h-full transform rounded-full p-[8px] text-default-black transition-all duration-300 ease-in-out hover:bg-default-disabled/hover',
+                            {
+                              'rotate-180': isBellExpanded,
+                              'rotate-0': !isBellExpanded,
+                            },
+                          )}
+                        />
                       </button>
                     </div>
 

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -24,6 +24,8 @@ import clsx from 'clsx';
 import TimeInputGroup from './TimeInputGroup';
 import DTBell from '../../../../components/icons/Bell';
 import DTAdd from '../../../../components/icons/Add';
+import NotificationBadge from '../../../../components/NotificationBadge/NotificationBadge';
+import DTExpand from '../../../../components/icons/Expand';
 
 type TimerCreationOption =
   | 'TIMER_TYPE'
@@ -145,6 +147,9 @@ export default function TimerCreationContent({
   console.log(
     `# initSpeech: ${initSpeechType} / currentSpeech: ${currentSpeechType}`,
   );
+
+  // 종소리 영역 확장 여부
+  const [isBellExpanded, setIsBellExpanded] = useState(false);
 
   // 발언 시간
   const { minutes: initMinutes, seconds: initSeconds } =
@@ -427,6 +432,10 @@ export default function TimerCreationContent({
     [currentSpeechType],
   );
 
+  const handleBellExpandButtonClick = useCallback(() => {
+    setIsBellExpanded(!isBellExpanded);
+  }, [isBellExpanded]);
+
   return (
     <div className="flex w-[820px] flex-col">
       {/* 헤더 */}
@@ -647,127 +656,150 @@ export default function TimerCreationContent({
               case 'BELL':
                 return (
                   <div
-                    className="flex w-full flex-col space-y-[16px]"
+                    className="flex w-full flex-col space-y-[8px]"
                     key={`${timerType}-${index}`}
                   >
-                    {/* 제목 */}
-                    <p className="text-body w-[80px] font-medium">
-                      종소리 설정
-                    </p>
+                    {/* 제목 및 종소리 횟수 배지 */}
+                    <div className="flex w-full flex-row justify-between">
+                      <div className="relative flex items-center space-x-[8px]">
+                        <p className="text-body w-[80px] font-medium">
+                          종소리 설정
+                        </p>
 
-                    {/* 입력부 */}
-                    <span className="flex w-full flex-row items-center space-x-[4px]">
-                      {/* 벨 유형 */}
-                      <DropdownMenu
-                        className=""
-                        options={bellOptions}
-                        selectedValue={bellInput.type}
-                        onSelect={(value: BellType) => {
-                          setBellInput((prev) => ({
-                            ...prev,
-                            type: value,
-                          }));
-                        }}
-                      />
-                      <span className="w-[8px]"></span>
-
-                      {/* 분, 초, 타종 횟수 */}
-                      <input
-                        type="number"
-                        min={0}
-                        max={59}
-                        className="w-[60px] rounded-[4px] border border-default-border p-[8px]"
-                        value={bellInput.min}
-                        onChange={(e) =>
-                          setBellInput((prev) => ({
-                            ...prev,
-                            min: Math.max(
-                              0,
-                              Math.min(59, Number(e.target.value)),
-                            ),
-                          }))
-                        }
-                        placeholder="분"
-                      />
-                      <span>분</span>
-
-                      <input
-                        type="number"
-                        min={0}
-                        max={59}
-                        className="w-[60px] rounded-[4px] border border-default-border p-[8px]"
-                        value={bellInput.sec}
-                        onChange={(e) =>
-                          setBellInput((prev) => ({
-                            ...prev,
-                            sec: Math.max(
-                              0,
-                              Math.min(59, Number(e.target.value)),
-                            ),
-                          }))
-                        }
-                        placeholder="초"
-                      />
-                      <span>초</span>
-                      <span className="w-[8px]"></span>
-
-                      <DTBell className="w-[24px]" />
-                      <p>x</p>
-                      <input
-                        type="number"
-                        min={1}
-                        max={3}
-                        className="w-[60px] rounded-[4px] border border-default-border p-[8px]"
-                        value={bellInput.count}
-                        onChange={(e) => {
-                          const value = Number(e.target.value) % 10;
-                          setBellInput((prev) => ({
-                            ...prev,
-                            count: Math.max(1, Math.min(3, Number(value))),
-                          }));
-                        }}
-                        placeholder="횟수"
-                      />
-                      <span className="w-[8px]"></span>
+                        <NotificationBadge
+                          count={bells.length}
+                          className="absolute -right-[16px] -top-[4px]"
+                        />
+                      </div>
 
                       <button
-                        type="button"
-                        className="flex size-[28px] items-center justify-center rounded-[8px] bg-default-disabled/hover p-[6px] text-default-white"
-                        onClick={handleAddBell}
+                        className="h-full"
+                        onClick={() => handleBellExpandButtonClick()}
                       >
-                        <DTAdd />
+                        <DTExpand className="h-full rounded-full p-[8px] text-default-black transition-colors duration-300 hover:bg-default-disabled/hover" />
                       </button>
-                    </span>
+                    </div>
 
-                    {/* 벨 리스트 */}
-                    <span className="flex h-[100px] w-full flex-col items-center gap-2 overflow-y-auto">
-                      {bells.map((bell, idx) => (
-                        <span
-                          key={idx}
-                          className="relative flex w-full flex-row rounded-[4px] border border-default-border bg-[#FFF2D0] px-[12px] py-[4px]"
-                        >
-                          <div className="flex items-center gap-1">
-                            <p className="text-[14px]">
-                              {BellTypeToString[bell.type]}
-                            </p>
-                            <p className="text-[14px]">
-                              {bell.min}분 {bell.sec}초
-                            </p>
+                    {/* 종소리 설정 영역 */}
+                    {isBellExpanded && (
+                      <div className="flex w-full flex-col space-y-[8px] rounded-[12px] bg-default-dim2 p-[8px]">
+                        {/* 입력부 */}
+                        <span className="flex w-full flex-row items-center space-x-[4px]">
+                          {/* 벨 유형 */}
+                          <DropdownMenu
+                            className=""
+                            options={bellOptions}
+                            selectedValue={bellInput.type}
+                            onSelect={(value: BellType) => {
+                              setBellInput((prev) => ({
+                                ...prev,
+                                type: value,
+                              }));
+                            }}
+                          />
+                          <span className="w-[8px]"></span>
 
-                            <span className="w-[8px]"></span>
-                            <DTBell className="size-[14px]" />
-                            <span className="text-[14px]">x {bell.count}</span>
-                          </div>
+                          {/* 분, 초, 타종 횟수 */}
+                          <input
+                            type="number"
+                            min={0}
+                            max={59}
+                            className="w-[52px] rounded-[4px] border border-default-border p-[8px]"
+                            value={bellInput.min}
+                            onChange={(e) =>
+                              setBellInput((prev) => ({
+                                ...prev,
+                                min: Math.max(
+                                  0,
+                                  Math.min(59, Number(e.target.value)),
+                                ),
+                              }))
+                            }
+                            placeholder="분"
+                          />
+                          <span>분</span>
+
+                          <input
+                            type="number"
+                            min={0}
+                            max={59}
+                            className="w-[52px] rounded-[4px] border border-default-border p-[8px]"
+                            value={bellInput.sec}
+                            onChange={(e) =>
+                              setBellInput((prev) => ({
+                                ...prev,
+                                sec: Math.max(
+                                  0,
+                                  Math.min(59, Number(e.target.value)),
+                                ),
+                              }))
+                            }
+                            placeholder="초"
+                          />
+                          <span>초</span>
+                          <span className="w-[8px]"></span>
+
+                          <DTBell className="w-[24px]" />
+                          <p>x</p>
+                          <input
+                            type="number"
+                            min={1}
+                            max={3}
+                            className="w-[48px] rounded-[4px] border border-default-border p-[8px]"
+                            value={bellInput.count}
+                            onChange={(e) => {
+                              const value = Number(e.target.value) % 10;
+                              setBellInput((prev) => ({
+                                ...prev,
+                                count: Math.max(1, Math.min(3, Number(value))),
+                              }));
+                            }}
+                            placeholder="횟수"
+                          />
+                          <span className="w-[8px]"></span>
 
                           <button
-                            className="absolute right-2 top-1/2 -translate-y-1/2 text-default-border"
-                            onClick={() => handleDeleteBell(idx)}
+                            type="button"
+                            className="flex size-[28px] items-center justify-center rounded-[8px] bg-brand p-[6px] text-default-white transition-colors duration-200 hover:bg-brand-hover"
+                            onClick={handleAddBell}
                           >
-                            <DTClose className="size-[10px]" />
+                            <DTAdd />
                           </button>
                         </span>
-                      ))}
-                    </span>
+
+                        {/* 벨 리스트 */}
+                        <span className="flex h-[100px] w-full flex-col items-center gap-2 overflow-y-auto">
+                          {bells.map((bell, idx) => (
+                            <span
+                              key={idx}
+                              className="relative flex w-full flex-row rounded-[4px] border border-default-border bg-[#FFF2D0] px-[12px] py-[4px]"
+                            >
+                              <div className="flex items-center gap-1">
+                                <p className="text-[14px]">
+                                  {BellTypeToString[bell.type]}
+                                </p>
+                                <p className="text-[14px]">
+                                  {bell.min}분 {bell.sec}초
+                                </p>
+
+                                <span className="w-[8px]"></span>
+                                <DTBell className="size-[14px]" />
+                                <span className="text-[14px]">
+                                  x {bell.count}
+                                </span>
+                              </div>
+
+                              <button
+                                className="absolute right-2 top-1/2 -translate-y-1/2 text-default-border"
+                                onClick={() => handleDeleteBell(idx)}
+                              >
+                                <DTClose className="size-[10px]" />
+                              </button>
+                            </span>
+                          ))}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 );
               default:

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -81,6 +81,7 @@ export default {
           'disabled/hover': '#D6D7D9',
           neutral: '#A3A3A3',
           dim: '#222222',
+          dim2: '#F2F2F2',
           border: '#79747E',
           timeout: '#4F4F4F',
           white: '#FFFFFF',


### PR DESCRIPTION
# 🚩 연관 이슈

closed #358 

# 📝 작업 내용
## 새로운 색상 추가
아코디언 UI에 사용된 새로운 배경 색상 `default-dim2`를 추가했습니다.

## 알림 배지 컴포넌트 추가
앱 곳곳에서 공통적으로 사용할 수 있게 `NotificationBadge` 컴포넌트를 추가했습니다.

## 타임박스 추가 모달의 종소리 설정 영역에 아코디언 UI 적용
통합 회의에서 논의된 대로 아코디언 UI를 적용했습니다. 여러분의 이해를 돕기 위해 간단하게 변경된 코드를 설명하겠습니다:

### 상태 값 추가
```tsx
const [isBellExpanded, setIsBellExpanded] = useState(false);
```

`isBellExpanded` 변수를 통해, 종소리 영역이 보이는지 여부를 저장합니다. `true`일 경우 보이는 거고, `false`일 경우 가려진 상태입니다.

### 버튼 클릭 시 이벤트 추가
```tsx
const handleBellExpandButtonClick = useCallback(() => {
  setIsBellExpanded(!isBellExpanded)
}, [isBellExpanded]);
```

버튼 클릭 시 동작하는 토글 함수를 추가했습니다. 단순하게, 현재 `isBellExpanded`의 반대 값으로 변경하는 로직입니다.

### 종소리 영역에 아코디언 UI 구조 적용
```tsx
<div
  className="flex flex-col"
>
  {/* 제목 및 종소리 횟수 배지 */}
  <div className="flex flex-row justify-between">
    <div className="relative flex items-center space-x-[8px]">
      <p>
        제목
      </p>

      <NotificationBadge
        count={bells.length}
        className="absolute -right-[16px] -top-[4px]"
      />
    </div>

    <button>
      확장 버튼
    </button>
  </div>

  {/* 종소리 설정 영역 */}
  {isBellExpanded && ()}
</div>
```

이해를 돕기 위해 스타일 태그는 간소화해 작성해 뒀습니다. 전체 코드는 Files Changed 탭에서 확인하실 수 있구요. 새로 추가한 `NotificationBadge` 컴포넌트를 사용하여 코드를 작성했습니다. 이 배지 컴포넌트 같은 경우, 아래와 같이 동작합니다:
- 카운트가 0일 때, 아무것도 표시하지 않음
- 카운트가 1 이상 99 이하일 때, 값을 그대로 표시함
- 카운트가 100 이상일 때, '99+'로 표시함

확장 버튼과 종소리 설정 추가 버튼에 간단한 애니메이션을 적용하여 심미성도 높였습니다.

추가로, 입력 필드들의 너비를 기존 60 px에서 더 줄였는데요. 이 부분은 종소리 설정 부분에 회색 배경이 들어오면서 양옆으로 패딩이 붙어버리는 바람에, 종소리 영역이 열렸을 때 모달 오른쪽의 입력 영역의 너비가 크게 늘어나서 타이머 샘플 사진이 너무 쪼그라들었기 때문입니다. 코드 리뷰하실 때 참고하시면 될 것 같아요.

# 🏞️ 스크린샷 (선택)
## 닫혔을 때
<img width="886" height="641" alt="image" src="https://github.com/user-attachments/assets/cf8b75d1-fd9f-4f10-be2e-2e561914467f" />

## 열렸을 때
<img width="857" height="783" alt="image" src="https://github.com/user-attachments/assets/25b02033-5c12-4f58-a63c-d2cb10eeb81b" />

# 🗣️ 리뷰 요구사항 (선택)
동작 잘 되는지 `npm run dev`로 한 번만 확인해주세요!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - NotificationBadge 컴포넌트 추가(카운트에 따라 숨김/표시, 99+ 축약 표기, 접근성 레이블 포함).
  - 타이머 생성의 BELL 설정에 접기/펼치기 UI 도입(헤더 배지·확장 버튼, 확장 영역에서 종 타입·시간·개수 입력 및 추가/삭제/편집, 배지에 개수 반영).

- 스타일
  - BELL 영역 간격 및 입력 필드 너비 소폭 조정.

- 문서
  - NotificationBadge 다양한 카운트 사례를 보여주는 Storybook 스토리 추가.

- 작업
  - 테마에 신규 중립 색상 토큰(dim2) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->