### PR TITLE
[FEAT] 피드백 타이머 초기화 시 0분 0초로 변경

### DIFF
--- a/src/page/TimerPage/FeedbackTimerPage.tsx
+++ b/src/page/TimerPage/FeedbackTimerPage.tsx
@@ -1,20 +1,10 @@
-import { useEffect } from 'react';
 import { useFeedbackTimer } from './hooks/useFeedbackTimer';
 import FeedbackTimer from './components/FeedbackTimer';
 import DefaultLayout from '../../layout/defaultLayout/DefaultLayout';
 import GoToHomeButton from '../../components/GoToHomeButton/GoToHomeButton';
 
-const INITIAL_TIME = 0;
-
 export default function FeedbackTimerPage() {
   const feedbackTimerInstance = useFeedbackTimer();
-  const { setTimer, setDefaultTimer } = feedbackTimerInstance;
-
-  useEffect(() => {
-    // 페이지가 로드될 때 타이머의 초기 시간을 설정
-    setTimer(INITIAL_TIME);
-    setDefaultTimer(INITIAL_TIME);
-  }, [setTimer, setDefaultTimer]);
 
   return (
     <DefaultLayout>

--- a/src/page/TimerPage/hooks/useFeedbackTimer.ts
+++ b/src/page/TimerPage/hooks/useFeedbackTimer.ts
@@ -6,15 +6,15 @@ import {
   useRef,
   useState,
 } from 'react';
-
+const INITIAL_TIME = 0;
 export function useFeedbackTimer(): FeedbackTimerLogics {
   // 타이머에 표시되는 현재 남은 시간
-  const [timer, setTimer] = useState<number | null>(null);
+  const [timer, setTimer] = useState<number | null>(INITIAL_TIME);
   // 타이머 요청에 대한 ID를 저장
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
 
   // 타이머의 총 시간
-  const [defaultTimer, setDefaultTimer] = useState(0);
+  const [defaultTimer, setDefaultTimer] = useState(INITIAL_TIME);
 
   // 타이머가 현재 동작중인지 여부
   const [isRunning, setIsRunning] = useState(false);
@@ -72,9 +72,9 @@ export function useFeedbackTimer(): FeedbackTimerLogics {
       clearInterval(intervalRef.current);
       intervalRef.current = null;
     }
-    setTimer(defaultTimer);
+    setTimer(INITIAL_TIME);
     setIsRunning(false);
-  }, [defaultTimer]);
+  }, []);
 
   /**
    * 타이머 시간을 조정 (타이머가 멈춰있을 때만)


### PR DESCRIPTION
# 🚩 연관 이슈

closed #398

# 📝 작업 내용
## 피드백 타이머 초기화 시 0분 0초로 변경

https://github.com/user-attachments/assets/31903a12-61da-4c2a-8423-d3bc106467d5

## FeedbackTimerPage에서 선언되어있던 불필요한 useEffect제거
기존 defaultTime과 time의 초기 세팅을 하는 useEffect를 useFeedbackTimer에서 초기상태로 변경하였습니다.

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 타이머 초기화 로직을 내부적으로 개선하여 코드 구조를 간소화했습니다.
  * 타이머 리셋 동작을 고정된 초기값 기반으로 통일하여 예측 가능성을 높였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->