### PR TITLE
[FIX] 발언자 길이 사전검증하기

### DIFF
--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -598,7 +598,9 @@ export default function TimerCreationContent({
                     <ClearableInput
                       id="speaker"
                       value={speaker}
-                      onChange={(e) => setSpeaker(e.target.value)}
+                      onChange={(e) =>
+                        setSpeaker(e.target.value.slice(0, MAX_SPEAKER_LEN))
+                      }
                       onClear={() => setSpeaker('')}
                       maxLength={MAX_SPEAKER_LEN}
                       placeholder="N번"


### PR DESCRIPTION
# 🚩 연관 이슈

closed #404

# 📝 작업 내용
### 발언자 글자수 검증 로직 공통화
기존에는 currentSpeechType === 'CUSTOM' 조건문 내부에서만 speaker.trim().length > 5 검증이 실행되고 있어
커스텀 발언 유형이 아닐 경우 글자수 제한이 전혀 적용되지 않았습니다.
검증 위치를 공통 영역으로 이동하여 모든 타이머 유형에서 5자 초과 입력 시 경고가 표시되도록 수정했습니다.

### ClearableInput 입력 단계에서도 글자 수 제한 적용
발언자 입력 필드에서 글자 수 제한이 실시간으로 반영되지 않아 5자 이상 입력이 가능했던 문제를 해결했습니다.


# 리뷰 요구사항 (선택)
한번씩 글자 수 제한이 제대로 작동하는지 확인해주세요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 토론자 이름 입력에 5자 최대 제한을 적용하고 입력 필드에 maxLength 반영
  * 플레이스홀더를 "N번"으로 간소화해 문자 제한을 명확히 함
  * 폼 제출 전에 길이 검증을 전역으로 강화하여 길이 관련 오류를 제출 전에 감지·보고

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->