### PR TITLE
[DESIGN] 신 기능 홍보 모달 사이즈 변경

### DIFF
--- a/src/components/UpdateModal/UpdateModal.tsx
+++ b/src/components/UpdateModal/UpdateModal.tsx
@@ -20,7 +20,7 @@ export default function UpdateModal({
   onClickDetailButton,
 }: UpdateModalProps) {
   return (
-    <div className="flex aspect-square w-[clamp(800px,min(62.5vw,90vh),1000px)] flex-col overflow-hidden rounded-[2.2%] bg-default-white">
+    <div className="flex aspect-square w-[clamp(600px,min(47.5vw,90vh),780px)] flex-col overflow-hidden rounded-[2.2%] bg-default-white">
       {isPredefinedPatchNote(data) ? (
         <>
           {/* 메인 컨텐츠 */}

--- a/src/components/UpdateModal/UpdateModal.tsx
+++ b/src/components/UpdateModal/UpdateModal.tsx
@@ -73,7 +73,7 @@ export default function UpdateModal({
               <input
                 id="update-modal-hide-for-week-predefined"
                 type="checkbox"
-                className="border-gray size-[clamp(16px,1.25vw,20px)] rounded-[4px]"
+                className="border-gray size-[clamp(12px,0.93vw,15px)] rounded-[4px]"
                 checked={isChecked}
                 onChange={(e) => onChecked(e.target.checked)}
               />

--- a/src/components/UpdateModal/UpdateModal.tsx
+++ b/src/components/UpdateModal/UpdateModal.tsx
@@ -25,12 +25,12 @@ export default function UpdateModal({
         <>
           {/* 메인 컨텐츠 */}
           <div className="flex h-[60%] w-full flex-col gap-[2%] bg-[#EFF0F4] p-[4.5%]">
-            <div className="flex w-full flex-row items-center gap-[1%]">
-              <div className="w-[15.7%] shrink-0">
-                <MegaphoneAsset className="h-auto w-full" />
+            <div className="flex h-[clamp(72px,6vh,96px)] w-full flex-row items-center gap-[1%]">
+              <div className="h-full w-[15.7%] shrink-0">
+                <MegaphoneAsset className="my-[8px] h-[80px] w-[93px]" />
               </div>
 
-              <div className="flex w-full flex-col space-y-[2.0%]">
+              <div className="flex w-full flex-col space-y-[clamp(15px,1.25vw,20px)]">
                 <p className="text-[clamp(12px,0.875vw,14px)] leading-none text-default-black">
                   디베이트 타이머에 새로운 기능이 생겼어요!
                 </p>

--- a/src/components/UpdateModal/UpdateModal.tsx
+++ b/src/components/UpdateModal/UpdateModal.tsx
@@ -31,7 +31,7 @@ export default function UpdateModal({
               </div>
 
               <div className="flex w-full flex-col space-y-[2.0%]">
-                <p className="text-[clamp(14px,1.25vw,20px)] leading-none text-default-black">
+                <p className="text-[clamp(12px,0.875vw,14px)] leading-none text-default-black">
                   디베이트 타이머에 새로운 기능이 생겼어요!
                 </p>
 
@@ -56,11 +56,11 @@ export default function UpdateModal({
           <div className="flex w-full flex-1 flex-col p-[1%]">
             {/* 타이틀 및 내용 */}
             <div className="flex h-full flex-col items-center justify-center">
-              <p className="text-[clamp(32px,2.8vw,45px)] font-bold text-brand">
+              <p className="text-[clamp(26px,2.1vw,34px)] font-bold text-brand">
                 {data.title}
               </p>
               <div className="mb-[1.6%] mt-[0.8%] h-[2px] w-[10%] bg-brand" />
-              <p className="text-center text-[clamp(20px,1.5vw,24px)]">
+              <p className="text-center text-[clamp(14px,1.1vw,18px)]">
                 {data.description}
               </p>
             </div>
@@ -73,11 +73,13 @@ export default function UpdateModal({
               <input
                 id="update-modal-hide-for-week-predefined"
                 type="checkbox"
-                className="border-gray size-[clamp(16px,1.5vw,20px)] rounded-[4px]"
+                className="border-gray size-[clamp(16px,1.25vw,20px)] rounded-[4px]"
                 checked={isChecked}
                 onChange={(e) => onChecked(e.target.checked)}
               />
-              <p className="text-[clamp(13px,1vw,16px)]">일주일 간 보지 않기</p>
+              <p className="text-[clamp(10px,0.75vw,12px)]">
+                일주일 간 보지 않기
+              </p>
             </label>
           </div>
         </>
@@ -100,11 +102,13 @@ export default function UpdateModal({
             <input
               id="update-modal-hide-for-week-image-only"
               type="checkbox"
-              className="border-gray size-[clamp(16px,1.5vw,20px)] rounded-[4px]"
+              className="border-gray size-[clamp(16px,1.25vw,20px)] rounded-[4px]"
               checked={isChecked}
               onChange={(e) => onChecked(e.target.checked)}
             />
-            <p className="text-[clamp(13px,1vw,16px)]">일주일 간 보지 않기</p>
+            <p className="text-[clamp(10px,0.75vw,12px)]">
+              일주일 간 보지 않기
+            </p>
           </label>
         </div>
       )}


### PR DESCRIPTION
# 🚩 연관 이슈

closed #423 

# 📝 작업 내용
써니의 요구 사항에 맞춰 신 기능 홍보 모달의 크기를 줄였습니다. 이에 맞추어, 내부 텍스트의 크기도 함께 적정 수준에서 줄였습니다. 그 이상 변경된 것은 없기에 작업 내용 소개는 이 정도에서 정리합니다.

# 🏞️ 스크린샷 (선택)
## 비교 스크린샷
<img width="1841" height="1085" alt="image" src="https://github.com/user-attachments/assets/13354e8e-9c62-47d7-afcd-989b6ac2930c" />

## 최소치일 경우의 스크린샷
<img width="1333" height="855" alt="image" src="https://github.com/user-attachments/assets/3f9e77cc-0326-4ed7-bda8-c7bfbb398c73" />

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **스타일**
  * 업데이트 모달의 최대/최소 폭을 줄여 레이아웃을 컴팩트하게 조정했습니다.
  * 제목, 설명 등 주요 텍스트의 글자 크기를 전반적으로 축소해 균형을 맞췄습니다.
  * "일주일 간 보지 않기" 옵션의 체크박스와 라벨 크기를 조정하여 정렬성을 개선했습니다.
  * 이미지 전용 변형의 텍스트·체크박스 크기도 별도 최적화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->