### PR TITLE
[FEAT] Sentry 노이즈 감소 및 API 에러 품질 개선

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -23,17 +23,17 @@ type SentryCapturedError = {
   __sentry_captured__?: boolean;
 };
 
-function normalizeEndpoint(url?: string) {
+export function normalizeEndpoint(url?: string) {
   if (!url) {
     return 'unknown';
   }
 
   return url
-    .replace(/[0-9]+/g, ':id')
     .replace(
       /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
       ':uuid',
-    );
+    )
+    .replace(/[0-9]+/g, ':id');
 }
 
 function resolveApiErrorLevel(status: number | undefined) {

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -100,7 +100,6 @@ function captureClientApiError(error: unknown) {
       search: window.location.search,
       url: config?.url,
       method: config?.method,
-      baseURL: config?.baseURL,
       params: config?.params,
       timeout: config?.timeout ?? requestTimeoutMs,
       errorCode: code,

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -107,6 +107,7 @@ function captureClientApiError(error: unknown) {
     fingerprint: [
       'api-error',
       String(status ?? 'network-error'),
+      requestMethod,
       normalizedUrl,
     ],
   });

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import * as Sentry from '@sentry/react';
+import type { SeverityLevel } from '@sentry/react';
 import {
   getAccessToken,
   removeAccessToken,
@@ -21,6 +22,16 @@ const requestTimeoutMs = 5000;
 type SentryCapturedError = {
   __sentry_captured__?: boolean;
 };
+
+function resolveApiErrorLevel(status: number | undefined) {
+  // 400/409/422는 사용자 입력·요청 상태 충돌 성격이 커서 warning으로 분리
+  if (status === 400 || status === 409 || status === 422) {
+    return 'warning';
+  }
+
+  // 그 외(주로 5xx/네트워크 실패)는 운영 대응이 필요한 장애 신호로 처리
+  return 'error';
+}
 
 // Axios instance
 export const axiosInstance = axios.create({
@@ -54,12 +65,16 @@ function captureClientApiError(error: unknown) {
   const { response, config, code } = error;
   const status = response?.status;
 
-  // 401 재발급 흐름과 정상/리다이렉트 응답만 제외하고, 4xx/5xx/네트워크 실패/타임아웃은 수집
+  // 401은 토큰 재발급 후 원요청 재시도로 자동 복구되는 정상 인증 흐름이므로 수집에서 제외
+  // 정상/리다이렉트 응답(<400)도 제외하고, 그 외 4xx/5xx/네트워크 실패/타임아웃은 수집
   if (status === 401 || (status !== undefined && status < 400)) {
     return;
   }
 
+  const level: SeverityLevel = resolveApiErrorLevel(status);
+
   Sentry.captureException(error, {
+    level,
     tags: {
       errorType: 'api-error',
       httpStatus: status ? String(status) : 'network-error',
@@ -98,7 +113,7 @@ axiosInstance.interceptors.response.use(
           null,
         );
 
-        // **새 Access Token은 응답 헤더(Authorization)에 담겨 있다고 가정**
+        // 새 Access Token은 응답 헤더(Authorization)에 담겨 있다고 가정
         const headerAuth = refreshResponse.headers['authorization'] || '';
 
         // Authorization: Bearer <새토큰> 형태라면 "Bearer " 부분 제거

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -23,6 +23,19 @@ type SentryCapturedError = {
   __sentry_captured__?: boolean;
 };
 
+function normalizeEndpoint(url?: string) {
+  if (!url) {
+    return 'unknown';
+  }
+
+  return url
+    .replace(/[0-9]+/g, ':id')
+    .replace(
+      /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
+      ':uuid',
+    );
+}
+
 function resolveApiErrorLevel(status: number | undefined) {
   // 400/409/422는 사용자 입력·요청 상태 충돌 성격이 커서 warning으로 분리
   if (status === 400 || status === 409 || status === 422) {
@@ -64,6 +77,8 @@ function captureClientApiError(error: unknown) {
 
   const { response, config, code } = error;
   const status = response?.status;
+  const normalizedUrl = normalizeEndpoint(config?.url);
+  const requestMethod = config?.method?.toUpperCase() ?? 'UNKNOWN';
 
   // 401은 토큰 재발급 후 원요청 재시도로 자동 복구되는 정상 인증 흐름이므로 수집에서 제외
   // 정상/리다이렉트 응답(<400)도 제외하고, 그 외 4xx/5xx/네트워크 실패/타임아웃은 수집
@@ -78,6 +93,7 @@ function captureClientApiError(error: unknown) {
     tags: {
       errorType: 'api-error',
       httpStatus: status ? String(status) : 'network-error',
+      endpoint: `${requestMethod} ${normalizedUrl}`,
     },
     extra: {
       pathname: window.location.pathname,
@@ -89,6 +105,11 @@ function captureClientApiError(error: unknown) {
       timeout: config?.timeout ?? requestTimeoutMs,
       errorCode: code,
     },
+    fingerprint: [
+      'api-error',
+      String(status ?? 'network-error'),
+      normalizedUrl,
+    ],
   });
 
   (error as SentryCapturedError).__sentry_captured__ = true;

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -52,5 +52,10 @@ if (import.meta.env.PROD && dsn) {
 
       return event;
     },
+    initialScope: {
+      tags: {
+        language: document.documentElement.lang || 'ko',
+      },
+    },
   });
 }

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -22,7 +22,7 @@ if (import.meta.env.PROD && dsn) {
     // 에러가 발생한 세션은 모두 Replay로 남김
     replaysOnErrorSampleRate: 1.0,
     beforeSend(event, hint) {
-      const originalException = hint.originalException;
+      const originalException = hint?.originalException;
 
       // 정상 사용자 흐름(이동/언마운트)에서 자주 생기는 취소성 에러는 노이즈로 간주
       if (originalException instanceof Error) {

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -47,6 +47,7 @@ if (import.meta.env.PROD && dsn) {
       if (event.extra && typeof event.extra === 'object') {
         const sanitizedExtra = { ...event.extra };
         delete sanitizedExtra.Authorization;
+        delete sanitizedExtra.authorization;
         event.extra = sanitizedExtra;
       }
 

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -21,5 +21,36 @@ if (import.meta.env.PROD && dsn) {
     replaysSessionSampleRate: 0,
     // 에러가 발생한 세션은 모두 Replay로 남김
     replaysOnErrorSampleRate: 1.0,
+    beforeSend(event, hint) {
+      const originalException = hint.originalException;
+
+      // 정상 사용자 흐름(이동/언마운트)에서 자주 생기는 취소성 에러는 노이즈로 간주
+      if (originalException instanceof Error) {
+        const normalizedMessage = originalException.message.toLowerCase();
+        const isCanceledRequest =
+          normalizedMessage.includes('cancel') ||
+          normalizedMessage.includes('aborted') ||
+          originalException.name === 'AbortError' ||
+          originalException.name === 'CanceledError';
+
+        if (isCanceledRequest) {
+          return null;
+        }
+      }
+
+      // 크로스 오리진 스크립트 에러는 재현 단서가 부족해 운영 액션 가능성이 낮음
+      if (event.exception?.values?.[0]?.value === 'Script error.') {
+        return null;
+      }
+
+      // 인증 헤더가 extra에 실수로 포함돼도 전송 전에 제거
+      if (event.extra && typeof event.extra === 'object') {
+        const sanitizedExtra = { ...event.extra };
+        delete sanitizedExtra.Authorization;
+        event.extra = sanitizedExtra;
+      }
+
+      return event;
+    },
   });
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@ import './instrument';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
+import * as Sentry from '@sentry/react';
 import { GlobalPortal } from './util/GlobalPortal';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import router from './routes/routes.tsx';
@@ -13,8 +14,12 @@ import {
   getMemberId,
   removeMemberId,
 } from './util/accessToken';
-import { DEFAULT_LANG } from './util/languageRouting';
+import { DEFAULT_LANG, isSupportedLang } from './util/languageRouting';
 import i18n from './i18n';
+
+function resolveCurrentLang(lang?: string) {
+  return isSupportedLang(lang) ? lang : DEFAULT_LANG;
+}
 
 // Functions that calls msw mocking worker
 if (import.meta.env.VITE_MOCK_API === 'true') {
@@ -50,6 +55,10 @@ if (import.meta.env.VITE_MOCK_API === 'true') {
 // Function that initializes main React app
 function initializeApp() {
   setupAnalytics();
+  const currentLang = resolveCurrentLang(
+    i18n.resolvedLanguage ?? i18n.language,
+  );
+  Sentry.setTag('language', currentLang);
 
   // memberId 복원: accessToken + memberId 모두 존재 시 identity 설정
   const memberId = getMemberId();
@@ -57,7 +66,7 @@ function initializeApp() {
     analyticsManager.setUserId(memberId);
     analyticsManager.setUserProperties({
       user_type: 'member',
-      language: document.documentElement.lang || DEFAULT_LANG,
+      language: currentLang,
     });
   } else if (memberId) {
     // accessToken 없이 memberId만 있으면 비회원 처리
@@ -66,9 +75,11 @@ function initializeApp() {
 
   // 언어 변경 시 user property 업데이트
   i18n.on('languageChanged', (lng: string) => {
+    const changedLang = resolveCurrentLang(lng);
+    Sentry.setTag('language', changedLang);
     analyticsManager.setUserProperties({
       user_type: getAccessToken() ? 'member' : 'guest',
-      language: lng,
+      language: changedLang,
     });
   });
 


### PR DESCRIPTION
# 🚩 연관 이슈

closed #451 

# 📝 작업 내용

## 1) 불필요한 에러 로그를 전송 전에 걸러내기
파일: src/instrument.ts

- 사용자가 페이지를 옮기거나 요청을 중단할 때 생기는 에러는 로그에서 제외
- 원인 파악이 어려운 브라우저 공통 스크립트 에러(Script error.)는 제외
- 인증값이 로그에 섞여 들어가지 않도록 제거
- 언어 정보를 공통 태그로 추가해 언어별 이슈 확인 가능

## 2) API 에러를 심각도별로 나누기
파일: src/apis/axiosInstance.ts

- 400/409/422는 warning(주의)으로 분류
- 5xx나 네트워크 실패는 error(장애 가능성 높음)로 분류
- 401은 토큰 재발급 흐름에서 자주 생기는 인증 처리 단계라 기존처럼 제외

   의도: 사용자 입력/상태 충돌성 에러는 알람 노이즈를 줄이고, 실제 장애 가능성이 높은 에러에 집중

## 3) 비슷한 API 에러를 한 그룹으로 묶기
파일: src/apis/axiosInstance.ts

- URL의 숫자 ID/UUID를 일반화해서 같은 유형의 에러로 묶이게 조정
- endpoint(요청 메서드 + API 경로) 태그 추가
- 같은 원인의 에러가 흩어지지 않도록 그룹핑 키(fingerprint) 적용
- 분석에 도움 적은 baseURL 정보는 제거

   의도: 같은 문제인데 여러 건으로 쪼개져 보이는 현상 줄이고, 어떤 API에서 문제가 나는지 빠르게 파악하기

## 기대 효과
- 알람 노이즈 감소
- 중요한 오류 우선 확인 가능
- API별 문제 추적 속도 개선
- 보안/민감정보 노출 위험 완화
## 확인 포인트
- 400/409/422가 warning으로 기록되는지
- 5xx/네트워크 실패가 error로 기록되는지
- 비슷한 API 에러가 한 이슈로 묶이는지
- 인증 헤더가 로그에 남지 않는지

# 🏞️ 스크린샷 (선택)

# 🗣️ 리뷰 요구사항 (선택)
 지금은 에러를 받고 있지만 불필요한 에러들이 많이 수집되어 일단 에러를 조금 선별해 보는 작업을 하나씩 진행해 보겠습니다 !!!!! 계속 다듬어가면서 센트리의 효과를 볼 수 있기를 .. 🥺 주석으로 설명을 달아놨는데 궁금한 점은 리뷰 편하게 남겨주세욥 ~!! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 에러 로깅 및 보고 시스템 최적화 — 캡처 정확도 향상 및 중복/불필요 알림 감소
  * 요청 엔드포인트 정규화로 유사 오류 그룹화 및 분석성 향상
  * 취소된 요청·크로스오리진 스크립트 오류 자동 필터링
  * 에러 리포트에 경로·메서드·타임아웃 등 메타데이터 추가로 조사 속도 향상
  * 민감 정보(Authorization 등) 제거로 개인정보 보호 강화
  * 사용 언어 자동 감지 및 태깅 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->