### PR TITLE
[FEAT] 라이브 공유용 테이블 데이터 GET API 구현

### DIFF
--- a/src/apis/apis/live.test.ts
+++ b/src/apis/apis/live.test.ts
@@ -1,0 +1,43 @@
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { ApiUrl } from '../endpoints';
+import { GetDebateTableDataForShareResponseType } from '../responses/live';
+import { getDebateTableDataForShare } from './live';
+
+const mockDebateTableForShare: GetDebateTableDataForShareResponseType = {
+  id: 302,
+  info: {
+    name: '공유용 자유토론 테이블',
+    agenda: '공유 토론 주제',
+    prosTeamName: '찬성',
+    consTeamName: '반대',
+  },
+  table: [
+    {
+      stance: 'NEUTRAL',
+      speechType: '자유토론',
+      bell: null,
+      boxType: 'TIME_BASED',
+      time: null,
+      timePerTeam: 60,
+      timePerSpeaking: 30,
+      speaker: null,
+    },
+  ],
+};
+
+describe('라이브 공유 테이블 조회 API', () => {
+  test('테이블 ID로 공유용 토론 테이블 데이터를 조회한다', async () => {
+    server.use(
+      http.get(`${ApiUrl.live}/table/customize/:tableId`, ({ params }) => {
+        expect(params.tableId).toBe('302');
+
+        return HttpResponse.json(mockDebateTableForShare);
+      }),
+    );
+
+    const data = await getDebateTableDataForShare(302);
+
+    expect(data).toEqual(mockDebateTableForShare);
+  });
+});

--- a/src/apis/apis/live.ts
+++ b/src/apis/apis/live.ts
@@ -1,6 +1,9 @@
 import { request } from '../primitives';
 import { ApiUrl } from '../endpoints';
-import { GetChairmanTokenResponseType } from '../responses/live';
+import {
+  GetChairmanTokenResponseType,
+  GetDebateTableDataForShareResponseType,
+} from '../responses/live';
 
 export const getChairmanToken = (tableId: string) => {
   return request<GetChairmanTokenResponseType>(
@@ -10,3 +13,17 @@ export const getChairmanToken = (tableId: string) => {
     null,
   );
 };
+
+// GET /api/live/table/customize/{tableId}
+export async function getDebateTableDataForShare(
+  tableId: number,
+): Promise<GetDebateTableDataForShareResponseType> {
+  const response = await request<GetDebateTableDataForShareResponseType>(
+    'GET',
+    `${ApiUrl.live}/table/customize/${tableId}`,
+    null,
+    null,
+  );
+
+  return response.data;
+}

--- a/src/apis/apis/live.ts
+++ b/src/apis/apis/live.ts
@@ -5,14 +5,19 @@ import {
   GetDebateTableDataForShareResponseType,
 } from '../responses/live';
 
-export const getChairmanToken = (tableId: string) => {
-  return request<GetChairmanTokenResponseType>(
+// GET /api/live/{tableId}/chairman-token
+export async function getChairmanToken(
+  tableId: string,
+): Promise<GetChairmanTokenResponseType> {
+  const response = await request<GetChairmanTokenResponseType>(
     'GET',
     `${ApiUrl.live}/${encodeURIComponent(tableId)}/chairman-token`,
     null,
     null,
   );
-};
+
+  return response.data;
+}
 
 // GET /api/live/table/customize/{tableId}
 export async function getDebateTableDataForShare(

--- a/src/apis/responses/live.ts
+++ b/src/apis/responses/live.ts
@@ -1,3 +1,10 @@
+import { DebateTableData } from '../../type/type';
+
 export interface GetChairmanTokenResponseType {
   chairmanToken: string;
+}
+
+// GET /api/live/table/customize/{tableId}
+export interface GetDebateTableDataForShareResponseType extends DebateTableData {
+  id: number;
 }

--- a/src/hooks/query/useGetChairmanToken.ts
+++ b/src/hooks/query/useGetChairmanToken.ts
@@ -11,7 +11,7 @@ export default function useGetChairmanToken(
   return useQuery({
     queryKey: chairmanTokenQueryKey(tableId),
     queryFn: async () => {
-      const { data } = await getChairmanToken(tableId);
+      const data = await getChairmanToken(tableId);
       return data.chairmanToken;
     },
     enabled: enabled && Boolean(tableId),

--- a/src/hooks/query/useGetDebateTableDataForShare.test.tsx
+++ b/src/hooks/query/useGetDebateTableDataForShare.test.tsx
@@ -1,0 +1,69 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { ApiUrl } from '../../apis/endpoints';
+import { GetDebateTableDataForShareResponseType } from '../../apis/responses/live';
+import { useGetDebateTableDataForShare } from './useGetDebateTableDataForShare';
+
+const mockDebateTableForShare: GetDebateTableDataForShareResponseType = {
+  id: 302,
+  info: {
+    name: '공유용 자유토론 테이블',
+    agenda: '공유 토론 주제',
+    prosTeamName: '찬성',
+    consTeamName: '반대',
+  },
+  table: [
+    {
+      stance: 'NEUTRAL',
+      speechType: '자유토론',
+      bell: null,
+      boxType: 'TIME_BASED',
+      time: null,
+      timePerTeam: 60,
+      timePerSpeaking: 30,
+      speaker: null,
+    },
+  ],
+};
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('useGetDebateTableDataForShare', () => {
+  test('공유용 토론 테이블 데이터를 조회하고 캐시에 저장한다', async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    server.use(
+      http.get(`${ApiUrl.live}/table/customize/:tableId`, () => {
+        return HttpResponse.json(mockDebateTableForShare);
+      }),
+    );
+
+    const { result } = renderHook(() => useGetDebateTableDataForShare(302), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual(mockDebateTableForShare);
+    expect(queryClient.getQueryData(['DebateTableDataForShare', 302])).toEqual(
+      mockDebateTableForShare,
+    );
+  });
+});

--- a/src/hooks/query/useGetDebateTableDataForShare.ts
+++ b/src/hooks/query/useGetDebateTableDataForShare.ts
@@ -2,17 +2,20 @@ import { useQuery } from '@tanstack/react-query';
 import { getDebateTableDataForShare } from '../../apis/apis/live';
 import { GetDebateTableDataForShareResponseType } from '../../apis/responses/live';
 
-export const debateTableDataForShareQueryKey = (tableId: number) =>
+export const debateTableDataForShareQueryKey = (tableId: number | undefined) =>
   ['DebateTableDataForShare', tableId] as const;
 
 export function useGetDebateTableDataForShare(
-  tableId: number,
+  tableId: number | undefined,
   options?: { enabled?: boolean },
 ) {
+  const isEnabled =
+    tableId !== undefined && !isNaN(tableId) && (options?.enabled ?? true);
+
   return useQuery<GetDebateTableDataForShareResponseType>({
     queryKey: debateTableDataForShareQueryKey(tableId),
-    queryFn: () => getDebateTableDataForShare(tableId),
-    enabled: options?.enabled,
+    queryFn: () => getDebateTableDataForShare(tableId!), // 위 isEnabled에서 tableId 타입 검증에서 !가 들어가도 됨
+    enabled: isEnabled,
     throwOnError: false,
   });
 }

--- a/src/hooks/query/useGetDebateTableDataForShare.ts
+++ b/src/hooks/query/useGetDebateTableDataForShare.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { getDebateTableDataForShare } from '../../apis/apis/live';
+import { GetDebateTableDataForShareResponseType } from '../../apis/responses/live';
+
+export const debateTableDataForShareQueryKey = (tableId: number) =>
+  ['DebateTableDataForShare', tableId] as const;
+
+export function useGetDebateTableDataForShare(
+  tableId: number,
+  options?: { enabled?: boolean },
+) {
+  return useQuery<GetDebateTableDataForShareResponseType>({
+    queryKey: debateTableDataForShareQueryKey(tableId),
+    queryFn: () => getDebateTableDataForShare(tableId),
+    enabled: options?.enabled,
+    throwOnError: false,
+  });
+}

--- a/src/hooks/useModal.test.tsx
+++ b/src/hooks/useModal.test.tsx
@@ -1,6 +1,7 @@
 // useModal.test.tsx
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import { useModal } from './useModal';
 import { GlobalPortal } from '../util/GlobalPortal';
 
@@ -9,6 +10,7 @@ function TestModal({
 }: {
   closeOnOverlayClick?: boolean;
 }) {
+  const [renderCount, setRenderCount] = useState(0);
   const { openModal, closeModal, ModalWrapper } = useModal({
     closeOnOverlayClick,
   });
@@ -19,10 +21,16 @@ function TestModal({
         <button data-testid="open-btn" onClick={openModal}>
           모달 열기
         </button>
+        <button onClick={() => setRenderCount((count) => count + 1)}>
+          부모 리렌더 {renderCount}
+        </button>
 
         {/* 모달 렌더링 */}
         <ModalWrapper>
-          <div data-testid="modal-content">Hello Modal</div>
+          <div data-testid="modal-content">
+            Hello Modal
+            <input aria-label="모달 입력" />
+          </div>
         </ModalWrapper>
 
         {/* 모달 닫기 (직접 호출 테스트용) */}
@@ -121,5 +129,24 @@ describe('useModal Hook 테스트', () => {
     await user.click(overlay);
     // 여전히 모달이 열린 상태
     expect(screen.getByTestId('modal-content')).toBeInTheDocument();
+  });
+
+  test('부모가 리렌더되어도 열린 모달의 내부 상태를 유지한다.', async () => {
+    const user = userEvent.setup();
+    render(<TestModal />);
+
+    await user.click(screen.getByTestId('open-btn'));
+    const inputBeforeRerender = screen.getByRole('textbox', {
+      name: '모달 입력',
+    });
+    await user.type(inputBeforeRerender, '입력값');
+
+    await user.click(screen.getByRole('button', { name: '부모 리렌더 0' }));
+
+    const inputAfterRerender = screen.getByRole('textbox', {
+      name: '모달 입력',
+    });
+    expect(inputAfterRerender).toBe(inputBeforeRerender);
+    expect(inputAfterRerender).toHaveValue('입력값');
   });
 });

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -9,6 +9,15 @@ interface UseModalOptions {
   onClose?: () => void;
 }
 
+interface ModalWrapperProps {
+  children: ReactNode;
+  closeButtonColor?: string;
+}
+
+// onClose가 없을 때 렌더마다 새 빈 함수를 만들면 연관된 콜백과 ModalWrapper의 참조도 바뀐다.
+// 동일한 기본 함수를 재사용해 열린 모달이 불필요하게 재마운트되지 않도록 한다.
+function noop() {}
+
 /**
  * 모달을 쉽게 열고 닫을 수 있는 훅.
  * @param options 모달 표시 옵션
@@ -18,7 +27,7 @@ export function useModal(options: UseModalOptions = {}) {
   const {
     closeOnOverlayClick = true,
     isCloseButtonExist = true,
-    onClose = () => {},
+    onClose = noop,
   } = options;
 
   const openModal = useCallback(() => {
@@ -51,39 +60,39 @@ export function useModal(options: UseModalOptions = {}) {
     [closeModal, closeOnOverlayClick],
   );
 
-  const ModalWrapper = ({
-    children,
-    closeButtonColor = 'text-neutral-0 hover:text-gray-300',
-  }: {
-    children: ReactNode;
-    closeButtonColor?: string;
-  }) => {
-    const { t } = useTranslation();
-    if (!isOpen) return null;
+  const ModalWrapper = useCallback(
+    function ModalWrapper({
+      children,
+      closeButtonColor = 'text-neutral-0 hover:text-gray-300',
+    }: ModalWrapperProps) {
+      const { t } = useTranslation();
+      if (!isOpen) return null;
 
-    return (
-      <GlobalPortal.Consumer>
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
-          onClick={handleOverlayClick}
-        >
-          <div className="relative overflow-hidden rounded-[20px] bg-white shadow-lg">
-            {children}
-            {isCloseButtonExist && (
-              <button
-                type="button"
-                onClick={closeModal}
-                className={`absolute right-4 top-4 text-3xl ${closeButtonColor}`}
-                aria-label={t('모달 닫기')}
-              >
-                <DTClose className="size-[32px]" />
-              </button>
-            )}
+      return (
+        <GlobalPortal.Consumer>
+          <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+            onClick={handleOverlayClick}
+          >
+            <div className="relative overflow-hidden rounded-[20px] bg-white shadow-lg">
+              {children}
+              {isCloseButtonExist && (
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className={`absolute right-4 top-4 text-3xl ${closeButtonColor}`}
+                  aria-label={t('모달 닫기')}
+                >
+                  <DTClose className="size-[32px]" />
+                </button>
+              )}
+            </div>
           </div>
-        </div>
-      </GlobalPortal.Consumer>
-    );
-  };
+        </GlobalPortal.Consumer>
+      );
+    },
+    [closeModal, handleOverlayClick, isCloseButtonExist, isOpen],
+  );
 
   return { isOpen, openModal, closeModal, ModalWrapper };
 }

--- a/src/mocks/handlers/live.ts
+++ b/src/mocks/handlers/live.ts
@@ -1,8 +1,106 @@
 import { http, HttpResponse } from 'msw';
 import { ApiUrl } from '../../apis/endpoints';
-import { GetChairmanTokenResponseType } from '../../apis/responses/live';
+import {
+  GetChairmanTokenResponseType,
+  GetDebateTableDataForShareResponseType,
+} from '../../apis/responses/live';
 
 export const liveHandlers = [
+  http.get(`${ApiUrl.live}/table/customize/:tableId`, ({ params }) => {
+    const { tableId } = params;
+    console.log(`# tableId = ${tableId}`);
+
+    const response: GetDebateTableDataForShareResponseType = {
+      id: 5,
+      info: {
+        name: '나의 자유토론 테이블',
+        agenda: '토론 주제',
+        prosTeamName: '찬성',
+        consTeamName: '반대',
+      },
+      table: [
+        {
+          stance: 'NEUTRAL',
+          speechType: '자유토론',
+          bell: null,
+          boxType: 'TIME_BASED',
+          time: null,
+          timePerTeam: 60,
+          timePerSpeaking: 33,
+          speaker: null,
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '자유토론',
+          bell: null,
+          boxType: 'TIME_BASED',
+          time: null,
+          timePerTeam: 35,
+          timePerSpeaking: null,
+          speaker: null,
+        },
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          bell: [
+            { type: 'BEFORE_END', time: 0, count: 2 },
+            { type: 'AFTER_START', time: 5, count: 1 },
+          ],
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'PROS',
+          speechType: '입론',
+          bell: [
+            { type: 'BEFORE_END', time: 0, count: 2 },
+            { type: 'AFTER_START', time: 7, count: 3 },
+          ],
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 1',
+        },
+        {
+          stance: 'NEUTRAL',
+          speechType: '작전 시간',
+          bell: [{ type: 'BEFORE_END', time: 0, count: 2 }],
+          boxType: 'NORMAL',
+          time: 60,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: null,
+        },
+        {
+          stance: 'CONS',
+          speechType: '최종 발언',
+          bell: [{ type: 'BEFORE_END', time: 0, count: 2 }],
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+        {
+          stance: 'PROS',
+          speechType: '최종 발언',
+          bell: [{ type: 'BEFORE_END', time: 0, count: 2 }],
+          boxType: 'NORMAL',
+          time: 120,
+          timePerTeam: null,
+          timePerSpeaking: null,
+          speaker: '발언자 2',
+        },
+      ],
+    };
+
+    return HttpResponse.json(response);
+  }),
+
   http.get(`${ApiUrl.live}/:tableId/chairman-token`, ({ params }) => {
     const { tableId } = params;
     console.log(`# Table ID = ${tableId}`);

--- a/src/page/TimerPage/hooks/useTimerHotkey.ts
+++ b/src/page/TimerPage/hooks/useTimerHotkey.ts
@@ -105,7 +105,7 @@ export function useTimerHotkey(
 
             onEvent(handleSwitching, 'TEAM_SWITCH');
           }
-          
+
           break;
         case 'KeyL':
           // 반대 진영 선택 및 찬성 타이머 정지
@@ -120,7 +120,7 @@ export function useTimerHotkey(
 
             onEvent(handleSwitching, 'TEAM_SWITCH');
           }
-          
+
           break;
         case 'Enter':
         case 'NumpadEnter':


### PR DESCRIPTION
# 🚩 연관 이슈

closed #458 

# 📝 작업 내용

별 거 없습니다. 라이브 공유용 테이블 데이터 GET API 구현.

- 응답 형식(response type) 정의
- API를 호출하는 axios 계층의 저수준 함수 구현
- axios 저수준 함수를 사용하는 TanStack Query 기반 React Hook 구현
- 추가된 코드에 대한 테스트 함수 및 msw 모방 핸들러 추가

# 🏞️ 스크린샷 (선택)
없음

# 🗣️ 리뷰 요구사항 (선택)
없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 라이브 토론 테이블 공유용 데이터를 테이블 ID 기반으로 조회할 수 있습니다.
  * 공유 데이터 조회를 위한 React Query 훅과 쿼리 키/활성화 제어를 제공합니다.
* **테스트**
  * 라이브 공유 테이블 조회 API 및 훅 동작을 검증하는 테스트를 추가하고, 응답 모킹을 확장했습니다.
* **버그 수정**
  * 모달 리렌더 시 입력 노드와 값 유지가 확인되도록 테스트를 보강했습니다.
* **리팩터링**
  * 모달 내부 콜백/래퍼 렌더 최적화를 적용했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->