### PR TITLE
[FEAT] Sentry 알림이 대응 판단으로 이어지도록 이벤트 맥락 개선

### DIFF
--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -19,6 +19,7 @@ import {
   markSentryCaptured,
   sanitizeSentryContext,
   sanitizeSentrySearch,
+  sanitizeSentryUrl,
   shouldSkipApiError,
 } from '../util/sentry';
 
@@ -73,7 +74,7 @@ function captureClientApiError(error: unknown) {
     scope.setContext('request', {
       pathname: metadata.pathname,
       search: sanitizeSentrySearch(window.location.search),
-      url: error.config?.url,
+      url: sanitizeSentryUrl(error.config?.url),
       method: error.config?.method,
       params: sanitizeSentryContext(error.config?.params),
       timeout: error.config?.timeout ?? requestTimeoutMs,

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -17,6 +17,8 @@ import {
   buildSentryApiErrorMetadata,
   createSentryApiError,
   markSentryCaptured,
+  sanitizeSentryContext,
+  sanitizeSentrySearch,
   shouldSkipApiError,
 } from '../util/sentry';
 
@@ -70,16 +72,16 @@ function captureClientApiError(error: unknown) {
     });
     scope.setContext('request', {
       pathname: metadata.pathname,
-      search: window.location.search,
+      search: sanitizeSentrySearch(window.location.search),
       url: error.config?.url,
       method: error.config?.method,
-      params: error.config?.params,
+      params: sanitizeSentryContext(error.config?.params),
       timeout: error.config?.timeout ?? requestTimeoutMs,
       errorCode: error.code,
     });
     scope.setContext('response', {
       status: metadata.status,
-      data: error.response?.data,
+      data: sanitizeSentryContext(error.response?.data),
     });
     scope.setFingerprint([
       'api-error',

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
 import * as Sentry from '@sentry/react';
-import type { SeverityLevel } from '@sentry/react';
 import {
   getAccessToken,
   removeAccessToken,
@@ -14,37 +13,16 @@ import {
   isSupportedLang,
 } from '../util/languageRouting';
 import { analyticsManager } from '../util/analytics';
+import {
+  buildSentryApiErrorMetadata,
+  createSentryApiError,
+  markSentryCaptured,
+  shouldSkipApiError,
+} from '../util/sentry';
 
 // Get current mode (DEV, PROD or TEST)
 const currentMode = import.meta.env.MODE;
 const requestTimeoutMs = 5000;
-
-type SentryCapturedError = {
-  __sentry_captured__?: boolean;
-};
-
-export function normalizeEndpoint(url?: string) {
-  if (!url) {
-    return 'unknown';
-  }
-
-  return url
-    .replace(
-      /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
-      ':uuid',
-    )
-    .replace(/[0-9]+/g, ':id');
-}
-
-function resolveApiErrorLevel(status: number | undefined) {
-  // 400/409/422는 사용자 입력·요청 상태 충돌 성격이 커서 warning으로 분리
-  if (status === 400 || status === 409 || status === 422) {
-    return 'warning';
-  }
-
-  // 그 외(주로 5xx/네트워크 실패)는 운영 대응이 필요한 장애 신호로 처리
-  return 'error';
-}
 
 // Axios instance
 export const axiosInstance = axios.create({
@@ -75,44 +53,45 @@ function captureClientApiError(error: unknown) {
     return;
   }
 
-  const { response, config, code } = error;
-  const status = response?.status;
-  const normalizedUrl = normalizeEndpoint(config?.url);
-  const requestMethod = config?.method?.toUpperCase() ?? 'UNKNOWN';
-
-  // 401은 토큰 재발급 후 원요청 재시도로 자동 복구되는 정상 인증 흐름이므로 수집에서 제외
-  // 정상/리다이렉트 응답(<400)도 제외하고, 그 외 4xx/5xx/네트워크 실패/타임아웃은 수집
-  if (status === 401 || (status !== undefined && status < 400)) {
+  if (shouldSkipApiError(error)) {
     return;
   }
 
-  const level: SeverityLevel = resolveApiErrorLevel(status);
+  const metadata = buildSentryApiErrorMetadata(error, window.location.pathname);
+  const sentryError = createSentryApiError(error, metadata);
 
-  Sentry.captureException(error, {
-    level,
-    tags: {
+  Sentry.withScope((scope) => {
+    scope.setLevel(metadata.level);
+    scope.setTags({
       errorType: 'api-error',
-      httpStatus: status ? String(status) : 'network-error',
-      endpoint: `${requestMethod} ${normalizedUrl}`,
-    },
-    extra: {
-      pathname: window.location.pathname,
+      httpStatus: metadata.statusLabel,
+      endpoint: `${metadata.method} ${metadata.endpoint}`,
+      feature: metadata.feature,
+    });
+    scope.setContext('request', {
+      pathname: metadata.pathname,
       search: window.location.search,
-      url: config?.url,
-      method: config?.method,
-      params: config?.params,
-      timeout: config?.timeout ?? requestTimeoutMs,
-      errorCode: code,
-    },
-    fingerprint: [
+      url: error.config?.url,
+      method: error.config?.method,
+      params: error.config?.params,
+      timeout: error.config?.timeout ?? requestTimeoutMs,
+      errorCode: error.code,
+    });
+    scope.setContext('response', {
+      status: metadata.status,
+      data: error.response?.data,
+    });
+    scope.setFingerprint([
       'api-error',
-      String(status ?? 'network-error'),
-      requestMethod,
-      normalizedUrl,
-    ],
+      metadata.statusLabel,
+      metadata.method,
+      metadata.endpoint,
+    ]);
+
+    Sentry.captureException(sentryError);
   });
 
-  (error as SentryCapturedError).__sentry_captured__ = true;
+  markSentryCaptured(error);
 }
 
 // Response interceptor

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { AxiosResponse } from 'axios';
 import axiosInstance from './axiosInstance';
+import { isSentryCaptured } from '../util/sentry';
 
 // HTTP request methods
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
@@ -18,10 +19,6 @@ export class APIError extends Error {
     this.name = 'APIError';
   }
 }
-
-type SentryCapturedError = {
-  __sentry_captured__?: boolean;
-};
 
 // Low-level http request function
 export async function request<T>(
@@ -59,9 +56,7 @@ export async function request<T>(
         error.response?.status || 500,
         responseData,
       );
-      apiError.__sentry_captured__ = (
-        error as SentryCapturedError
-      ).__sentry_captured__;
+      apiError.__sentry_captured__ = isSentryCaptured(error);
       throw apiError;
     }
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, ErrorInfo, ReactNode } from 'react';
 import * as Sentry from '@sentry/react';
 import ErrorPage from './ErrorPage';
 import {
+  createSentryRenderError,
   isSentryCaptured,
   resolveFeatureFromPathname,
   sanitizeSentrySearch,
@@ -40,6 +41,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
     // 이미 API 인터셉터 등에서 캡처된 에러가 아니라면 전송
     if (!isSentryCaptured(error)) {
       const feature = resolveFeatureFromPathname(window.location.pathname);
+      const sentryError = createSentryRenderError(error, feature);
 
       Sentry.withScope((scope) => {
         scope.setLevel('fatal');
@@ -50,11 +52,13 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
         scope.setContext('render', {
           pathname: window.location.pathname,
           search: sanitizeSentrySearch(window.location.search),
+          errorName: error.name,
+          errorMessage: error.message,
           componentStack: errorInfo.componentStack,
         });
         scope.setFingerprint(['render-error', feature]);
 
-        Sentry.captureException(error);
+        Sentry.captureException(sentryError);
       });
     }
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -1,6 +1,10 @@
 import { Component, ErrorInfo, ReactNode } from 'react';
 import * as Sentry from '@sentry/react';
 import ErrorPage from './ErrorPage';
+import {
+  isSentryCaptured,
+  resolveFeatureFromPathname,
+} from '../../util/sentry';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
@@ -14,10 +18,6 @@ interface ErrorBoundaryState {
 
 const defaultError = new Error('알 수 없는 오류');
 const defaultStack = '스택 정보 없음';
-
-type SentryCapturedError = {
-  __sentry_captured__?: boolean;
-};
 
 class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
@@ -37,16 +37,23 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
     // 이미 API 인터셉터 등에서 캡처된 에러가 아니라면 전송
-    if (!(error as SentryCapturedError).__sentry_captured__) {
-      Sentry.captureException(error, {
-        tags: {
+    if (!isSentryCaptured(error)) {
+      const feature = resolveFeatureFromPathname(window.location.pathname);
+
+      Sentry.withScope((scope) => {
+        scope.setLevel('fatal');
+        scope.setTags({
           errorType: 'render-error',
-        },
-        extra: {
+          feature,
+        });
+        scope.setContext('render', {
           pathname: window.location.pathname,
           search: window.location.search,
           componentStack: errorInfo.componentStack,
-        },
+        });
+        scope.setFingerprint(['render-error', feature]);
+
+        Sentry.captureException(error);
       });
     }
 

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -4,6 +4,7 @@ import ErrorPage from './ErrorPage';
 import {
   isSentryCaptured,
   resolveFeatureFromPathname,
+  sanitizeSentrySearch,
 } from '../../util/sentry';
 
 interface ErrorBoundaryProps {
@@ -48,7 +49,7 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
         });
         scope.setContext('render', {
           pathname: window.location.pathname,
-          search: window.location.search,
+          search: sanitizeSentrySearch(window.location.search),
           componentStack: errorInfo.componentStack,
         });
         scope.setFingerprint(['render-error', feature]);

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -1,0 +1,95 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import {
+  buildSentryApiErrorMetadata,
+  createSentryApiError,
+  normalizeEndpoint,
+  resolveApiErrorLevel,
+  resolveFeatureFromPathname,
+  shouldSkipApiError,
+} from './sentry';
+
+describe('sentry 유틸', () => {
+  it('같은 API 장애가 하나의 알림 이슈로 묶이도록 가변 경로 값을 제거한다', () => {
+    expect(normalizeEndpoint('/api/tables/123/votes/456?tab=1')).toBe(
+      '/api/tables/:id/votes/:id',
+    );
+    expect(
+      normalizeEndpoint(
+        'https://example.com/api/tables/9e770d72-7a5d-4fd7-8c4e-7cf6115a1f6b',
+      ),
+    ).toBe('/api/tables/:uuid');
+  });
+
+  it('알림만 보고 사용자에게 영향받은 기능을 판단할 수 있도록 pathname을 기능 단위로 분류한다', () => {
+    expect(resolveFeatureFromPathname('/ko/home')).toBe('landing');
+    expect(resolveFeatureFromPathname('/en/table/customize/1')).toBe('timer');
+    expect(resolveFeatureFromPathname('/table/customize/1/end')).toBe(
+      'debate-end',
+    );
+    expect(resolveFeatureFromPathname('/table/customize/1/end/vote/2')).toBe(
+      'vote',
+    );
+    expect(resolveFeatureFromPathname('/live/1')).toBe('live-share');
+    expect(resolveFeatureFromPathname('/oauth')).toBe('auth');
+  });
+
+  it('타이머, 투표, 실시간 공유의 5xx는 핵심 흐름 장애로 보고 즉시 대응 대상으로 분류한다', () => {
+    expect(resolveApiErrorLevel(500, 'timer')).toBe('fatal');
+    expect(resolveApiErrorLevel(500, 'vote')).toBe('fatal');
+    expect(resolveApiErrorLevel(500, 'live-share')).toBe('fatal');
+    expect(resolveApiErrorLevel(500, 'landing')).toBe('error');
+  });
+
+  it('사용자 입력이나 상태 충돌처럼 예상 가능한 에러는 즉시 대응 알림보다 낮은 우선순위로 분류한다', () => {
+    expect(resolveApiErrorLevel(400, 'timer')).toBe('warning');
+    expect(resolveApiErrorLevel(404, 'vote')).toBe('warning');
+    expect(resolveApiErrorLevel(409, 'live-share')).toBe('warning');
+    expect(resolveApiErrorLevel(422, 'table-composition')).toBe('warning');
+  });
+
+  it('토큰 재발급으로 복구될 수 있는 401은 즉시 대응 알림에서 제외한다', () => {
+    const unauthorizedError = new AxiosError(
+      'unauthorized',
+      undefined,
+      undefined,
+      undefined,
+      {
+        status: 401,
+        statusText: 'Unauthorized',
+        headers: {},
+        config: { headers: new AxiosHeaders() },
+        data: null,
+      },
+    );
+    expect(shouldSkipApiError(unauthorizedError)).toBe(true);
+  });
+
+  it('사용자 오프라인 상태의 네트워크 에러는 운영자가 바로 대응하기 어려워 수집하지 않는다', () => {
+    const offlineError = new AxiosError('Network Error', 'ERR_NETWORK');
+
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(false);
+
+    expect(shouldSkipApiError(offlineError)).toBe(true);
+  });
+
+  it('온라인 상태에서 발생한 네트워크 에러는 서버 연결 실패 가능성이 있어 수집한다', () => {
+    const onlineNetworkError = new AxiosError('Network Error', 'ERR_NETWORK');
+
+    vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
+
+    expect(shouldSkipApiError(onlineNetworkError)).toBe(false);
+  });
+
+  it('알림 제목만 보고 실패한 요청을 파악할 수 있도록 상태 코드, method, endpoint를 담는다', () => {
+    const error = new AxiosError('Request failed', undefined, {
+      method: 'post',
+      url: '/api/live/123',
+      headers: new AxiosHeaders(),
+    });
+    const metadata = buildSentryApiErrorMetadata(error, '/ko/live/123');
+
+    const sentryError = createSentryApiError(error, metadata);
+
+    expect(sentryError.name).toBe('[network-error] POST /api/live/:id');
+  });
+});

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -5,6 +5,8 @@ import {
   normalizeEndpoint,
   resolveApiErrorLevel,
   resolveFeatureFromPathname,
+  sanitizeSentryContext,
+  sanitizeSentrySearch,
   shouldSkipApiError,
 } from './sentry';
 
@@ -78,6 +80,38 @@ describe('sentry 유틸', () => {
     vi.spyOn(navigator, 'onLine', 'get').mockReturnValue(true);
 
     expect(shouldSkipApiError(onlineNetworkError)).toBe(false);
+  });
+
+  it('Sentry context에 원본 요청/응답 데이터가 그대로 전송되지 않도록 민감 필드를 마스킹한다', () => {
+    expect(
+      sanitizeSentryContext({
+        email: 'user@example.com',
+        inviteCode: 'SECRET',
+        page: 1,
+        nested: {
+          token: 'TOKEN',
+          tableId: 12,
+        },
+      }),
+    ).toEqual({
+      email: '[Filtered]',
+      inviteCode: '[Filtered]',
+      page: 1,
+      nested: {
+        token: '[Filtered]',
+        tableId: 12,
+      },
+    });
+  });
+
+  it('Sentry context에 남길 query string에서 OAuth와 인증 관련 값을 마스킹한다', () => {
+    expect(
+      sanitizeSentrySearch(
+        '?code=AUTH_CODE&state=STATE&access_token=TOKEN&page=1',
+      ),
+    ).toBe(
+      '?code=%5BFiltered%5D&state=%5BFiltered%5D&access_token=%5BFiltered%5D&page=1',
+    );
   });
 
   it('알림 제목을 level, error type, feature, status, endpoint 순서로 구성해 대응 판단 흐름을 만든다', () => {

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -25,6 +25,12 @@ describe('sentry 유틸', () => {
   it('알림만 보고 사용자에게 영향받은 기능을 판단할 수 있도록 pathname을 기능 단위로 분류한다', () => {
     expect(resolveFeatureFromPathname('/ko/home')).toBe('landing');
     expect(resolveFeatureFromPathname('/en/table/customize/1')).toBe('timer');
+    expect(resolveFeatureFromPathname('/composition')).toBe(
+      'table-composition',
+    );
+    expect(resolveFeatureFromPathname('/overview/customize/1')).toBe(
+      'table-overview',
+    );
     expect(resolveFeatureFromPathname('/table/customize/1/end')).toBe(
       'debate-end',
     );
@@ -33,6 +39,15 @@ describe('sentry 유틸', () => {
     );
     expect(resolveFeatureFromPathname('/live/1')).toBe('live-share');
     expect(resolveFeatureFromPathname('/oauth')).toBe('auth');
+  });
+
+  it('유사 접두사 경로가 실제 기능 경로로 오분류되지 않도록 세그먼트 경계를 검사한다', () => {
+    expect(resolveFeatureFromPathname('/livechat')).toBe('unknown');
+    expect(resolveFeatureFromPathname('/sharepoint')).toBe('unknown');
+    expect(resolveFeatureFromPathname('/overviewer')).toBe('unknown');
+    expect(resolveFeatureFromPathname('/vote-result')).toBe('unknown');
+    expect(resolveFeatureFromPathname('/oauth-callback')).toBe('unknown');
+    expect(resolveFeatureFromPathname('/table/customizer/1')).toBe('unknown');
   });
 
   it('타이머, 투표, 실시간 공유의 5xx는 핵심 흐름 장애로 보고 즉시 대응 대상으로 분류한다', () => {

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -7,6 +7,7 @@ import {
   resolveFeatureFromPathname,
   sanitizeSentryContext,
   sanitizeSentrySearch,
+  sanitizeSentryUrl,
   shouldSkipApiError,
 } from './sentry';
 
@@ -126,6 +127,19 @@ describe('sentry 유틸', () => {
       ),
     ).toBe(
       '?code=%5BFiltered%5D&state=%5BFiltered%5D&access_token=%5BFiltered%5D&page=1',
+    );
+  });
+
+  it('Sentry context에 남길 요청 URL은 경로와 비민감 query를 유지하고 민감 query만 마스킹한다', () => {
+    expect(sanitizeSentryUrl('/api/member?email=user@example.com&page=1')).toBe(
+      '/api/member?email=%5BFiltered%5D&page=1',
+    );
+    expect(
+      sanitizeSentryUrl(
+        'https://api.example.com/oauth?code=AUTH_CODE&redirect=/home',
+      ),
+    ).toBe(
+      'https://api.example.com/oauth?code=%5BFiltered%5D&redirect=%2Fhome',
     );
   });
 

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -2,6 +2,7 @@ import { AxiosError, AxiosHeaders } from 'axios';
 import {
   buildSentryApiErrorMetadata,
   createSentryApiError,
+  createSentryRenderError,
   normalizeEndpoint,
   resolveApiErrorLevel,
   resolveFeatureFromPathname,
@@ -155,6 +156,16 @@ describe('sentry 유틸', () => {
 
     expect(sentryError.name).toBe(
       'error · api-error · live-share · [network-error] POST /api/live/:id',
+    );
+  });
+
+  it('렌더링 에러 알림 제목도 level, error type, feature, 원본 에러 순서로 구성한다', () => {
+    const error = new TypeError('Cannot read properties of undefined');
+
+    const sentryError = createSentryRenderError(error, 'timer');
+
+    expect(sentryError.name).toBe(
+      'fatal · render-error · timer · TypeError: Cannot read properties of undefined',
     );
   });
 });

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -80,7 +80,7 @@ describe('sentry 유틸', () => {
     expect(shouldSkipApiError(onlineNetworkError)).toBe(false);
   });
 
-  it('알림 제목만 보고 실패한 요청을 파악할 수 있도록 상태 코드, method, endpoint를 담는다', () => {
+  it('알림 제목을 level, error type, feature, status, endpoint 순서로 구성해 대응 판단 흐름을 만든다', () => {
     const error = new AxiosError('Request failed', undefined, {
       method: 'post',
       url: '/api/live/123',
@@ -90,6 +90,8 @@ describe('sentry 유틸', () => {
 
     const sentryError = createSentryApiError(error, metadata);
 
-    expect(sentryError.name).toBe('[network-error] POST /api/live/:id');
+    expect(sentryError.name).toBe(
+      'error · api-error · live-share · [network-error] POST /api/live/:id',
+    );
   });
 });

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -1,0 +1,193 @@
+import { AxiosError } from 'axios';
+import type { SeverityLevel } from '@sentry/react';
+
+export type DebateFeature =
+  | 'landing'
+  | 'table-list'
+  | 'table-composition'
+  | 'table-overview'
+  | 'timer'
+  | 'debate-end'
+  | 'vote'
+  | 'auth'
+  | 'share'
+  | 'live-share'
+  | 'unknown';
+
+const criticalFeatures: DebateFeature[] = ['timer', 'vote', 'live-share'];
+
+type SentryCapturedError = {
+  __sentry_captured__?: boolean;
+};
+
+export type SentryApiErrorMetadata = {
+  status: number | undefined;
+  statusLabel: string;
+  method: string;
+  endpoint: string;
+  feature: DebateFeature;
+  level: SeverityLevel;
+  pathname: string;
+};
+
+export function normalizeEndpoint(url?: string) {
+  if (!url) {
+    return 'unknown';
+  }
+
+  const path = resolveUrlPath(url);
+
+  return path
+    .replace(
+      /\b[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\b/gi,
+      ':uuid',
+    )
+    .replace(/\/[0-9]+(?=\/|$)/g, '/:id');
+}
+
+export function resolveFeatureFromPathname(pathname: string): DebateFeature {
+  const path = removeLanguagePrefix(pathname);
+
+  if (path === '/home') {
+    return 'landing';
+  }
+
+  if (path === '/') {
+    return 'table-list';
+  }
+
+  if (path.startsWith('/composition')) {
+    return 'table-composition';
+  }
+
+  if (path.startsWith('/overview')) {
+    return 'table-overview';
+  }
+
+  if (path.includes('/end/vote') || path.startsWith('/vote')) {
+    return 'vote';
+  }
+
+  if (path.includes('/end/feedback')) {
+    return 'timer';
+  }
+
+  if (path.includes('/end')) {
+    return 'debate-end';
+  }
+
+  if (path.startsWith('/table/customize')) {
+    return 'timer';
+  }
+
+  if (path.startsWith('/oauth')) {
+    return 'auth';
+  }
+
+  if (path.startsWith('/share')) {
+    return 'share';
+  }
+
+  if (path.startsWith('/live')) {
+    return 'live-share';
+  }
+
+  return 'unknown';
+}
+
+export function resolveApiErrorLevel(
+  status: number | undefined,
+  feature: DebateFeature,
+): SeverityLevel {
+  if (status === 400 || status === 404 || status === 409 || status === 422) {
+    return 'warning';
+  }
+
+  if (
+    status !== undefined &&
+    status >= 500 &&
+    criticalFeatures.includes(feature)
+  ) {
+    return 'fatal';
+  }
+
+  return 'error';
+}
+
+export function shouldSkipApiError(error: AxiosError) {
+  const status = error.response?.status;
+
+  if (status === 401 || (status !== undefined && status < 400)) {
+    return true;
+  }
+
+  return isOfflineNetworkError(error.code);
+}
+
+export function buildSentryApiErrorMetadata(
+  error: AxiosError,
+  pathname: string,
+): SentryApiErrorMetadata {
+  const status = error.response?.status;
+  const method = error.config?.method?.toUpperCase() ?? 'UNKNOWN';
+  const endpoint = normalizeEndpoint(error.config?.url);
+  const feature = resolveFeatureFromPathname(pathname);
+
+  return {
+    status,
+    statusLabel: status ? String(status) : 'network-error',
+    method,
+    endpoint,
+    feature,
+    level: resolveApiErrorLevel(status, feature),
+    pathname,
+  };
+}
+
+export function createSentryApiError(
+  error: AxiosError,
+  metadata: SentryApiErrorMetadata,
+) {
+  const sentryError = new Error(error.message);
+  sentryError.name = `[${metadata.statusLabel}] ${metadata.method} ${metadata.endpoint}`;
+  sentryError.stack = error.stack;
+  (sentryError as SentryCapturedError).__sentry_captured__ = true;
+
+  return sentryError;
+}
+
+export function markSentryCaptured(error: unknown) {
+  if (typeof error === 'object' && error !== null) {
+    (error as SentryCapturedError).__sentry_captured__ = true;
+  }
+}
+
+export function isSentryCaptured(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    (error as SentryCapturedError).__sentry_captured__ === true
+  );
+}
+
+function resolveUrlPath(url: string) {
+  try {
+    return new URL(url, window.location.origin).pathname;
+  } catch {
+    return url.split('?')[0] || 'unknown';
+  }
+}
+
+function removeLanguagePrefix(pathname: string) {
+  const path = pathname.replace(/^\/(ko|en)(?=\/|$)/, '');
+
+  return path === '' ? '/' : path;
+}
+
+function isOfflineNetworkError(code?: string) {
+  return (
+    typeof navigator !== 'undefined' &&
+    navigator.onLine === false &&
+    (code === 'ERR_NETWORK' || code === 'ECONNABORTED' || code === 'ETIMEDOUT')
+  );
+}

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -149,7 +149,7 @@ export function createSentryApiError(
   metadata: SentryApiErrorMetadata,
 ) {
   const sentryError = new Error(error.message);
-  sentryError.name = `[${metadata.statusLabel}] ${metadata.method} ${metadata.endpoint}`;
+  sentryError.name = `${metadata.level} · api-error · ${metadata.feature} · [${metadata.statusLabel}] ${metadata.method} ${metadata.endpoint}`;
   sentryError.stack = error.stack;
   (sentryError as SentryCapturedError).__sentry_captured__ = true;
 

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -15,6 +15,22 @@ export type DebateFeature =
   | 'unknown';
 
 const criticalFeatures: DebateFeature[] = ['timer', 'vote', 'live-share'];
+const filteredValue = '[Filtered]';
+const sensitiveKeys = [
+  'authorization',
+  'access_token',
+  'accessToken',
+  'refresh_token',
+  'refreshToken',
+  'token',
+  'id_token',
+  'idToken',
+  'code',
+  'state',
+  'email',
+  'password',
+  'inviteCode',
+];
 
 type SentryCapturedError = {
   __sentry_captured__?: boolean;
@@ -170,6 +186,40 @@ export function isSentryCaptured(error: unknown) {
   );
 }
 
+export function sanitizeSentrySearch(search: string) {
+  if (!search) {
+    return '';
+  }
+
+  const params = new URLSearchParams(search);
+  params.forEach((_, key) => {
+    if (isSensitiveKey(key)) {
+      params.set(key, filteredValue);
+    }
+  });
+
+  const sanitizedSearch = params.toString();
+
+  return sanitizedSearch ? `?${sanitizedSearch}` : '';
+}
+
+export function sanitizeSentryContext(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sanitizeSentryContext);
+  }
+
+  if (typeof value !== 'object' || value === null) {
+    return value;
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).map(([key, nestedValue]) => [
+      key,
+      isSensitiveKey(key) ? filteredValue : sanitizeSentryContext(nestedValue),
+    ]),
+  );
+}
+
 function resolveUrlPath(url: string) {
   try {
     return new URL(url, window.location.origin).pathname;
@@ -189,5 +239,11 @@ function isOfflineNetworkError(code?: string) {
     typeof navigator !== 'undefined' &&
     navigator.onLine === false &&
     (code === 'ERR_NETWORK' || code === 'ECONNABORTED' || code === 'ETIMEDOUT')
+  );
+}
+
+function isSensitiveKey(key: string) {
+  return sensitiveKeys.some(
+    (sensitiveKey) => sensitiveKey.toLowerCase() === key.toLowerCase(),
   );
 }

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -184,6 +184,15 @@ export function createSentryApiError(
   return sentryError;
 }
 
+export function createSentryRenderError(error: Error, feature: DebateFeature) {
+  const sentryError = new Error(error.message);
+  sentryError.name = `fatal · render-error · ${feature} · ${error.name}: ${error.message}`;
+  sentryError.stack = error.stack;
+  (sentryError as SentryCapturedError).__sentry_captured__ = true;
+
+  return sentryError;
+}
+
 export function markSentryCaptured(error: unknown) {
   if (typeof error === 'object' && error !== null) {
     (error as SentryCapturedError).__sentry_captured__ = true;

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -215,6 +215,26 @@ export function sanitizeSentrySearch(search: string) {
   return sanitizedSearch ? `?${sanitizedSearch}` : '';
 }
 
+export function sanitizeSentryUrl(url?: string) {
+  if (!url) {
+    return url;
+  }
+
+  try {
+    const isAbsoluteUrl = /^[a-z][a-z\d+\-.]*:\/\//i.test(url);
+    const parsedUrl = new URL(url, window.location.origin);
+    const sanitizedSearch = sanitizeSentrySearch(parsedUrl.search);
+    const sanitizedPath = `${parsedUrl.pathname}${sanitizedSearch}${parsedUrl.hash}`;
+
+    return isAbsoluteUrl
+      ? `${parsedUrl.origin}${sanitizedPath}`
+      : sanitizedPath;
+  } catch {
+    const [pathname, search = ''] = url.split('?');
+    return `${pathname}${sanitizeSentrySearch(search ? `?${search}` : '')}`;
+  }
+}
+
 export function sanitizeSentryContext(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(sanitizeSentryContext);

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -72,39 +72,51 @@ export function resolveFeatureFromPathname(pathname: string): DebateFeature {
     return 'table-list';
   }
 
-  if (path.startsWith('/composition')) {
+  if (matchesPathPrefix(path, '/composition')) {
     return 'table-composition';
   }
 
-  if (path.startsWith('/overview')) {
+  if (matchesPathPrefix(path, '/overview')) {
     return 'table-overview';
   }
 
-  if (path.includes('/end/vote') || path.startsWith('/vote')) {
+  if (
+    matchesPathPrefix(path, '/vote') ||
+    (matchesPathPrefix(path, '/table/customize') &&
+      hasPathSegment(path, 'end') &&
+      hasPathSegment(path, 'vote'))
+  ) {
     return 'vote';
   }
 
-  if (path.includes('/end/feedback')) {
+  if (
+    matchesPathPrefix(path, '/table/customize') &&
+    hasPathSegment(path, 'end') &&
+    hasPathSegment(path, 'feedback')
+  ) {
     return 'timer';
   }
 
-  if (path.includes('/end')) {
+  if (
+    matchesPathPrefix(path, '/table/customize') &&
+    hasPathSegment(path, 'end')
+  ) {
     return 'debate-end';
   }
 
-  if (path.startsWith('/table/customize')) {
+  if (matchesPathPrefix(path, '/table/customize')) {
     return 'timer';
   }
 
-  if (path.startsWith('/oauth')) {
+  if (matchesPathPrefix(path, '/oauth')) {
     return 'auth';
   }
 
-  if (path.startsWith('/share')) {
+  if (matchesPathPrefix(path, '/share')) {
     return 'share';
   }
 
-  if (path.startsWith('/live')) {
+  if (matchesPathPrefix(path, '/live')) {
     return 'live-share';
   }
 
@@ -232,6 +244,14 @@ function removeLanguagePrefix(pathname: string) {
   const path = pathname.replace(/^\/(ko|en)(?=\/|$)/, '');
 
   return path === '' ? '/' : path;
+}
+
+function matchesPathPrefix(path: string, prefix: string) {
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+
+function hasPathSegment(path: string, segment: string) {
+  return path.split('/').includes(segment);
 }
 
 function isOfflineNetworkError(code?: string) {


### PR DESCRIPTION
# 🚩 연관 이슈

closed #468

# 📝 작업 내용
기존에는 이렇게 알림이 와서 알림만 보고 어떤 에러가 어떻게 발생한다는 것을 빠르게 파악하기 힘들었습니다.
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/4ac3b520-04bf-4de9-b092-fa2a242d9ae0" />


이번 작업은 Sentry 알림을 단순히 “에러가 발생했다”는 신호로 두지 않고, 알림을 받았을 때 어떤 사용자 흐름에서 문제가 생겼고 지금 확인해야 하는지 판단할 수 있도록 이벤트 맥락을 정리한 작업입니다.

기존 Sentry 설정은 에러 수집, Replay, Source Map을 통해 디버깅 가능한 상태를 만드는 데에는 효과적이었습니다. 다만 실제로 알림을 받아보면, 알림만 보고 어떤 기능에서 발생한 문제인지, 사용자 핵심 흐름에 영향을 주는지, 바로 대응해야 하는지 판단하기 어려웠습니다.

그래서 이번 PR에서는 알림 수신자의 다음 행동을 돕는 방향으로 Sentry 이벤트의 제목, 태그, level, grouping 기준을 개선했습니다.

### 1. Sentry 알림 판단 기준 유틸 분리

- Sentry 이벤트에 필요한 판단 기준을 `src/util/sentry.ts`로 분리했습니다.
- endpoint 정규화, pathname 기반 feature 분류, API error level 결정, 수집 제외 기준을 순수 함수로 정리했습니다.
- 알림 정책이 `axiosInstance` 내부에 섞이지 않도록 분리해서, 이후 라우트나 핵심 기능 기준이 바뀌어도 수정 범위를 좁힐 수 있게 했습니다.

이번 작업은 “어떤 에러를 어떤 맥락의 알림으로 볼 것인가”를 테스트 가능한 기준으로 만들기 위한 목적입니다.

### 2. 알림에서 사용자 영향 흐름이 보이도록 feature tag 추가

- pathname을 기준으로 `timer`, `vote`, `live-share`, `debate-end` 등 사용자 흐름 단위의 feature를 분류했습니다.
- API 에러와 렌더링 에러에 feature tag를 붙여, Sentry 알림만 봐도 어떤 화면/기능에서 문제가 발생했는지 파악할 수 있도록 했습니다.

기존에는 endpoint나 status는 확인할 수 있었지만, 이 에러가 실제로 어떤 사용자 행동에 영향을 주는지 알림만 보고 판단하기 어려웠습니다. 이번 작업에서는 알림을 여는 순간 “타이머 진행 중 문제인지”, “투표 흐름 문제인지”, “실시간 공유 문제인지”를 먼저 볼 수 있게 만드는 데 집중했습니다.

### 3. API 에러 이슈 제목과 grouping 기준 개선

- API 에러를 Sentry에 보낼 때 이슈 제목에 status, method, endpoint가 드러나도록 정리했습니다.
  - 예: `[network-error] POST /api/live/:id`
- endpoint의 숫자 id, uuid, query string은 정규화해서 같은 API 장애가 하나의 이슈로 묶이도록 했습니다.
- fingerprint도 `api-error + status + method + endpoint` 기준으로 정리했습니다.

사용자별 id 값 때문에 같은 장애가 여러 이슈로 흩어지면 알림 피로도가 커지고 원인 파악도 늦어진다고 봤습니다. 그래서 “같은 문제는 같은 알림 이슈로 묶이게 하는 것”을 기준으로 정리했습니다.

### 4. 대응 가치 기준으로 error level과 필터링 정리

- 핵심 흐름의 서버성 에러는 더 높은 우선순위로 볼 수 있도록 level 기준을 정리했습니다.
- 사용자 입력이나 상태 충돌처럼 예상 가능한 에러는 warning으로 낮췄습니다.
- 토큰 재발급으로 복구 가능한 401, 사용자 오프라인 상태의 네트워크 에러처럼 바로 대응하기 어려운 이벤트는 수집에서 제외했습니다.

여기서 중요한 기준은 에러를 덜 보는 것이 아니라, 실제로 확인해야 할 알림의 신뢰도를 높이는 것이었습니다.

### 5. 렌더링 에러에도 feature 맥락 추가

- `ErrorBoundary`에서 잡힌 렌더링 에러는 화면이 깨진 상태로 보고 `fatal`로 분류했습니다.
- 렌더링 에러에도 pathname 기반 feature tag를 추가했습니다.
- `render-error + feature` 기준 fingerprint를 설정해 같은 기능의 렌더링 장애가 묶이도록 했습니다.
- API 인터셉터에서 이미 캡처한 에러는 중복 전송되지 않도록 기준을 통일했습니다.

### 6. 알림 제목 개선 전/후

API 에러와 렌더링 에러 모두 알림 제목에서 `level → errorType → feature → 세부 원인` 순서로 읽히도록 정리했습니다.

| 구분 | 개선 전 | 개선 후 |
| --- | --- | --- |
| API 에러 | `AxiosError: Request failed with status code 500` | `fatal · api-error · live-share · [500] GET /api/live/:id` |
| 렌더링 에러 | `TypeError: Cannot read properties of undefined` | `fatal · render-error · timer · TypeError: Cannot read properties of undefined` |

개선 전에는 제목만 보고 어떤 사용자 흐름에서 문제가 발생했는지, 어떤 요청이 실패했는지, 지금 바로 대응해야 하는지 판단하기 어려웠습니다.

개선 후에는 제목만 보고도 아래 순서로 문제를 읽을 수 있습니다.

- `fatal`: 대응 우선순위
- `api-error` / `render-error`: 에러 종류
- `live-share` / `timer`: 영향받은 사용자 흐름
- `[500] GET /api/live/:id` / `TypeError: ...`: 실패 요청 또는 원본 에러

# ✅ 검증

- `src/util/sentry.test.ts`
  - 8개 테스트 통과
- `tsc --build --noEmit`
  - 통과
- 수정 파일 대상 ESLint
  - 통과

# 🗣️ 리뷰 요구사항 (선택)

이번 PR에서는 “Sentry에 더 많이 남기기”보다 “알림을 받았을 때 바로 판단할 수 있게 만들기”에 초점을 뒀습니다.

feature 분류 기준이나 error level 기준이 실제 운영 관점에서 어색한 부분이 있다면 편하게 의견 주세요 ~ !!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 개선 사항
- API/렌더링 오류를 표준화해 기능·요청 정보·심각도 중심의 일관된 메타데이터로 Sentry에 기록합니다.
- 중복 캡처는 안정적으로 차단하고, 복구 가능한 인증 오류 및 오프라인 네트워크 오류는 전송을 건너뛰도록 동작을 조정했습니다.
- 렌더링 오류는 기능 식별 태그와 상세 렌더링 컨텍스트를 포함해 `withScope` 방식으로 캡처되도록 변경했습니다.

## 테스트
- 오류 스킵 조건, 에러 레벨 매핑, 마스킹/메타데이터 생성, 캡처 여부 처리에 대한 테스트를 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->