### PR TITLE
[FIX] Sentry 이벤트 전송 누락 및 API 에러 중복 캡처 수정

### DIFF
--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { AxiosResponse } from 'axios';
 import axiosInstance from './axiosInstance';
-import { isSentryCaptured } from '../util/sentry';
+import { isSentryCaptured, markSentryCaptured } from '../util/sentry';
 
 // HTTP request methods
 export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
@@ -10,7 +10,6 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 export class APIError extends Error {
   public readonly status: number;
   public readonly data: unknown;
-  public __sentry_captured__?: boolean;
 
   constructor(message: string, status: number, data: unknown) {
     super(message);
@@ -56,7 +55,9 @@ export async function request<T>(
         error.response?.status || 500,
         responseData,
       );
-      apiError.__sentry_captured__ = isSentryCaptured(error);
+      if (isSentryCaptured(error)) {
+        markSentryCaptured(apiError);
+      }
       throw apiError;
     }
 

--- a/src/apis/primitives.ts
+++ b/src/apis/primitives.ts
@@ -55,6 +55,8 @@ export async function request<T>(
         error.response?.status || 500,
         responseData,
       );
+      // Axios 인터셉터에서 이미 보낸 에러는 APIError로 감싼 뒤에도
+      // ErrorBoundary/전역 핸들러에서 중복 수집되지 않도록 캡처 상태를 전달한다.
       if (isSentryCaptured(error)) {
         markSentryCaptured(apiError);
       }

--- a/src/components/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary/ErrorBoundary.tsx
@@ -38,7 +38,8 @@ class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
-    // 이미 API 인터셉터 등에서 캡처된 에러가 아니라면 전송
+    // API 인터셉터에서 이미 커스텀 이벤트로 전송한 에러는 전역 beforeSend에서도 drop된다.
+    // ErrorBoundary에서는 아직 수집되지 않은 렌더링 에러만 render-error로 전송한다.
     if (!isSentryCaptured(error)) {
       const feature = resolveFeatureFromPathname(window.location.pathname);
       const sentryError = createSentryRenderError(error, feature);

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/react';
-import { isSentryCaptured } from './util/sentry';
+import { shouldSkipSentryEvent } from './util/sentry';
 
 const dsn = import.meta.env.VITE_SENTRY_DSN;
 const isSentryEnabled =
@@ -27,27 +27,13 @@ if (isSentryEnabled && dsn) {
     beforeSend(event, hint) {
       const originalException = hint?.originalException;
 
-      // API 인터셉터에서 이미 커스텀 이벤트로 전송한 에러는 전역 캡처에서 중복 수집하지 않는다.
-      if (isSentryCaptured(originalException)) {
-        return null;
-      }
-
-      // 정상 사용자 흐름(이동/언마운트)에서 자주 생기는 취소성 에러는 노이즈로 간주
-      if (originalException instanceof Error) {
-        const normalizedMessage = originalException.message.toLowerCase();
-        const isCanceledRequest =
-          normalizedMessage.includes('cancel') ||
-          normalizedMessage.includes('aborted') ||
-          originalException.name === 'AbortError' ||
-          originalException.name === 'CanceledError';
-
-        if (isCanceledRequest) {
-          return null;
-        }
-      }
-
-      // 크로스 오리진 스크립트 에러는 재현 단서가 부족해 운영 액션 가능성이 낮음
-      if (event.exception?.values?.[0]?.value === 'Script error.') {
+      // 이미 수집한 API 에러, 취소성 에러, 원인 추적이 어려운 Script error는 전송하지 않음
+      if (
+        shouldSkipSentryEvent(
+          originalException,
+          event.exception?.values?.[0]?.value,
+        )
+      ) {
         return null;
       }
 

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,4 +1,5 @@
 import * as Sentry from '@sentry/react';
+import { isSentryCaptured } from './util/sentry';
 
 const dsn = import.meta.env.VITE_SENTRY_DSN;
 const isSentryEnabled =
@@ -25,6 +26,11 @@ if (isSentryEnabled && dsn) {
     replaysOnErrorSampleRate: 1.0,
     beforeSend(event, hint) {
       const originalException = hint?.originalException;
+
+      // API 인터셉터에서 이미 커스텀 이벤트로 전송한 에러는 전역 캡처에서 중복 수집하지 않는다.
+      if (isSentryCaptured(originalException)) {
+        return null;
+      }
 
       // 정상 사용자 흐름(이동/언마운트)에서 자주 생기는 취소성 에러는 노이즈로 간주
       if (originalException instanceof Error) {

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,8 +1,10 @@
 import * as Sentry from '@sentry/react';
 
 const dsn = import.meta.env.VITE_SENTRY_DSN;
+const isSentryEnabled =
+  import.meta.env.PROD || import.meta.env.VITE_ENABLE_SENTRY === 'true';
 
-if (import.meta.env.PROD && dsn) {
+if (isSentryEnabled && dsn) {
   Sentry.init({
     dsn,
     environment: import.meta.env.MODE,

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -11,6 +11,7 @@ import {
   sanitizeSentryContext,
   sanitizeSentrySearch,
   sanitizeSentryUrl,
+  shouldSkipSentryEvent,
   shouldSkipApiError,
 } from './sentry';
 
@@ -117,6 +118,22 @@ describe('sentry 유틸', () => {
     markSentryCaptured(originalError);
 
     expect(isSentryCaptured(originalError)).toBe(true);
+  });
+
+  it('이미 커스텀 이벤트로 전송한 에러는 전역 Sentry 이벤트에서 제외한다', () => {
+    const error = new Error('already captured');
+
+    markSentryCaptured(error);
+
+    expect(shouldSkipSentryEvent(error)).toBe(true);
+  });
+
+  it('운영 액션 가능성이 낮은 취소성 에러와 Script error는 Sentry 이벤트에서 제외한다', () => {
+    expect(shouldSkipSentryEvent(new Error('Request aborted'))).toBe(true);
+    expect(shouldSkipSentryEvent(new DOMException('', 'AbortError'))).toBe(
+      true,
+    );
+    expect(shouldSkipSentryEvent(undefined, 'Script error.')).toBe(true);
   });
 
   it('Sentry context에 원본 요청/응답 데이터가 그대로 전송되지 않도록 민감 필드를 마스킹한다', () => {

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -111,13 +111,19 @@ describe('sentry 유틸', () => {
     const metadata = buildSentryApiErrorMetadata(originalError, '/vote/123');
 
     const sentryError = createSentryApiError(originalError, metadata);
+    const sdkCapturedError = Object.assign(new Error('sdk captured'), {
+      __sentry_captured__: true,
+    });
 
     expect('__sentry_captured__' in sentryError).toBe(false);
     expect(isSentryCaptured(sentryError)).toBe(false);
+    expect(isSentryCaptured(sdkCapturedError)).toBe(false);
 
     markSentryCaptured(originalError);
+    markSentryCaptured(sdkCapturedError);
 
     expect(isSentryCaptured(originalError)).toBe(true);
+    expect(isSentryCaptured(sdkCapturedError)).toBe(true);
   });
 
   it('이미 커스텀 이벤트로 전송한 에러는 전역 Sentry 이벤트에서 제외한다', () => {

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -3,6 +3,8 @@ import {
   buildSentryApiErrorMetadata,
   createSentryApiError,
   createSentryRenderError,
+  isSentryCaptured,
+  markSentryCaptured,
   normalizeEndpoint,
   resolveApiErrorLevel,
   resolveFeatureFromPathname,
@@ -99,6 +101,24 @@ describe('sentry 유틸', () => {
     expect(shouldSkipApiError(onlineNetworkError)).toBe(false);
   });
 
+  it('SDK 내부 플래그와 앱 전용 플래그를 분리해 중복 캡처를 판단한다', () => {
+    const originalError = new AxiosError('Request failed', undefined, {
+      method: 'get',
+      url: '/api/polls/123/votes',
+      headers: new AxiosHeaders(),
+    });
+    const metadata = buildSentryApiErrorMetadata(originalError, '/vote/123');
+
+    const sentryError = createSentryApiError(originalError, metadata);
+
+    expect('__sentry_captured__' in sentryError).toBe(false);
+    expect(isSentryCaptured(sentryError)).toBe(false);
+
+    markSentryCaptured(originalError);
+
+    expect(isSentryCaptured(originalError)).toBe(true);
+  });
+
   it('Sentry context에 원본 요청/응답 데이터가 그대로 전송되지 않도록 민감 필드를 마스킹한다', () => {
     expect(
       sanitizeSentryContext({
@@ -144,7 +164,7 @@ describe('sentry 유틸', () => {
     );
   });
 
-  it('알림 제목을 level, error type, feature, status, endpoint 순서로 구성해 대응 판단 흐름을 만든다', () => {
+  it('API 에러 알림 제목은 level, error type, feature, status, endpoint 순서로 구성한다', () => {
     const error = new AxiosError('Request failed', undefined, {
       method: 'post',
       url: '/api/live/123',
@@ -159,7 +179,7 @@ describe('sentry 유틸', () => {
     );
   });
 
-  it('렌더링 에러 알림 제목도 level, error type, feature, 원본 에러 순서로 구성한다', () => {
+  it('렌더링 에러 알림 제목은 level, error type, feature, 원본 에러 순서로 구성한다', () => {
     const error = new TypeError('Cannot read properties of undefined');
 
     const sentryError = createSentryRenderError(error, 'timer');

--- a/src/util/sentry.test.ts
+++ b/src/util/sentry.test.ts
@@ -128,12 +128,22 @@ describe('sentry 유틸', () => {
     expect(shouldSkipSentryEvent(error)).toBe(true);
   });
 
-  it('운영 액션 가능성이 낮은 취소성 에러와 Script error는 Sentry 이벤트에서 제외한다', () => {
-    expect(shouldSkipSentryEvent(new Error('Request aborted'))).toBe(true);
+  it('사용자 이동이나 요청 취소로 발생한 에러와 Script error는 Sentry 이벤트에서 제외한다', () => {
     expect(shouldSkipSentryEvent(new DOMException('', 'AbortError'))).toBe(
       true,
     );
+    expect(shouldSkipSentryEvent({ name: 'CanceledError' })).toBe(true);
+    expect(shouldSkipSentryEvent({ code: 'ERR_CANCELED' })).toBe(true);
     expect(shouldSkipSentryEvent(undefined, 'Script error.')).toBe(true);
+  });
+
+  it('서비스 에러 메시지에 cancel이나 aborted가 포함되어도 취소성 에러로 오분류하지 않는다', () => {
+    expect(
+      shouldSkipSentryEvent(new Error('Debate live session was cancelled')),
+    ).toBe(false);
+    expect(shouldSkipSentryEvent(new Error('Request was aborted by server'))).toBe(
+      false,
+    );
   });
 
   it('Sentry context에 원본 요청/응답 데이터가 그대로 전송되지 않도록 민감 필드를 마스킹한다', () => {

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -319,18 +319,13 @@ function isCanceledError(originalException: unknown) {
     return false;
   }
 
-  const { name, message } = originalException as {
+  const { name, code } = originalException as {
     name?: unknown;
-    message?: unknown;
+    code?: unknown;
   };
-  const normalizedMessage =
-    typeof message === 'string' ? message.toLowerCase() : '';
 
   return (
-    normalizedMessage.includes('cancel') ||
-    normalizedMessage.includes('aborted') ||
-    name === 'AbortError' ||
-    name === 'CanceledError'
+    name === 'AbortError' || name === 'CanceledError' || code === 'ERR_CANCELED'
   );
 }
 

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -36,6 +36,7 @@ type SentryCapturedError = {
   __debate_timer_sentry_captured__?: boolean;
 };
 
+// API 에러 알림 메타데이터
 export type SentryApiErrorMetadata = {
   status: number | undefined;
   statusLabel: string;
@@ -46,6 +47,7 @@ export type SentryApiErrorMetadata = {
   pathname: string;
 };
 
+// 엔드포인트 그룹핑
 export function normalizeEndpoint(url?: string) {
   if (!url) {
     return 'unknown';
@@ -61,6 +63,7 @@ export function normalizeEndpoint(url?: string) {
     .replace(/\/[0-9]+(?=\/|$)/g, '/:id');
 }
 
+// 기능 태그
 export function resolveFeatureFromPathname(pathname: string): DebateFeature {
   const path = removeLanguagePrefix(pathname);
 
@@ -123,6 +126,7 @@ export function resolveFeatureFromPathname(pathname: string): DebateFeature {
   return 'unknown';
 }
 
+// API 에러 심각도
 export function resolveApiErrorLevel(
   status: number | undefined,
   feature: DebateFeature,
@@ -142,6 +146,7 @@ export function resolveApiErrorLevel(
   return 'error';
 }
 
+// API 에러 수집 제외
 export function shouldSkipApiError(error: AxiosError) {
   const status = error.response?.status;
 
@@ -152,6 +157,7 @@ export function shouldSkipApiError(error: AxiosError) {
   return isOfflineNetworkError(error.code);
 }
 
+// API 에러 메타데이터
 export function buildSentryApiErrorMetadata(
   error: AxiosError,
   pathname: string,
@@ -172,6 +178,7 @@ export function buildSentryApiErrorMetadata(
   };
 }
 
+// API 이슈 제목
 export function createSentryApiError(
   error: AxiosError,
   metadata: SentryApiErrorMetadata,
@@ -183,6 +190,7 @@ export function createSentryApiError(
   return sentryError;
 }
 
+// 렌더링 이슈 제목
 export function createSentryRenderError(error: Error, feature: DebateFeature) {
   const sentryError = new Error(error.message);
   sentryError.name = `fatal · render-error · ${feature} · ${error.name}: ${error.message}`;
@@ -191,6 +199,7 @@ export function createSentryRenderError(error: Error, feature: DebateFeature) {
   return sentryError;
 }
 
+// 중복 캡처 표시
 export function markSentryCaptured(error: unknown) {
   if (typeof error === 'object' && error !== null) {
     (error as SentryCapturedError).__debate_timer_sentry_captured__ = true;
@@ -205,6 +214,23 @@ export function isSentryCaptured(error: unknown) {
   );
 }
 
+// 전역 이벤트 필터
+export function shouldSkipSentryEvent(
+  originalException: unknown,
+  exceptionValue?: string,
+) {
+  if (isSentryCaptured(originalException)) {
+    return true;
+  }
+
+  if (isCanceledError(originalException)) {
+    return true;
+  }
+
+  return exceptionValue === 'Script error.';
+}
+
+// 컨텍스트 마스킹
 export function sanitizeSentrySearch(search: string) {
   if (!search) {
     return '';
@@ -222,6 +248,7 @@ export function sanitizeSentrySearch(search: string) {
   return sanitizedSearch ? `?${sanitizedSearch}` : '';
 }
 
+// 요청 URL 마스킹
 export function sanitizeSentryUrl(url?: string) {
   if (!url) {
     return url;
@@ -242,6 +269,7 @@ export function sanitizeSentryUrl(url?: string) {
   }
 }
 
+// 요청/응답 데이터 마스킹
 export function sanitizeSentryContext(value: unknown): unknown {
   if (Array.isArray(value)) {
     return value.map(sanitizeSentryContext);
@@ -259,6 +287,7 @@ export function sanitizeSentryContext(value: unknown): unknown {
   );
 }
 
+// URL 파싱
 function resolveUrlPath(url: string) {
   try {
     return new URL(url, window.location.origin).pathname;
@@ -267,20 +296,45 @@ function resolveUrlPath(url: string) {
   }
 }
 
+// 라우트 정규화
 function removeLanguagePrefix(pathname: string) {
   const path = pathname.replace(/^\/(ko|en)(?=\/|$)/, '');
 
   return path === '' ? '/' : path;
 }
 
+// 라우트 접두사 매칭
 function matchesPathPrefix(path: string, prefix: string) {
   return path === prefix || path.startsWith(`${prefix}/`);
 }
 
+// 라우트 세그먼트 매칭
 function hasPathSegment(path: string, segment: string) {
   return path.split('/').includes(segment);
 }
 
+// 취소성 에러 판별
+function isCanceledError(originalException: unknown) {
+  if (typeof originalException !== 'object' || originalException === null) {
+    return false;
+  }
+
+  const { name, message } = originalException as {
+    name?: unknown;
+    message?: unknown;
+  };
+  const normalizedMessage =
+    typeof message === 'string' ? message.toLowerCase() : '';
+
+  return (
+    normalizedMessage.includes('cancel') ||
+    normalizedMessage.includes('aborted') ||
+    name === 'AbortError' ||
+    name === 'CanceledError'
+  );
+}
+
+// 오프라인 네트워크 에러 판별
 function isOfflineNetworkError(code?: string) {
   return (
     typeof navigator !== 'undefined' &&
@@ -289,6 +343,7 @@ function isOfflineNetworkError(code?: string) {
   );
 }
 
+// 민감 필드 판별
 function isSensitiveKey(key: string) {
   return sensitiveKeys.some(
     (sensitiveKey) => sensitiveKey.toLowerCase() === key.toLowerCase(),

--- a/src/util/sentry.ts
+++ b/src/util/sentry.ts
@@ -33,7 +33,7 @@ const sensitiveKeys = [
 ];
 
 type SentryCapturedError = {
-  __sentry_captured__?: boolean;
+  __debate_timer_sentry_captured__?: boolean;
 };
 
 export type SentryApiErrorMetadata = {
@@ -179,7 +179,6 @@ export function createSentryApiError(
   const sentryError = new Error(error.message);
   sentryError.name = `${metadata.level} · api-error · ${metadata.feature} · [${metadata.statusLabel}] ${metadata.method} ${metadata.endpoint}`;
   sentryError.stack = error.stack;
-  (sentryError as SentryCapturedError).__sentry_captured__ = true;
 
   return sentryError;
 }
@@ -188,14 +187,13 @@ export function createSentryRenderError(error: Error, feature: DebateFeature) {
   const sentryError = new Error(error.message);
   sentryError.name = `fatal · render-error · ${feature} · ${error.name}: ${error.message}`;
   sentryError.stack = error.stack;
-  (sentryError as SentryCapturedError).__sentry_captured__ = true;
 
   return sentryError;
 }
 
 export function markSentryCaptured(error: unknown) {
   if (typeof error === 'object' && error !== null) {
-    (error as SentryCapturedError).__sentry_captured__ = true;
+    (error as SentryCapturedError).__debate_timer_sentry_captured__ = true;
   }
 }
 
@@ -203,7 +201,7 @@ export function isSentryCaptured(error: unknown) {
   return (
     typeof error === 'object' &&
     error !== null &&
-    (error as SentryCapturedError).__sentry_captured__ === true
+    (error as SentryCapturedError).__debate_timer_sentry_captured__ === true
   );
 }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,8 @@
 interface ImportMetaEnv {
   readonly VITE_MOCK_API: string;
   readonly VITE_BASE_PATH: string;
+  readonly VITE_SENTRY_DSN?: string;
+  readonly VITE_ENABLE_SENTRY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
# 🚩 연관 이슈

closed #471

# 📝 작업 내용

이전 작업에서 API 에러와 렌더링 에러의 제목, 태그, grouping 기준은 정리했지만, 실제로 이벤트를 보내보니 두 가지 문제가 있었습니다.

1. Sentry SDK 내부 캡처 플래그와 충돌해 커스텀 이벤트가 정상적으로 만들어지지 않을 수 있음
2. 커스텀 `api-error` 이벤트가 수집된 뒤에도 `APIError / Unhandled` 이벤트가 한 번 더 수집됨

그래서 이번 PR에서는 Sentry 이벤트를 “의도한 형태로 한 번만” 남길 수 있도록 캡처 플래그와 전역 필터링 흐름을 정리했습니다.

### 1. Sentry SDK 내부 캡처 플래그 충돌 수정
에러가 발생해도 이미 처리된 에러라 event를 보내지 않는 것을 확인했습니다. 
- 기존에 사용하던 `__sentry_captured__` 플래그가 Sentry SDK 내부에서도 사용하는 값이라, 전송용 Error에 붙이면 아직 보내지 않은 에러가 이미 캡처된 것처럼 처리될 수 있었습니다.
- 따라서 앱 내부 중복 캡처 판단에는 `__debate_timer_sentry_captured__` 전용 플래그를 사용하도록 변경하고, Sentry에 실제로 보낼 `sentryError`에는 캡처 플래그를 붙이지 않도록 정리했습니다.

### 2. APIError / Unhandled 중복 수집 방지
<img width="1094" height="346" alt="image" src="https://github.com/user-attachments/assets/a635cea4-b3b6-48b9-ab33-27c0fa6a88a2" />

커스텀 `api-error` 이벤트는 원하는 제목으로 수집됐지만, 같은 API 실패가 `APIError / Unhandled` 이벤트로 한 번 더 수집되는 것을 확인했습니다.

원인은 API 에러가 한 번만 발생하더라도, 프론트 내부에서는 에러 객체가 아래 흐름을 거치기 때문이었습니다.

```text
AxiosError 발생
→ API 인터셉터에서 커스텀 api-error로 수집
→ request<T>에서 APIError로 감싸 다시 throw
→ React Query / 전역 핸들러 흐름에서 APIError가 다시 Sentry에 수집
```

즉 같은 요청 실패가 `api-error`와 `APIError / Unhandled`로 나뉘어 들어오면서, 실제로는 하나의 문제인데 Sentry 피드에서는 두 개의 문제처럼 보였습니다.

- API 인터셉터에서 이미 커스텀 `api-error`로 보낸 원본 AxiosError에 앱 전용 캡처 상태를 표시했습니다.
- `request<T>`에서 AxiosError를 `APIError`로 감싸는 과정에서도 이 캡처 상태를 전달했습니다.
- `beforeSend`에서는 이미 캡처 상태가 있는 에러를 전역 Sentry 이벤트로 다시 보내지 않도록 처리했습니다.

수정 후에는 아래 흐름처럼 커스텀 `api-error` 이벤트만 남고, 이후 다시 잡히는 `APIError / Unhandled` 이벤트는 전송 직전에 제외되도록 하여 해결했습니다. 

### 3. beforeSend 필터링 기준 정리

`beforeSend`는 Sentry가 이벤트를 실제로 전송하기 직전에 마지막으로 거르는 지점입니다.

기존에는 `beforeSend` 안에 취소성 에러와 `Script error.` 제외 조건이 직접 들어가 있었고, 이번에 APIError 중복 수집까지 막으면서 필터링 기준이 더 늘어났습니다. 이 상태로 두면 어떤 이벤트를 왜 버리는지 `instrument.ts` 안에서 계속 해석해야 하고, 조건이 추가될 때 테스트하기도 어려웠습니다.

그래서 전역 이벤트 제외 기준을 `shouldSkipSentryEvent`로 분리했습니다.

- 이미 커스텀 이벤트로 수집한 에러는 중복 알림을 막기 위해 제외했습니다.
- 취소성 에러는 사용자 이동/언마운트 같은 정상 흐름에서도 발생할 수 있어 제외했습니다.
- `Script error.`는 크로스 오리진 스크립트 등으로 원인 추적 단서가 부족해 제외했습니다.
- `AbortError`처럼 브라우저에서 `DOMException` 형태로 들어올 수 있는 취소성 에러도 보완했습니다.

### 4. dev 환경 Sentry 검증 지원

- production이 아니더라도 `VITE_ENABLE_SENTRY=true`와 `VITE_SENTRY_DSN`이 있을 때 Sentry를 켤 수 있도록 했습니다.
- dev 환경에서 발생한 이벤트는 `environment: development`로 확인할 수 있습니다.
- production에 직접 영향을 주지 않고 Sentry envelope의 `type: event` 전송 여부와 Issues 반영 여부를 확인할 수 있도록 했습니다.


# 🗣️ 리뷰 요구사항 (선택)
혹시 센트리 알림에서 더 필요하신 부분이 있거나 궁금하신 부분 편하게 말씀해 주세요 감사합니다 ☺️ !!! 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * Sentry가 동일 오류를 중복 수집하지 않도록 수집 판정 로직을 개선했습니다.
  * 취소/종료된 요청 등 불필요한 이벤트와 일부 브라우저 스크립트 오류를 전송에서 제외합니다.
  * 운영 환경 또는 활성화 설정 시에만 Sentry 초기화를 수행하도록 변경했습니다.
  * 오류 전송 시 인증 정보는 계속 안전하게 제거됩니다.
* **테스트**
  * Sentry 유틸 동작 및 이벤트 스킵/중복 수집 관련 테스트를 확장했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->