### PR TITLE
[CHORE] 글로벌 템플릿 분기 추가 

### DIFF
--- a/src/apis/apis/organization.test.ts
+++ b/src/apis/apis/organization.test.ts
@@ -1,0 +1,52 @@
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { ApiUrl } from '../endpoints';
+import { GetOrganizationTemplatesResponseType } from '../responses/organization';
+import { getOrganizationTemplates } from './organization';
+
+const mockTemplatesResponse: GetOrganizationTemplatesResponseType = {
+  organizations: [
+    {
+      organization: '테스트 기관',
+      affiliation: '테스트 대학',
+      iconPath: '/icon/test.png',
+      templates: [],
+    },
+  ],
+};
+
+describe('조직 템플릿 조회 API', () => {
+  test('language=KO_KR 쿼리 파라미터와 함께 템플릿을 조회한다', async () => {
+    let capturedLanguage: string | null = null;
+
+    server.use(
+      http.get(ApiUrl.organization + '/templates', ({ request }) => {
+        const url = new URL(request.url);
+        capturedLanguage = url.searchParams.get('language');
+        return HttpResponse.json(mockTemplatesResponse);
+      }),
+    );
+
+    const data = await getOrganizationTemplates('KO_KR');
+
+    expect(capturedLanguage).toBe('KO_KR');
+    expect(data).toEqual(mockTemplatesResponse);
+  });
+
+  test('language=US_EN 쿼리 파라미터와 함께 템플릿을 조회한다', async () => {
+    let capturedLanguage: string | null = null;
+
+    server.use(
+      http.get(ApiUrl.organization + '/templates', ({ request }) => {
+        const url = new URL(request.url);
+        capturedLanguage = url.searchParams.get('language');
+        return HttpResponse.json(mockTemplatesResponse);
+      }),
+    );
+
+    const data = await getOrganizationTemplates('US_EN');
+
+    expect(capturedLanguage).toBe('US_EN');
+    expect(data).toEqual(mockTemplatesResponse);
+  });
+});

--- a/src/apis/apis/organization.ts
+++ b/src/apis/apis/organization.ts
@@ -2,14 +2,18 @@ import { ApiUrl } from '../endpoints';
 import { request } from '../primitives';
 import { GetOrganizationTemplatesResponseType } from '../responses/organization';
 
+export type ApiLanguageCode = 'KO_KR' | 'US_EN';
+
 // GET /api/organizations/templates
-export async function getOrganizationTemplates(): Promise<GetOrganizationTemplatesResponseType> {
+export async function getOrganizationTemplates(
+  language: ApiLanguageCode,
+): Promise<GetOrganizationTemplatesResponseType> {
   const requestUrl: string = ApiUrl.organization + '/templates';
   const response = await request<GetOrganizationTemplatesResponseType>(
     'GET',
     requestUrl,
     null,
-    null,
+    { language },
   );
 
   return response.data;

--- a/src/hooks/query/useGetOrganizationTemplates.test.tsx
+++ b/src/hooks/query/useGetOrganizationTemplates.test.tsx
@@ -1,0 +1,107 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../mocks/server';
+import { ApiUrl } from '../../apis/endpoints';
+import { GetOrganizationTemplatesResponseType } from '../../apis/responses/organization';
+import { useGetOrganizationTemplates } from './useGetOrganizationTemplates';
+import i18n from '../../i18n';
+
+const mockTemplatesResponse: GetOrganizationTemplatesResponseType = {
+  organizations: [
+    {
+      organization: '테스트 기관',
+      affiliation: '테스트 대학',
+      iconPath: '/icon/test.png',
+      templates: [],
+    },
+  ],
+};
+
+function createWrapper(queryClient: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+describe('useGetOrganizationTemplates', () => {
+  afterEach(() => {
+    i18n.changeLanguage('ko');
+  });
+
+  test('한국어(ko) 설정 시 language=KO_KR 파라미터로 요청한다', async () => {
+    i18n.changeLanguage('ko');
+    const queryClient = createQueryClient();
+    let capturedLanguage: string | null = null;
+
+    server.use(
+      http.get(ApiUrl.organization + '/templates', ({ request }) => {
+        const url = new URL(request.url);
+        capturedLanguage = url.searchParams.get('language');
+        return HttpResponse.json(mockTemplatesResponse);
+      }),
+    );
+
+    const { result } = renderHook(() => useGetOrganizationTemplates(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(capturedLanguage).toBe('KO_KR');
+    expect(result.current.data).toEqual(mockTemplatesResponse);
+    expect(
+      queryClient.getQueryData(['OrganizationTemplates', 'KO_KR']),
+    ).toEqual(mockTemplatesResponse);
+  });
+
+  test('영어(en) 설정 시 language=US_EN 파라미터로 요청한다', async () => {
+    await i18n.changeLanguage('en');
+    const queryClient = createQueryClient();
+    let capturedLanguage: string | null = null;
+
+    server.use(
+      http.get(ApiUrl.organization + '/templates', ({ request }) => {
+        const url = new URL(request.url);
+        capturedLanguage = url.searchParams.get('language');
+        return HttpResponse.json(mockTemplatesResponse);
+      }),
+    );
+
+    const { result } = renderHook(() => useGetOrganizationTemplates(), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(capturedLanguage).toBe('US_EN');
+    expect(result.current.data).toEqual(mockTemplatesResponse);
+    expect(
+      queryClient.getQueryData(['OrganizationTemplates', 'US_EN']),
+    ).toEqual(mockTemplatesResponse);
+  });
+
+  test('enabled=false 이면 API를 호출하지 않는다', () => {
+    const queryClient = createQueryClient();
+
+    const { result } = renderHook(() => useGetOrganizationTemplates(false), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/src/hooks/query/useGetOrganizationTemplates.ts
+++ b/src/hooks/query/useGetOrganizationTemplates.ts
@@ -1,11 +1,25 @@
 import { useQuery } from '@tanstack/react-query';
 import { GetOrganizationTemplatesResponseType } from '../../apis/responses/organization';
-import { getOrganizationTemplates } from '../../apis/apis/organization';
+import {
+  getOrganizationTemplates,
+  ApiLanguageCode,
+} from '../../apis/apis/organization';
+import i18n from '../../i18n';
+
+const LANG_MAP: Record<string, ApiLanguageCode> = {
+  ko: 'KO_KR',
+  en: 'US_EN',
+};
+
+function getApiLanguage(): ApiLanguageCode {
+  return LANG_MAP[i18n.language] ?? 'KO_KR';
+}
 
 export function useGetOrganizationTemplates(enabled?: boolean) {
+  const language = getApiLanguage();
   return useQuery<GetOrganizationTemplatesResponseType>({
-    queryKey: ['OrganizationTemplates'],
-    queryFn: () => getOrganizationTemplates(),
+    queryKey: ['OrganizationTemplates', language],
+    queryFn: () => getOrganizationTemplates(language),
     enabled,
     throwOnError: false,
   });


### PR DESCRIPTION
# 🚩 연관 이슈                                                                                       

closed #475                                                                                          
                                                                                                       
# 📝 작업 내용                                                                                       
                                                                                                       
메인페이지의 조직 템플릿 조회를 언어 설정에 따라 분기합니다.                                         
                                                                                                       
  - `getOrganizationTemplates`에 `language` 파라미터 추가 → `?language=KO_KR` / `?language=US_EN`      
  쿼리로 요청                                                                                          
  - `useGetOrganizationTemplates` 훅에서 `i18n.language`를 읽어 `ko → KO_KR`, `en → US_EN`으로 매핑    
  (fallback `KO_KR`)                                                                                   
  - `queryKey`에 `language`를 포함해 언어별 React Query 캐시 분리                                      
  - 테스트 추가 (총 5개)                                                                               
    - API: KO_KR / US_EN 쿼리 파라미터 검증                                                            
    - 훅: 언어별 분기 및 캐시 분리, `enabled=false` 미호출 검증                                        
                                                                                                       
# 🗣 리뷰 요구사항 (선택)                                                                            
                                                                                                       
  - i18n 코드 → API 언어 코드 매핑 위치(훅 레이어)가 적절한지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 현재 선택된 언어에 맞는 조직 템플릿을 조회합니다.
  * 한국어와 영어 템플릿을 각각 지원합니다.
  * 지원되지 않는 언어는 한국어 템플릿으로 자동 대체됩니다.
  * 언어별 조회 결과가 পৃথ পৃথ로 캐시되어 더욱 정확하게 관리됩니다.
  * 조회가 비활성화된 경우 불필요한 API 요청이 발생하지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->