### PR TITLE
[FEAT] 입력 검증 디바운스 + 붉은 테두리·카운터 현출

### DIFF
--- a/src/components/ClearableInput/ClearableInput.tsx
+++ b/src/components/ClearableInput/ClearableInput.tsx
@@ -6,22 +6,38 @@ interface ClearableInputProps extends InputHTMLAttributes<HTMLInputElement> {
   value: string;
   disabled?: boolean;
   onClear?: () => void;
+  /** 검증 실패 시 붉은 테두리로 표시 */
+  isError?: boolean;
+  /** 설정 시 입력창 경계 바로 아래에 `현재/최대` 글자 수 카운터를 노출한다. */
+  maxCount?: number;
 }
 
 export default function ClearableInput({
   value,
   onClear,
   disabled = false,
+  isError = false,
+  maxCount,
   className,
   ...rest
 }: ClearableInputProps) {
+  const hasCounter = typeof maxCount === 'number';
+  const isOverLimit = hasCounter && value.length > maxCount;
+
   return (
     <div className={clsx('relative w-full', className)}>
       <input
         {...rest}
         value={value}
         disabled={disabled}
-        className="text-body h-[48px] w-full appearance-none rounded-[4px] border border-default-border p-[12px] text-default-black placeholder-default-border focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+        aria-invalid={isError || undefined}
+        className={clsx(
+          'text-body h-[48px] w-full appearance-none rounded-[4px] p-[12px] text-default-black placeholder-default-border focus:outline-none [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none',
+          // box-border 기준이라 테두리를 굵혀도 외곽 크기(48px)는 유지 → 레이아웃 밀림 없음
+          isError
+            ? 'border-2 border-semantic-error'
+            : 'border border-default-border',
+        )}
       />
       {value && !disabled && onClear && (
         <button
@@ -31,6 +47,20 @@ export default function ClearableInput({
         >
           <IoMdCloseCircle />
         </button>
+      )}
+      {hasCounter && (
+        // 박스 경계 바로 아래에 절대배치 → 레이아웃을 밀지 않아 행 간격이 균일하게 유지된다.
+        <span
+          aria-live="polite"
+          className={clsx(
+            'pointer-events-none absolute right-1 top-full mt-[2px] text-[11px] leading-none',
+            isOverLimit
+              ? 'font-semibold text-semantic-error'
+              : 'text-default-neutral',
+          )}
+        >
+          {value.length}/{maxCount}
+        </span>
       )}
     </div>
   );

--- a/src/components/ClearableInput/ClearableInput.tsx
+++ b/src/components/ClearableInput/ClearableInput.tsx
@@ -1,6 +1,7 @@
 import clsx from 'clsx';
 import { InputHTMLAttributes } from 'react';
 import { IoMdCloseCircle } from 'react-icons/io';
+import { useTranslation } from 'react-i18next';
 
 interface ClearableInputProps extends InputHTMLAttributes<HTMLInputElement> {
   value: string;
@@ -21,6 +22,7 @@ export default function ClearableInput({
   className,
   ...rest
 }: ClearableInputProps) {
+  const { t } = useTranslation();
   const hasCounter = typeof maxCount === 'number';
   const isOverLimit = hasCounter && value.length > maxCount;
 
@@ -59,7 +61,10 @@ export default function ClearableInput({
               : 'text-default-neutral',
           )}
         >
-          {value.length}/{maxCount}
+          {t('{{current}}/{{max}}', {
+            current: value.length,
+            max: maxCount,
+          })}
         </span>
       )}
     </div>

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * 값의 변경이 delay(ms) 동안 멈추면(= 입력이 끝났다고 판단되면) 갱신되는 디바운스 값을 반환한다.
+ * 입력 중에는 이전 값을 유지하므로, 타이핑 도중이 아니라 입력이 마쳤을 때 검증을 트리거하는 데 사용한다.
+ */
+const useDebounce = <T>(value: T, delay = 400): T => {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedValue(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -161,13 +161,15 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
           <button
             disabled={isLoading}
             onClick={() => {
-              const pros = info.prosTeamName || '';
-              const cons = info.consTeamName || '';
+              // 제출 시점에 현재값(디바운스 미반영분 포함)으로 전체 필드를 재검증한다.
+              // 위반이 있으면 진행을 막고, 사유는 붉은 테두리·카운터로 표시된다.
+              const hasInvalidField =
+                validateTableName(info.name ?? '') !== null ||
+                validateAgenda(info.agenda ?? '') !== null ||
+                validateTeamName(info.prosTeamName ?? '') !== null ||
+                validateTeamName(info.consTeamName ?? '') !== null;
 
-              const isTooLong = pros.length > 15 || cons.length > 15;
-
-              if (isTooLong) {
-                alert(t('팀명은 최대 15자까지 입력할 수 있습니다.'));
+              if (hasInvalidField) {
                 return;
               }
 

--- a/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
+++ b/src/page/TableComposition/components/TableNameAndType/TableNameAndType.tsx
@@ -3,6 +3,14 @@ import ClearableInput from '../../../../components/ClearableInput/ClearableInput
 import HeaderTitle from '../../../../components/HeaderTitle/HeaderTitle';
 import DefaultLayout from '../../../../layout/defaultLayout/DefaultLayout';
 import { DebateInfo, StanceToString } from '../../../../type/type';
+import useDebounce from '../../../../hooks/useDebounce';
+import {
+  TABLE_FIELD_LIMITS,
+  VALIDATION_DEBOUNCE_MS,
+  validateAgenda,
+  validateTableName,
+  validateTeamName,
+} from '../../../../util/tableValidation';
 
 interface TableNameAndTypeProps {
   info: DebateInfo;
@@ -21,6 +29,26 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
     isLoading,
     onButtonClick,
   } = props;
+
+  // 입력이 멈췄다고 판단(디바운스)되면 각 필드를 검증해 붉은 테두리로 노출한다.
+  const debouncedName = useDebounce(info.name ?? '', VALIDATION_DEBOUNCE_MS);
+  const debouncedAgenda = useDebounce(
+    info.agenda ?? '',
+    VALIDATION_DEBOUNCE_MS,
+  );
+  const debouncedProsTeamName = useDebounce(
+    info.prosTeamName ?? '',
+    VALIDATION_DEBOUNCE_MS,
+  );
+  const debouncedConsTeamName = useDebounce(
+    info.consTeamName ?? '',
+    VALIDATION_DEBOUNCE_MS,
+  );
+
+  const nameError = validateTableName(debouncedName) !== null;
+  const agendaError = validateAgenda(debouncedAgenda) !== null;
+  const prosTeamNameError = validateTeamName(debouncedProsTeamName) !== null;
+  const consTeamNameError = validateTeamName(debouncedConsTeamName) !== null;
 
   const handleFieldChange = <K extends keyof DebateInfo>(
     field: K,
@@ -71,6 +99,8 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
             onClear={() => clearField('name')}
             placeholder={t('시간표 1')}
             disabled={isLoading}
+            isError={nameError}
+            maxCount={TABLE_FIELD_LIMITS.name}
           />
 
           <label className="flex items-center text-base font-semibold md:text-2xl">
@@ -82,6 +112,8 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
             onClear={() => clearField('agenda')}
             placeholder={t('토론 주제를 입력해주세요')}
             disabled={isLoading}
+            isError={agendaError}
+            maxCount={TABLE_FIELD_LIMITS.agenda}
           />
 
           <>
@@ -100,6 +132,8 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
                 onClear={() => clearTeamNameField('prosTeamName')}
                 placeholder={t(StanceToString['PROS'])}
                 disabled={isLoading}
+                isError={prosTeamNameError}
+                maxCount={TABLE_FIELD_LIMITS.teamName}
               />
 
               <span>vs.</span>
@@ -114,6 +148,8 @@ export default function TableNameAndType(props: TableNameAndTypeProps) {
                 onClear={() => clearTeamNameField('consTeamName')}
                 placeholder={t(StanceToString['CONS'])}
                 disabled={isLoading}
+                isError={consTeamNameError}
+                maxCount={TABLE_FIELD_LIMITS.teamName}
               />
             </div>
           </>

--- a/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
+++ b/src/page/TableComposition/components/TimerCreationContent/TimerCreationContent.tsx
@@ -30,6 +30,12 @@ import DTBell from '../../../../components/icons/Bell';
 import DTAdd from '../../../../components/icons/Add';
 import NotificationBadge from '../../../../components/NotificationBadge/NotificationBadge';
 import DTExpand from '../../../../components/icons/Expand';
+import useDebounce from '../../../../hooks/useDebounce';
+import {
+  TABLE_FIELD_LIMITS,
+  VALIDATION_DEBOUNCE_MS,
+  validateSpeechType,
+} from '../../../../util/tableValidation';
 
 type TimerCreationOption =
   | 'TIMER_TYPE'
@@ -271,6 +277,14 @@ export default function TimerCreationContent({
   ];
 
   const options = isNormalTimer ? NORMAL_OPTIONS : TIME_BASED_OPTIONS;
+
+  // 입력이 멈췄다고 판단(디바운스)되면 검증해 붉은 테두리로 노출한다.
+  // 발언자(speaker)는 maxLength+slice 로 하드캡되어 초과가 불가능하므로 검증/카운터를 두지 않는다.
+  const debouncedSpeechType = useDebounce(
+    speechTypeTextValue,
+    VALIDATION_DEBOUNCE_MS,
+  );
+  const speechTypeError = validateSpeechType(debouncedSpeechType) !== null;
 
   const handleSubmit = useCallback(() => {
     const totalTime = minutes * 60 + seconds;
@@ -675,6 +689,8 @@ export default function TimerCreationContent({
                       onChange={(e) => setSpeechTypeTextValue(e.target.value)}
                       onClear={() => setSpeechTypeTextValue('')}
                       placeholder={t('주도권 토론 등')}
+                      isError={speechTypeError}
+                      maxCount={TABLE_FIELD_LIMITS.speechType}
                     />
                   </TimerCreationContentItem>
                 );
@@ -706,6 +722,8 @@ export default function TimerCreationContent({
                           }
                           onClear={() => setSpeechTypeTextValue('')}
                           placeholder={t('입론, 반론, 작전 시간 등')}
+                          isError={speechTypeError}
+                          maxCount={TABLE_FIELD_LIMITS.speechType}
                         />
                       )}
                     </span>

--- a/src/util/tableValidation.ts
+++ b/src/util/tableValidation.ts
@@ -1,0 +1,62 @@
+/**
+ * 토론 테이블 입력값 검증 규칙.
+ * 값은 debate-timer-be 의 도메인 제약과 동일하게 유지해야 한다.
+ * - TableName.NAME_MAX_LENGTH = 20 / TeamName.NAME_MAX_LENGTH = 15 / Agenda.AGENDA_MAX_LENGTH = 255
+ * - CustomizeTimeBox.SPEECH_TYPE_MAX_LENGTH = 10 / SPEAKER_MAX_LENGTH = 5
+ */
+export const TABLE_FIELD_LIMITS = {
+  name: 20,
+  teamName: 15,
+  agenda: 255,
+  speechType: 10,
+  speaker: 5,
+} as const;
+
+// 입력 검증(붉은 테두리) 디바운스 지연(ms). 카운터는 라이브 값이라 즉시 반응하므로,
+// 테두리와의 인지 간극을 줄이기 위해 짧게 유지한다.
+export const VALIDATION_DEBOUNCE_MS = 200;
+
+// TableName / TeamName 의 NAME_REGEX 와 동치 (문자/기호/공백 허용, 제어문자 등 제외)
+const NAME_REGEX = /^[\p{L}\p{M}\p{N}\p{P}\p{Z}\s]+$/u;
+
+/**
+ * 필드별 검증 결과. null 이면 정상.
+ * 붉은 테두리는 null 여부만으로 판단하고, 사유(LENGTH/FORM)는 추후 회복 메시지 노출에 재사용한다.
+ */
+export type FieldError = null | 'LENGTH' | 'FORM';
+
+export const validateTableName = (value: string): FieldError => {
+  const v = value ?? '';
+  // 빈 값은 제출 시 기본값('시간표 1')으로 대체되므로 입력 중 에러로 보지 않는다.
+  if (v.length === 0) return null;
+  if (v.length > TABLE_FIELD_LIMITS.name) return 'LENGTH';
+  if (!NAME_REGEX.test(v)) return 'FORM';
+  return null;
+};
+
+export const validateTeamName = (value: string): FieldError => {
+  const v = value ?? '';
+  // 빈 값은 제출 시 기본값('찬성'/'반대')으로 대체되므로 입력 중 에러로 보지 않는다.
+  if (v.length === 0) return null;
+  if (v.length > TABLE_FIELD_LIMITS.teamName) return 'LENGTH';
+  if (!NAME_REGEX.test(v)) return 'FORM';
+  return null;
+};
+
+export const validateAgenda = (value: string): FieldError => {
+  const v = value ?? '';
+  if (v.length > TABLE_FIELD_LIMITS.agenda) return 'LENGTH';
+  return null;
+};
+
+export const validateSpeechType = (value: string): FieldError => {
+  const v = value ?? '';
+  if (v.length > TABLE_FIELD_LIMITS.speechType) return 'LENGTH';
+  return null;
+};
+
+export const validateSpeaker = (value: string): FieldError => {
+  const v = value ?? '';
+  if (v.trim().length > TABLE_FIELD_LIMITS.speaker) return 'LENGTH';
+  return null;
+};


### PR DESCRIPTION
# 🚩 연관 이슈

closed #474

# 📝 작업 내용

POST 시점 alert 대신, 입력이 멈추면(디바운스 200ms) 길이 제한을 검증해 해당 입력창을 굵은 붉은 테두리로 표시하고, 박스 경계 아래 글자 수  카운터(현재/최대)로 사유를 알린다.

<img width="793" height="283" alt="image" src="https://github.com/user-attachments/assets/9d15b1b8-0a3b-4436-8484-ff4ecb3d27f8" />


대상: 시간표 이름(20)·팀명(15)·주제(255)·발언 유형(10).  발언자는 입력 자체가 하드캡되어 제외.

검증 규칙은 BE 도메인 제약을 미러링(util/tableValidation),  카운터는 절대배치라 레이아웃 밀림 없이 색만 전환된다.

# 🏞️ 스크린샷 (선택)

# 🗣️ 리뷰 요구사항 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 토론 테이블 생성 화면에 입력값 검증을 추가했습니다.
  * 이름, 안건, 팀명, 발언 유형 및 발언자의 형식과 글자 수를 확인합니다.
  * 오류가 있는 입력란에 오류 스타일과 접근성 정보를 표시합니다.
  * 글자 수 제한이 설정된 입력란에 실시간 카운터를 제공합니다.
  * 입력 중에는 검증을 잠시 지연해 보다 자연스러운 입력 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->